### PR TITLE
Allow the usage of system libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_custom_target(CmakeAdditionalFiles
   SOURCES
   ${phd_src_dir}/thirdparty/thirdparty.cmake
   ${phd_src_dir}/cmake_modules/FindASCOM_INTERFACE.cmake
+  ${phd_src_dir}/cmake_modules/FindCFITSIO.cmake
   ${phd_src_dir}/cmake_modules/FindINDI.cmake
   ${phd_src_dir}/cmake_modules/FindNova.cmake
   ${phd_src_dir}/cmake_modules/PHD2BuildDoc.cmake

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -44,6 +44,11 @@ set(CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake_modules/ )
 
 
+# these option allow to use system libraries
+option(USE_SYSTEM_CFITSIO "Enable this option here or in cmake call if you want to use system's cfitsio." OFF)
+option(USE_SYSTEM_LIBUSB "Enable this option here or in cmake call if you want to use system's libUSB." OFF)
+
+
 
 # these variables allow to specify to which the main project will link and
 # to potentially copy some resources to the output directory of the main project.
@@ -179,96 +184,103 @@ endmacro(copy_dependency_with_config)
 ##############################################
 # cfitsio
 
-set(libcfitsio_root ${thirdparties_deflate_directory}/cfitsio)
-if(NOT EXISTS ${libcfitsio_root})
-  # untar the dependency
-  message(STATUS "Untarring cfitsio")
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${thirdparty_dir}/cfitsio3370.tar.gz
-                  WORKING_DIRECTORY ${thirdparties_deflate_directory})
-endif()
+if (USE_SYSTEM_CFITSIO)
+  find_package(CFITSIO REQUIRED)
+  include_directories(${CFITSIO_INCLUDE_DIR})
+  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${CFITSIO_LIBRARIES})
+  message(STATUS "Using system's CFITSIO.")
+else (USE_SYSTEM_CFITSIO)
+  set(libcfitsio_root ${thirdparties_deflate_directory}/cfitsio)
+  if(NOT EXISTS ${libcfitsio_root})
+    # untar the dependency
+    message(STATUS "Untarring cfitsio")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${thirdparty_dir}/cfitsio3370.tar.gz
+                    WORKING_DIRECTORY ${thirdparties_deflate_directory})
+  endif()
 
-# copied and adapted from the CMakeLists.txt of cftsio project. The sources of the project
-# are left untouched
+  # copied and adapted from the CMakeLists.txt of cftsio project. The sources of the project
+  # are left untouched
 
-# Define project version
-set(CFITSIO_MAJOR_VERSION 3)
-set(CFITSIO_MINOR_VERSION 37)
-set(CFITSIO_VERSION ${CFITSIO_MAJOR_VERSION}.${CFITSIO_MINOR_VERSION})
-
-
-file(GLOB CFTSIO_H_FILES "${libcfitsio_root}/*.h")
-
-# OpenPhdGuiding COMMENT HERE
-# Raffi: these should also be cleaned (link against zlib of the system)
-
-set(CFTSIO_SRC_FILES
-    buffers.c cfileio.c checksum.c drvrfile.c drvrmem.c
-    drvrnet.c drvrsmem.c drvrgsiftp.c editcol.c edithdu.c eval_l.c
-    eval_y.c eval_f.c fitscore.c getcol.c getcolb.c getcold.c getcole.c
-    getcoli.c getcolj.c getcolk.c getcoll.c getcols.c getcolsb.c
-    getcoluk.c getcolui.c getcoluj.c getkey.c group.c grparser.c
-    histo.c iraffits.c
-    modkey.c putcol.c putcolb.c putcold.c putcole.c putcoli.c
-    putcolj.c putcolk.c putcoluk.c putcoll.c putcols.c putcolsb.c
-    putcolu.c putcolui.c putcoluj.c putkey.c region.c scalnull.c
-    swapproc.c wcssub.c wcsutil.c imcompress.c quantize.c ricecomp.c
-    pliocomp.c fits_hcompress.c fits_hdecompress.c
-
-    zlib/zuncompress.c
-    zlib/zcompress.c
-    zlib/adler32.c
-    zlib/crc32.c
-    zlib/inffast.c
-    zlib/inftrees.c
-    zlib/trees.c
-    zlib/zutil.c
-    zlib/deflate.c
-    zlib/infback.c
-    zlib/inflate.c
-    zlib/uncompr.c
-
-    simplerng.c
-    f77_wrap1.c f77_wrap2.c f77_wrap3.c f77_wrap4.c
-)
-
-foreach(_src_file IN LISTS CFTSIO_SRC_FILES)
-  set(CFTSIO_SRC_FILES_rooted "${CFTSIO_SRC_FILES_rooted}" ${libcfitsio_root}/${_src_file})
-endforeach()
-
-add_library(cfitsio STATIC ${CFTSIO_H_FILES} ${CFTSIO_SRC_FILES_rooted})
-target_include_directories(cfitsio PUBLIC ${libcfitsio_root}/)
-
-# OpenPhdGuiding MODIFICATION HERE: we link against math library only on UNIX
-if(UNIX)
-  target_link_libraries(cfitsio m)
-endif()
-
-# OpenPhdGuiding MODIFICATION HERE: suppress warning about unused function result
-if(UNIX AND NOT APPLE)
-  set_target_properties(cfitsio PROPERTIES COMPILE_FLAGS "-Wno-unused-result")
-  # Raffi: use target_compile_options ?
-endif()
-
-if(WIN32)
-  target_compile_definitions(
-    cfitsio
-    PRIVATE FF_NO_UNISTD_H
-    PRIVATE _CRT_SECURE_NO_WARNINGS
-    PRIVATE _CRT_SECURE_NO_DEPRECATE)
-endif()
+  # Define project version
+  set(CFITSIO_MAJOR_VERSION 3)
+  set(CFITSIO_MINOR_VERSION 37)
+  set(CFITSIO_VERSION ${CFITSIO_MAJOR_VERSION}.${CFITSIO_MINOR_VERSION})
 
 
-set_target_properties(cfitsio PROPERTIES
-                      VERSION ${CFITSIO_VERSION}
-                      SOVERSION ${CFITSIO_MAJOR_VERSION}
-                      FOLDER "Thirdparty/")
+  file(GLOB CFTSIO_H_FILES "${libcfitsio_root}/*.h")
+
+  # OpenPhdGuiding COMMENT HERE
+  # Raffi: these should also be cleaned (link against zlib of the system)
+
+  set(CFTSIO_SRC_FILES
+      buffers.c cfileio.c checksum.c drvrfile.c drvrmem.c
+      drvrnet.c drvrsmem.c drvrgsiftp.c editcol.c edithdu.c eval_l.c
+      eval_y.c eval_f.c fitscore.c getcol.c getcolb.c getcold.c getcole.c
+      getcoli.c getcolj.c getcolk.c getcoll.c getcols.c getcolsb.c
+      getcoluk.c getcolui.c getcoluj.c getkey.c group.c grparser.c
+      histo.c iraffits.c
+      modkey.c putcol.c putcolb.c putcold.c putcole.c putcoli.c
+      putcolj.c putcolk.c putcoluk.c putcoll.c putcols.c putcolsb.c
+      putcolu.c putcolui.c putcoluj.c putkey.c region.c scalnull.c
+      swapproc.c wcssub.c wcsutil.c imcompress.c quantize.c ricecomp.c
+      pliocomp.c fits_hcompress.c fits_hdecompress.c
+
+      zlib/zuncompress.c
+      zlib/zcompress.c
+      zlib/adler32.c
+      zlib/crc32.c
+      zlib/inffast.c
+      zlib/inftrees.c
+      zlib/trees.c
+      zlib/zutil.c
+      zlib/deflate.c
+      zlib/infback.c
+      zlib/inflate.c
+      zlib/uncompr.c
+
+      simplerng.c
+      f77_wrap1.c f77_wrap2.c f77_wrap3.c f77_wrap4.c
+  )
+
+  foreach(_src_file IN LISTS CFTSIO_SRC_FILES)
+    set(CFTSIO_SRC_FILES_rooted "${CFTSIO_SRC_FILES_rooted}" ${libcfitsio_root}/${_src_file})
+  endforeach()
+
+  add_library(cfitsio STATIC ${CFTSIO_H_FILES} ${CFTSIO_SRC_FILES_rooted})
+  target_include_directories(cfitsio PUBLIC ${libcfitsio_root}/)
+
+  # OpenPhdGuiding MODIFICATION HERE: we link against math library only on UNIX
+  if(UNIX)
+    target_link_libraries(cfitsio m)
+  endif()
+
+  # OpenPhdGuiding MODIFICATION HERE: suppress warning about unused function result
+  if(UNIX AND NOT APPLE)
+    set_target_properties(cfitsio PROPERTIES COMPILE_FLAGS "-Wno-unused-result")
+    # Raffi: use target_compile_options ?
+  endif()
+
+  if(WIN32)
+    target_compile_definitions(
+      cfitsio
+      PRIVATE FF_NO_UNISTD_H
+      PRIVATE _CRT_SECURE_NO_WARNINGS
+      PRIVATE _CRT_SECURE_NO_DEPRECATE)
+  endif()
 
 
-# indicating the link and include directives to the main project.
-# already done by the directive target_include_directories(cfitsio PUBLIC
-# include_directories(${libcfitsio_root})
-set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} cfitsio)
+  set_target_properties(cfitsio PROPERTIES
+                        VERSION ${CFITSIO_VERSION}
+                        SOVERSION ${CFITSIO_MAJOR_VERSION}
+                        FOLDER "Thirdparty/")
 
+
+  # indicating the link and include directives to the main project.
+  # already done by the directive target_include_directories(cfitsio PUBLIC
+  # include_directories(${libcfitsio_root})
+  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} cfitsio)
+
+endif(USE_SYSTEM_CFITSIO)
 
 
 
@@ -404,13 +416,18 @@ elseif(UNIX)
 
   # this would find the libUSB module that is installed on the system.
   # It requires "sudo apt-get install libusb-1.0-0-dev"
-  pkg_check_modules(USB_pkg libusb-1.0)
-  if(0) # if(USB_pkg_FOUND) - force using the bundled libusb - older versions may not work with the ZWO ASI camera SDK
-    include_directories(${USB_pkg_INCLUDE_DIRS})
-    set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${USB_pkg_LIBRARIES})
-    set(USB_build FALSE)
-    set(openphd_libusb ${USB_pkg_LIBRARIES})
-  else()
+  if(USE_SYSTEM_LIBUSB)
+    pkg_check_modules(USB_pkg libusb-1.0)
+    if(0)
+      message(FATAL_ERROR "libUSB not detected")
+    else()
+      include_directories(${USB_pkg_INCLUDE_DIRS})
+      set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${USB_pkg_LIBRARIES})
+      set(USB_build FALSE)
+      set(openphd_libusb ${USB_pkg_LIBRARIES})
+      message(STATUS "Using system's libUSB.")
+    endif()
+  else(USE_SYSTEM_LIBUSB)
 
     # in case the library is not installed on the system (as I have on my machines)
     # try by building the library ourselves

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -450,7 +450,7 @@ elseif(UNIX)
 
     set(${LIBUSB}_additional_compile_definition "OS_LINUX=1")
     set(${LIBUSB}_additional_include_dir ${thirdparty_dir}/include/${LIBUSB})
-  endif()
+  endif(USE_SYSTEM_LIBUSB)
 
 else()
   message(FATAL_ERROR "libUSB unsupported platform")


### PR DESCRIPTION
I would like to package PHD2 for inclusion in Fedora and EPEL repositories, but in order to do so there must be a way to make it build using system libraries instead of bundled libraries.

This is a first patch to let user specify the use of system provided Cfitsio and libUSB. The appropriate options defaults to off, so they don't change anything to the previous build method. (the cfitsio part of the patch seems to change a lot, but I only added spaces to format lines for the new IF-ELSE statement I introduced - the code is untouched).
