### PR TITLE
Direct attach SBIG in Linux

### DIFF
--- a/cam_SBIG.cpp
+++ b/cam_SBIG.cpp
@@ -70,6 +70,7 @@ Camera_SBIGClass::Camera_SBIGClass()
     UseTrackingCCD = false;
     HasShutter = true;
     HasSubframes = true;
+    IsColor = false;
 }
 
 Camera_SBIGClass::~Camera_SBIGClass()
@@ -348,6 +349,8 @@ bool Camera_SBIGClass::Connect(const wxString& camId)
     Debug.Write(wxString::Format("SBIG: %s type=%u, UseTrackingCCD=%d, MaxBin = %hu, 1x1 size %d x %d, 2x2 size %d x %d\n", gcir0.name, gcir0.cameraType, UseTrackingCCD, MaxBinning, m_imageSize[0].x, m_imageSize[0].y, m_imageSize[1].x, m_imageSize[1].y));
 
     Name = gcir0.name;
+    IsColor = Name.find("Color");
+   
     Connected = true;
     return false;
 }
@@ -544,6 +547,9 @@ bool Camera_SBIGClass::Capture(int duration, usImage& img, int options, const wx
     }
 
     if (options & CAPTURE_SUBTRACT_DARK) SubtractDark(img);
+    if (IsColor && Binning == 1 && (options & CAPTURE_RECON)) {
+        QuickLRecon(img);
+    }
 
     return false;
 }

--- a/cam_SBIG.h
+++ b/cam_SBIG.h
@@ -38,6 +38,8 @@
 
 #if defined (__APPLE__)
 #include <SBIGUDrv/sbigudrv.h>
+#elif defined(__LINUX__)
+    #include <sbigudrv.h>
 #else
 #include "cameras/Sbigudrv.h"
 #endif
@@ -48,6 +50,7 @@ class Camera_SBIGClass : public GuideCamera
     bool m_driverLoaded;
     wxSize m_imageSize[2]; // 0=>bin1, 1=>bin2
     double m_devicePixelSize;
+    bool IsColor;
 
 public:
     Camera_SBIGClass();

--- a/cameras.h
+++ b/cameras.h
@@ -111,6 +111,7 @@
 # define INDI_CAMERA
 # define ZWO_ASI
 # define SXV
+# define SBIG
 
 #endif
 

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -629,6 +629,11 @@ else()   # Linux or OSX
   # INDI depends on libz
   find_package(ZLIB REQUIRED)
   set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${ZLIB_LIBRARIES})
+  
+  # INDI depends on Nova
+  find_library(NOVALIB REQUIRED NAMES nova)
+  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} nova)
+  
 endif()
 
 
@@ -787,8 +792,36 @@ if(NOT EXISTS ${qhyccd_root})
     WORKING_DIRECTORY ${qhyccd_root})
 endif()
 
+#############################################
+# SBIG specific dependencies if installed part of system
+#############################################
+if(SBIG_SYSTEM)
+
+  # Assumes SBIG's Universal driver has been loaded into the system and placed
+  # in a standard path. (e.g. sbigudrv.h in /usr/include, libsbigudrv.so in /usr/lib )
+  # 
+  # SDK for linux can be found here -> ftp://ftp.diffractionlimited.com/pub/devsw/LinuxDevKit.tar.gz
+  # 
+  # To rebuild libSBIG
+  # cd ${WORKDIR}/LinuxDevKit/x86/c/testapp
+  #  local sharedlink="-shared -Wl,-soname,libSBIG-1.33.0"
+  #  g++ -c ${CXXFLAGS} -c -fPIC -I /usr/include/libusb-1.0 -I ${WORKDIR}/LinuxDevKit/x86/c/testapp csbigimg.cpp csbigcam.cpp
+  #  g++ -L ${WORKDIR}/LinuxDevKit/x86/c/lib64/ ${sharedlink} -o libSBIG=1.33.0 csbigimg.o csbigcam.o -lm -lsbigudrv -lusb -lcfitsio
+  #  ar -cvq libSBIG.a csbigimg.o csbigcam.o
 
 
+  message(STATUS "Finding SBIG Univeral Drivers on system")
+  find_path(SBIG_INCLUDE_DIR sbigudrv.h)
+  find_library(SBIG_LIBRARIES NAMES SBIG)
+  find_library(SBIGUDRV_LIBRARIES NAMES sbigudrv)
+  include_directories(${SBIG_INCLUDE_DIR})
+  
+  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} SBIG sbigudrv)
+ 
+  if(UNIX)
+    add_definitions("-DTARGET=7") 
+  endif()
+endif()
 
 #############################################
 #


### PR DESCRIPTION
Following changes:
- fix a link error for indilib (requires nova libraries)
- use "system" installed copy of SBIG SDK.
- color support for sbig

Fixed a load error with current indilib (indilib appears to need the nova libraries).

The changes are fairly small (mostly in thirdparty/thirdparty.cmake).
I created a section to handle the case where the sbig libraries are loaded on the system

Added check for color on sbig cameras and call the QuickLRecon function

(sorry about the line end change change in cam_SBIG.cpp for the color support.
Here's the diff ignoring whitespace for the color support)

```
@@ -70,6 +70,7 @@ Camera_SBIGClass::Camera_SBIGClass()
     UseTrackingCCD = false;
     HasShutter = true;
     HasSubframes = true;
+    IsColor = false;
 }
 
 Camera_SBIGClass::~Camera_SBIGClass()
@@ -348,6 +349,8 @@ bool Camera_SBIGClass::Connect(const wxString& camId)
     Debug.Write(wxString::Format("SBIG: %s type=%u, UseTrackingCCD=%d, MaxBin = %hu, 1x1 size %d x %d, 2x2 size %d x %d\n", gcir0.name, gcir0.cameraType, UseTrackingCCD, MaxBinning, m_imageSize[0].x, m_imageSize[0].y, m_imageSize[1].x, m_imageSize[1].y));
 
     Name = gcir0.name;
+    IsColor = Name.find("Color");
+   
     Connected = true;
     return false;
 }
@@ -544,6 +547,9 @@ bool Camera_SBIGClass::Capture(int duration, usImage& img, int options, const wx
     }
 
     if (options & CAPTURE_SUBTRACT_DARK) SubtractDark(img);
+    if (IsColor && Binning == 1 && (options & CAPTURE_RECON)) {
+        QuickLRecon(img);
+    }
 
     return false;
 }
```