### PR TITLE
Bug fixed as issue #565 - cam_qhy5.cpp file

### DIFF
--- a/cam_qhy5.cpp
+++ b/cam_qhy5.cpp
@@ -146,9 +146,9 @@ bool Camera_QHY5Class::ST4PulseGuideScope(int direction, int duration)
     int reg = 0;
     int32_t dur[2] = { -1, -1};
 
-    duration /= 10;
+    // duration /= 10;
 
-    if (duration >= 255) duration = 254; // Max guide pulse is 2.54s -- 255 keeps it on always
+    if (duration >= 2500) duration = 2500; // Max guide pulse is 2.54s -- 255 keeps it on always
     switch (direction)
     {
     case WEST:


### PR DESCRIPTION
I'm owner of a Magzero Mz5-m camera (QHY5 camera for italian market brand) that doesn't work well with PHD2 on Raspberry (ubuntu mate 16.04 OS): in particular calibration and guiding procedures fail (i use a 9x50 finder as guidescope and all calibration and guiding settings are correctly set).
After many test I've found the reason: a bug in cam_qhy5.cpp file.
The bug is here:

`bool Camera_QHY5Class::ST4PulseGuideScope(int direction, int duration)
{
int result = -1;
int reg = 0;
int32_t dur[2] = { -1, -1};

duration /= 10;

if (duration >= 255) duration = 254; // Max guide pulse is 2.54s -- 255 keeps it on always`
with this settings calibration steps (and guiding corrections I suppose) are limited to 254 ms, a too short value for guiding expecially with short guidescopes (i.e. 9x50 finder that i use).
This bug is confirmed by testing the funcion "Manual guide" where even with long time pulses (1000 ms and longer) corresponds always a short noise of motor movements, compatible with a 254 ms correction pulse.
Also the calibration procedures confirm this: instead of about 12 steps, 40 or higher steps are necessary to perform (a bad) calibration.
I modify the cpp file as follows:

` bool Camera_QHY5Class::ST4PulseGuideScope(int direction, int duration)
{
int result = -1;
int reg = 0;
int32_t dur[2] = { -1, -1};

// duration /= 10;

if (duration >= 2500) duration = 2500; // Max guide pulse is 2.54s -- 255 keeps it on always `
and rebuild PHD2 according the procedure for Ubuntu.
Now calibration and guiding work. 

Matteo