### PR TITLE
Update PHD2 to compile with INDI 1.4

### DIFF
--- a/cmake_modules/FindINDI.cmake
+++ b/cmake_modules/FindINDI.cmake
@@ -3,87 +3,159 @@
 #
 #  INDI_FOUND - system has INDI
 #  INDI_INCLUDE_DIR - the INDI include directory
-#  INDI_LIBRARIES - Link these to use INDI
-#  INDI_MAIN_LIBRARIES - Link to these to build INDI drivers with main()
-#  INDI_DRIVER_LIBRARIES - Link to these to build INDI drivers with indibase support
+#  For Android
+#  INDI_CLIENT_ANDROID_LIBRARIES - Link to these for INDI Android client
+#  For other platforms
+#  INDI_LIBRARIES - Link to these for XML and INDI Common support (INDI < 1.4 ONLY)
 #  INDI_CLIENT_LIBRARIES - Link to these to build INDI clients
-#  INDI_DATA_DIR - INDI shared data dir.
+#  INDI_CLIENT_QT_LIBRARIES - Link to these to build INDI clients with Qt5 backend
 
-# Copyright (c) 2011, Jasem Mutlaq <mutlaqja@ikarustech.com>
+# Copyright (c) 2016, Jasem Mutlaq <mutlaqja@ikarustech.com>
 # Copyright (c) 2012, Pino Toscano <pino@kde.org>
 # Based on FindLibfacile by Carsten Niehaus, <cniehaus@gmx.de>
 #
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# Redistribution AND use is allowed according to the terms of the BSD license.
 
-if (INDI_INCLUDE_DIR AND INDI_DATA_DIR AND INDI_LIBRARIES AND INDI_DRIVER_LIBRARIES AND INDI_CLIENT_LIBRARIES)
+macro(_INDI_check_version)
+  file(READ "${INDI_INCLUDE_DIR}/indiapi.h" _INDI_version_header)
 
+  string(REGEX MATCH "#define INDI_VERSION_MAJOR[ \t]+([0-9]+)" _INDI_version_major_match "${_INDI_version_header}")
+  set(INDI_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "#define INDI_VERSION_MINOR[ \t]+([0-9]+)" _INDI_version_minor_match "${_INDI_version_header}")
+  set(INDI_VERSION_MINOR "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "#define INDI_VERSION_RELEASE[ \t]+([0-9]+)" _INDI_version_release_match "${_INDI_version_header}")
+  set(INDI_VERSION_RELEASE "${CMAKE_MATCH_1}")
+
+  set(INDI_VERSION ${INDI_VERSION_MAJOR}.${INDI_VERSION_MINOR}.${INDI_VERSION_RELEASE})
+  if(${INDI_VERSION} VERSION_LESS ${INDI_FIND_VERSION})
+    set(INDI_VERSION_OK FALSE)
+  else(${INDI_VERSION} VERSION_LESS ${INDI_FIND_VERSION})
+    set(INDI_VERSION_OK TRUE)
+  endif(${INDI_VERSION} VERSION_LESS ${INDI_FIND_VERSION})
+
+  if(NOT INDI_VERSION_OK)
+    message(STATUS "INDI version ${INDI_VERSION} found in ${INDI_INCLUDE_DIR}, "
+                   "but at least version ${INDI_FIND_VERSION} is required")
+  else(NOT INDI_VERSION_OK)
+      mark_as_advanced(INDI_VERSION_MAJOR INDI_VERSION_MINOR INDI_VERSION_RELEASE)
+  endif(NOT INDI_VERSION_OK)
+endmacro(_INDI_check_version)
+
+if (INDI_INCLUDE_DIR)
   # in cache already
-  set(INDI_FOUND TRUE)
-  message(STATUS "Set      INDI_FOUND:            ${INDI_FOUND}")
-  message(STATUS "[Cached] PC_INDI_FOUND:         ${PC_INDI_FOUND}")
-  message(STATUS "[Cached] PC_INDI_VERSION:       ${PC_INDI_VERSION}")
-  message(STATUS "[Cached] INDI_INCLUDE_DIR:      ${INDI_INCLUDE_DIR}")
-  message(STATUS "[Cached] INDI_DATA_DIR:         ${INDI_DATA_DIR}")
-  message(STATUS "[Cached] INDI_LIBRARIES:        ${INDI_LIBRARIES}")
-  message(STATUS "[Cached] INDI_DRIVER_LIBRARIES: ${INDI_DRIVER_LIBRARIES}")
-  message(STATUS "[Cached] INDI_CLIENT_LIBRARIES: ${INDI_CLIENT_LIBRARIES}")
+  _INDI_check_version()
+  if(ANDROID)
+      if(INDI_CLIENT_ANDROID_LIBRARIES)
+          set(INDI_FOUND ${INDI_VERSION_OK})
+          message(STATUS "Found INDI: ${INDI_CLIENT_ANDROID_LIBRARIES}")
+      endif(INDI_CLIENT_ANDROID_LIBRARIES)
+  else(ANDROID)
+      if(INDI_LIBRARIES AND (INDI_CLIENT_LIBRARIES OR INDI_CLIENT_QT_LIBRARIES))
+          set(INDI_FOUND ${INDI_VERSION_OK})
+          message(STATUS "Found INDI: ${INDI_LIBRARIES}, ${INDI_CLIENT_LIBRARIES}, ${INDI_INCLUDE_DIR}")
+      endif(INDI_LIBRARIES AND (INDI_CLIENT_LIBRARIES OR INDI_CLIENT_QT_LIBRARIES))
+  endif(ANDROID)
+endif(INDI_INCLUDE_DIR)
 
-else (INDI_INCLUDE_DIR AND INDI_DATA_DIR AND INDI_LIBRARIES AND INDI_DRIVER_LIBRARIES AND INDI_CLIENT_LIBRARIES)
+if(NOT INDI_FOUND)
+  if (NOT WIN32 AND NOT ANDROID)
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+      pkg_check_modules(PC_INDI INDI)
+    endif (PKG_CONFIG_FOUND)
+  endif (NOT WIN32 AND NOT ANDROID)
 
-  find_package(PkgConfig)
-
-  if (PKG_CONFIG_FOUND)
-    if (INDI_FIND_VERSION)
-      set(version_string ">=${INDI_FIND_VERSION}")
-    endif()
-    pkg_check_modules(PC_INDI libindi${version_string})
-  else()
-    # assume it was found
-    set(PC_INDI_FOUND TRUE)
-  endif()
-
-  if (PC_INDI_FOUND)
-    find_path(INDI_INCLUDE_DIR indidevapi.h
-      PATH_SUFFIXES libindi
-      HINTS ${PC_INDI_INCLUDE_DIRS}
-    )
-
-    find_library(INDI_LIBRARIES NAMES indi
-      HINTS ${PC_INDI_LIBRARY_DIRS}
-    )
-
-    find_library(INDI_DRIVER_LIBRARIES NAMES indidriver
-      HINTS ${PC_INDI_LIBRARY_DIRS}
-    )
-
-    find_library(INDI_CLIENT_LIBRARIES NAMES indiclient
-      HINTS ${PC_INDI_LIBRARY_DIRS}
-    )
-
-    find_path(INDI_DATA_DIR drivers.xml
-      PATH_SUFFIXES share/indi
-    )
-
-    set(INDI_VERSION "${PC_INDI_VERSION}")
-
-  endif()
-
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(INDI
-                                    REQUIRED_VARS INDI_INCLUDE_DIR INDI_LIBRARIES INDI_DRIVER_LIBRARIES INDI_CLIENT_LIBRARIES
-                                    VERSION_VAR INDI_VERSION
+  find_path(INDI_INCLUDE_DIR indidevapi.h
+    PATH_SUFFIXES libindi
+    ${PC_INDI_INCLUDE_DIRS}
+    ${_obIncDir}
+    ${GNUWIN32_DIR}/include
   )
 
-  message(STATUS "Found INDI_FOUND:            ${INDI_FOUND}")
-  message(STATUS "Found PC_INDI_FOUND:         ${PC_INDI_FOUND}")
-  message(STATUS "Found PC_INDI_VERSION:       ${PC_INDI_VERSION}")
-  message(STATUS "Found INDI_INCLUDE_DIR:      ${INDI_INCLUDE_DIR}")
-  message(STATUS "Found INDI_DATA_DIR:         ${INDI_DATA_DIR}")
-  message(STATUS "Found INDI_LIBRARIES:        ${INDI_LIBRARIES}")
-  message(STATUS "Found INDI_DRIVER_LIBRARIES: ${INDI_DRIVER_LIBRARIES}")
-  message(STATUS "Found INDI_CLIENT_LIBRARIES: ${INDI_CLIENT_LIBRARIES}")
+if (INDI_INCLUDE_DIR)
+  _INDI_check_version()
 
-  mark_as_advanced(INDI_INCLUDE_DIR INDI_DATA_DIR INDI_LIBRARIES INDI_DRIVER_LIBRARIES INDI_CLIENT_LIBRARIES)
+if(ANDROID)
+      find_library(INDI_CLIENT_ANDROID_LIBRARIES NAMES indiclientandroid
+          PATHS
+          ${BUILD_KSTARSLITE_DIR}/android_libs/${ANDROID_ARCHITECTURE}/
+      )
+else(ANDROID)
+    # Deprecated in INDI Library >= 1.4.0
+    if (INDI_VERSION VERSION_LESS "1.4.0")
+    find_library(INDI_LIBRARIES NAMES indi
+        PATHS
+        ${PC_INDI_LIBRARY_DIRS}
+        ${_obLinkDir}
+        ${GNUWIN32_DIR}/lib
+    )
+    else()
+    set(INDI_LIBRARIES "Deprecated")
+    endif()
 
-endif (INDI_INCLUDE_DIR AND INDI_DATA_DIR AND INDI_LIBRARIES AND INDI_DRIVER_LIBRARIES AND INDI_CLIENT_LIBRARIES)
+    find_library(INDI_CLIENT_LIBRARIES NAMES indiclient
+        PATHS
+        ${PC_INDI_LIBRARY_DIRS}
+        ${_obLinkDir}
+        ${GNUWIN32_DIR}/lib
+    )
+
+    find_library(INDI_CLIENT_QT_LIBRARIES NAMES indiclientqt
+        PATHS
+            ${PC_INDI_LIBRARY_DIRS}
+            ${_obLinkDir}
+            ${GNUWIN32_DIR}/lib
+    )
+endif(ANDROID)
+endif(INDI_INCLUDE_DIR)
+
+if(ANDROID)
+  if(INDI_INCLUDE_DIR AND INDI_CLIENT_ANDROID_LIBRARIES)
+    set(INDI_FOUND TRUE)
+  else()
+    set(INDI_FOUND FALSE)
+  endif()
+else(ANDROID)
+  if (INDI_INCLUDE_DIR AND INDI_LIBRARIES AND (INDI_CLIENT_LIBRARIES OR INDI_CLIENT_QT_LIBRARIES) AND INDI_VERSION_OK)
+      # If INDI is found we need to make sure on WIN32 we have INDI Client Qt backend otherwise we can't use INDI
+      if (WIN32)
+          if (INDI_CLIENT_QT_LIBRARIES)
+              set(INDI_FOUND TRUE)
+          else(INDI_CLIENT_QT_LIBRARIES)
+              set(INDI_FOUND FALSE)
+          endif(INDI_CLIENT_QT_LIBRARIES)
+      else (WIN32)
+          set(INDI_FOUND TRUE)
+      endif(WIN32)
+  else (INDI_INCLUDE_DIR AND INDI_LIBRARIES AND (INDI_CLIENT_LIBRARIES OR INDI_CLIENT_QT_LIBRARIES) AND INDI_VERSION_OK)
+    set(INDI_FOUND FALSE)
+  endif (INDI_INCLUDE_DIR AND INDI_LIBRARIES AND (INDI_CLIENT_LIBRARIES OR INDI_CLIENT_QT_LIBRARIES) AND INDI_VERSION_OK)
+endif(ANDROID)
+
+  if (INDI_FOUND)
+    if (NOT INDI_FIND_QUIETLY)
+        if(ANDROID)
+            message(STATUS "Found INDI Android Client: ${INDI_CLIENT_ANDROID_LIBRARIES}")
+        else(ANDROID)
+          message(STATUS "Found INDI: ${INDI_INCLUDE_DIR}")
+
+          if (INDI_CLIENT_LIBRARIES)
+            message(STATUS "Found INDI Client Library: ${INDI_CLIENT_LIBRARIES}")
+          endif (INDI_CLIENT_LIBRARIES)
+          if (INDI_CLIENT_QT_LIBRARIES)
+            message(STATUS "Found INDI Qt5 Client Library: ${INDI_CLIENT_QT_LIBRARIES}")
+          endif (INDI_CLIENT_QT_LIBRARIES)
+      endif(ANDROID)
+    endif (NOT INDI_FIND_QUIETLY)
+  else (INDI_FOUND)
+    if (INDI_FIND_REQUIRED)
+      message(FATAL_ERROR "INDI not found. Please install INDI and try again.")
+    endif (INDI_FIND_REQUIRED)
+  endif (INDI_FOUND)
+
+    if(ANDROID)
+        mark_as_advanced(INDI_INCLUDE_DIR INDI_CLIENT_ANDROID_LIBRARIES)
+    else(ANDROID)
+        mark_as_advanced(INDI_INCLUDE_DIR INDI_LIBRARIES INDI_CLIENT_LIBRARIES INDI_CLIENT_QT_LIBRARIES)
+    endif(ANDROID)
+endif(NOT INDI_FOUND)

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -887,7 +887,7 @@ endif()  # APPLE
 # Unix/Linux specific dependencies
 # - ASI cameras
 # - INDI
-# - Nova (optional)
+# - Nova (Required by INDI)
 # - USB (commonly shared)
 # - math (libm)
 # - 
@@ -927,28 +927,26 @@ if(UNIX AND NOT APPLE)
   # some features for indi >= 0.9 are used apparently
   find_package(INDI 0.9 REQUIRED)
   include_directories(${INDI_INCLUDE_DIR})
-  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${INDI_CLIENT_LIBRARIES} ${INDI_LIBRARIES})
-  if(PC_INDI_VERSION VERSION_LESS "1.1")
+  if(INDI_VERSION VERSION_LESS "1.4")
+    set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${INDI_CLIENT_LIBRARIES} ${INDI_LIBRARIES})
+  else(INDI_VERSION VERSION_LESS "1.4")
+      set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${INDI_CLIENT_LIBRARIES})
+  endif(INDI_VERSION VERSION_LESS "1.4")
+  if(INDI_VERSION VERSION_LESS "1.1")
     add_definitions("-DINDI_PRE_1_1_0")
   endif()
-  if(PC_INDI_VERSION VERSION_LESS "1.0")
+  if(INDI_VERSION VERSION_LESS "1.0")
     add_definitions("-DINDI_PRE_1_0_0")
   endif()
   
   # INDI depends on libz
   find_package(ZLIB REQUIRED)
   set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${ZLIB_LIBRARIES})
-
   
-  # Nova
-  find_package(Nova)
-  if(NOVA_FOUND)
-      include_directories(${NOVA_INCLUDE_DIR})
-      set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${NOVA_LIBRARIES})
-      add_definitions("-DLIBNOVA" )
-  else()
-      message(WARNING "libnova not found! Considere to install libnova-dev ")
-  endif() 
-
+  # INDI depends on libnova
+  find_package(Nova REQUIRED)
+  include_directories(${NOVA_INCLUDE_DIR})
+  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${NOVA_LIBRARIES})
+  add_definitions("-DLIBNOVA")
 
 endif()


### PR DESCRIPTION
INDI 1.4 removed INDI Library (libindi.so) and so clients now need only to link with the static INDI client library (libindiclient.a) along with some dependencies (libnova, libz, libm). This pull request addresses this change and PHD2 can now compile with the latest INDI. It can also still compile on earlier versions of INDI.