### PR TITLE
Resizable and not to compressed INDI configuration

### DIFF
--- a/config_INDI.cpp
+++ b/config_INDI.cpp
@@ -58,8 +58,15 @@
 #define POS(r, c)        wxGBPosition(r,c)
 #define SPAN(r, c)       wxGBSpan(r,c)
 
-INDIConfig::INDIConfig(wxWindow *parent, int devtype) : wxDialog(parent, wxID_ANY, (const wxString)_T("INDI Configuration"))
+INDIConfig::INDIConfig(wxWindow *parent, int devtype) : wxDialog(parent, wxID_ANY, (const wxString)_T("INDI Configuration"),
+		wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
+    auto sizerLabelFlags  = wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL;
+    auto sizerButtonFlags = wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL;
+    auto sizerSectionFlags = wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL;
+    auto sizerTextFlags = wxALIGN_LEFT | wxALL | wxEXPAND;
+    int border = 2;
+
     dev_type = devtype;
     gui = NULL;
     
@@ -68,64 +75,70 @@ INDIConfig::INDIConfig(wxWindow *parent, int devtype) : wxDialog(parent, wxID_AN
     wxBoxSizer *sizer;
 
     pos = 0;
-    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Hostname:")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
-    host = new wxTextCtrl(this, wxID_ANY);
-    gbs->Add(host, POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+    gbs->Add(new wxStaticText(this, wxID_ANY, _T("INDI Server")),
+	     POS(pos, 0), SPAN(1, 1), sizerSectionFlags, border);
 
     pos ++;
-    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Port:")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
+    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Hostname")),
+	     POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
+    host = new wxTextCtrl(this, wxID_ANY);
+    gbs->Add(host, POS(pos, 1), SPAN(1, 1), sizerTextFlags, border);
+
+    pos ++;
+    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Port")),
+	     POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
     port = new wxTextCtrl(this, wxID_ANY);
-    gbs->Add(port, POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+    gbs->Add(port, POS(pos, 1), SPAN(1, 1), sizerTextFlags, border);
     
     pos ++;
     connect_status = new wxStaticText(this, wxID_ANY, _T("Disconnected"));
-    gbs->Add(connect_status,POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
-    gbs->Add(new wxButton(this, MCONNECT, _T("Connect")), POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+    gbs->Add(connect_status,POS(pos, 0), SPAN(1, 1), wxALIGN_RIGHT | wxALL | wxALIGN_CENTER_VERTICAL, border);
+    gbs->Add(new wxButton(this, MCONNECT, _T("Connect")), POS(pos, 1), SPAN(1, 1), sizerButtonFlags, border);
     
     pos ++;
     gbs->Add(new wxStaticText(this, wxID_ANY, _T("========")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL);
+	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL, border);
     devlabel = new wxStaticText(this, wxID_ANY, _T("Device"));
-    gbs->Add(devlabel,POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL);
     if (devtype == TYPE_CAMERA) {
 	devlabel->SetLabel(_T("Camera"));
     }
     else if (devtype == TYPE_MOUNT) {
 	devlabel->SetLabel(_T("Mount"));
     }
+    gbs->Add(devlabel,POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL, border);
     
     pos ++;
-    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Driver:")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
+    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Driver")),
+	     POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
     dev =  new wxComboBox(this, wxID_ANY, _T(""));
-    gbs->Add(dev, POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+    gbs->Add(dev, POS(pos, 1), SPAN(1, 1), sizerTextFlags, border);
 
     if (devtype == TYPE_CAMERA) {
 	pos ++;
-	gbs->Add(new wxStaticText(this, wxID_ANY, _T("CCD:")),
-		 POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
+	gbs->Add(new wxStaticText(this, wxID_ANY, _T("CCD")),
+		 POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
 	ccd =  new wxComboBox(this, wxID_ANY, _T(""));
-	gbs->Add(ccd, POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
 	ccd->Append(_T("Main imager"));
 	ccd->Append(_T("Guider"));
+	gbs->Add(ccd, POS(pos, 1), SPAN(1, 1), sizerTextFlags, border);
     }
     
     pos ++;
-    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Port:")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
+    gbs->Add(new wxStaticText(this, wxID_ANY, _T("Port")),
+	     POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
     devport = new wxTextCtrl(this, wxID_ANY);
-    gbs->Add(devport, POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+    gbs->Add(devport, POS(pos, 1), SPAN(1, 1), sizerTextFlags, border);
 
     pos ++;
     gbs->Add(new wxStaticText(this, wxID_ANY, _T("Other options")),
-	     POS(pos, 0), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL);
-    gbs->Add(new wxButton(this, MINDIGUI, _T("INDI")), POS(pos, 1), SPAN(1, 1), wxALIGN_LEFT | wxALL | wxEXPAND);
+	     POS(pos, 0), SPAN(1, 1), sizerLabelFlags, border);
+    gbs->Add(new wxButton(this, MINDIGUI, _T("INDI")), POS(pos, 1), SPAN(1, 1), sizerButtonFlags, border);
 
     sizer = new wxBoxSizer(wxVERTICAL) ;
     sizer->Add(gbs);
+    sizer->AddSpacer(10);
     sizer->Add(CreateButtonSizer(wxOK | wxCANCEL));
+    sizer->AddSpacer(10);
     SetSizer(sizer);
     sizer->SetSizeHints(this) ;
     sizer->Fit(this) ;


### PR DESCRIPTION
Made more room in the INDI configuration dialog. 
Started with this as I could not see the full name of the selected camera.

Attached the dialog before and after:
![indi config too small](https://cloud.githubusercontent.com/assets/7082679/10804386/8a081ac2-7dc7-11e5-95f2-e2c5f554fd66.png)
![indi config more space](https://cloud.githubusercontent.com/assets/7082679/10804392/914fa07a-7dc7-11e5-9507-e6b3edc55f10.png)
