### PR TITLE
Use SO_REUSEADDR for servers

### DIFF
--- a/event_server.cpp
+++ b/event_server.cpp
@@ -2115,7 +2115,7 @@ bool EventServer::EventServerStart(unsigned int instanceId)
     unsigned int port = 4400 + instanceId - 1;
     wxIPV4address eventServerAddr;
     eventServerAddr.Service(port);
-    m_serverSocket = new wxSocketServer(eventServerAddr);
+    m_serverSocket = new wxSocketServer(eventServerAddr, wxSOCKET_REUSEADDR);
 
     if (!m_serverSocket->Ok())
     {

--- a/socket_server.cpp
+++ b/socket_server.cpp
@@ -94,7 +94,7 @@ bool MyFrame::StartServer(bool state)
         unsigned int port = 4300 + m_instanceNumber - 1;
         wxIPV4address sockServerAddr;
         sockServerAddr.Service(port);
-        SocketServer = new wxSocketServer(sockServerAddr);
+        SocketServer = new wxSocketServer(sockServerAddr, wxSOCKET_REUSEADDR);
 
         // We use Ok() here to see if the server is really listening
         if (!SocketServer->Ok())


### PR DESCRIPTION
Use SO_REUSEADDR for servers so that event/socket server start does not fail on phd restart