### PR TITLE
Staticpa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,9 @@ set(phd2_SRC
   ${phd_src_dir}/socket_server.h
   ${phd_src_dir}/starcross_test.cpp
   ${phd_src_dir}/starcross_test.h
+  ${phd_src_dir}/staticpa_tool.h
+  ${phd_src_dir}/staticpa_toolwin.h
+  ${phd_src_dir}/staticpa_toolwin.cpp
   ${phd_src_dir}/statswindow.cpp
   ${phd_src_dir}/statswindow.h
 

--- a/eegg.cpp
+++ b/eegg.cpp
@@ -192,7 +192,7 @@ void MyFrame::OnStaticPaTool(wxCommandEvent& WXUNUSED(evt))
 {
     if (!pStaticPaTool)
     {
-		pStaticPaTool = StaticPaTool::CreateStaticPaToolWindow();
+        pStaticPaTool = StaticPaTool::CreateStaticPaToolWindow();
     }
 
     if (pStaticPaTool)

--- a/eegg.cpp
+++ b/eegg.cpp
@@ -34,6 +34,7 @@
 
 #include "phd.h"
 #include "drift_tool.h"
+#include "staticpa_tool.h"
 #include "manualcal_dialog.h"
 #include "calreview_dialog.h"
 #include "nudge_lock.h"
@@ -184,6 +185,19 @@ void MyFrame::OnDriftTool(wxCommandEvent& WXUNUSED(evt))
     if (pDriftTool)
     {
         pDriftTool->Show();
+    }
+}
+
+void MyFrame::OnStaticPaTool(wxCommandEvent& WXUNUSED(evt))
+{
+    if (!pStaticPaTool)
+    {
+		pStaticPaTool = StaticPaTool::CreateStaticPaToolWindow();
+    }
+
+    if (pStaticPaTool)
+    {
+        pStaticPaTool->Show();
     }
 }
 

--- a/guider.cpp
+++ b/guider.cpp
@@ -1250,26 +1250,16 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 SetState(STATE_SELECTED);
                 break;
             case STATE_SELECTED:
-                // nothing to do but wait
+                // See if a Static PA is underway
                 if (pStaticPaTool && pStaticPaTool->IsAligning())
                 {
-                    //Get the current position
-                    // Reset the lock position
-                    // See if the star has moved enough
-                    // If yes then bookmark the position and set up for the next position until aligned
-                    // If not then rotate the mount some more
+                    // Rotate the mount in RA a bit
                     if (!pStaticPaTool->RotateMount())
                     {
                         SetState(STATE_UNINITIALIZED);
-                        statusMessage = _("alignment failed");
-                        throw ERROR_INFO("Alignment failed");
+                        statusMessage = _("Static PA rotation failed");
+                        throw ERROR_INFO("Static PA rotation failed");
                     }
-
-                    if (!pStaticPaTool->IsAligned())
-                    {
-                        break;
-                    }
-                    assert(pStaticPaTool->IsAligned());
                 }
                 break;
             case STATE_CALIBRATING_PRIMARY:

--- a/guider.cpp
+++ b/guider.cpp
@@ -143,7 +143,7 @@ Guider::Guider(wxWindow *parent, int xSize, int ySize) :
     SetBackgroundColour(wxColour((unsigned char) 30, (unsigned char) 30,(unsigned char) 30));
 
     s_deflectionLogger.Init();
-	pStaticPaTool = 0;
+    pStaticPaTool = 0;
 }
 
 Guider::~Guider(void)
@@ -429,7 +429,7 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
         int XImgSize = m_displayedImage->GetWidth();
         int YImgSize = m_displayedImage->GetHeight();
 
-		if (m_overlayMode)
+        if (m_overlayMode)
         {
             dc.SetPen(wxPen(wxColor(200,50,50)));
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
@@ -566,8 +566,8 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
                     }
                     break;
 
-				case OVERLAY_NONE:
-					break;
+                case OVERLAY_NONE:
+                    break;
             }
         }
 
@@ -620,12 +620,12 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
         }
 
         
- 		// draw static polar align stuff
-		// Ideally get a pointer to StaticPaTool and let it do the work
-		if (pStaticPaTool)
-		{
-			pStaticPaTool->PaintHelper(dc, m_scaleFactor);
-		}
+         // draw static polar align stuff
+        // Ideally get a pointer to StaticPaTool and let it do the work
+        if (pStaticPaTool)
+        {
+            pStaticPaTool->PaintHelper(dc, m_scaleFactor);
+        }
 
         if (IsPaused())
         {
@@ -857,9 +857,9 @@ void Guider::SetState(GUIDER_STATE newState)
                     // start over...
                     newState = STATE_UNINITIALIZED;
                     break;
-				case STATE_CALIBRATED:
-				case STATE_GUIDING:
-					newState = STATE_SELECTED;
+                case STATE_CALIBRATED:
+                case STATE_GUIDING:
+                    newState = STATE_SELECTED;
                     break;
                 case STATE_STOP:
                     break;
@@ -868,11 +868,11 @@ void Guider::SetState(GUIDER_STATE newState)
 
         assert(newState != STATE_STOP);
 
-		if (newState > m_state + 1)
-		{
-			Debug.Write(wxString::Format("Cannot transition from %d to  newState=%d\n", m_state, newState));
-			throw ERROR_INFO("Illegal state transition");
-		}
+        if (newState > m_state + 1)
+        {
+            Debug.Write(wxString::Format("Cannot transition from %d to  newState=%d\n", m_state, newState));
+            throw ERROR_INFO("Illegal state transition");
+        }
         GUIDER_STATE requestedState = newState;
 
         switch (requestedState)
@@ -946,7 +946,7 @@ void Guider::SetState(GUIDER_STATE newState)
 
             case STATE_SELECTING:
             case STATE_CALIBRATED:
-			case STATE_STOP:
+            case STATE_STOP:
                 break;
         }
 
@@ -1184,14 +1184,14 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                     SetState(STATE_UNINITIALIZED);
                     EvtServer.NotifyStarLost(info);
                     break;
-				case STATE_CALIBRATING_PRIMARY:
-				case STATE_CALIBRATING_SECONDARY:
-					GuideLog.CalibrationFrameDropped(info);
-					Debug.Write("Star lost during calibration... blundering on\n");
-					EvtServer.NotifyStarLost(info);
-					pFrame->StatusMsg(_("star lost"));
-					break;
-				case STATE_GUIDING:
+                case STATE_CALIBRATING_PRIMARY:
+                case STATE_CALIBRATING_SECONDARY:
+                    GuideLog.CalibrationFrameDropped(info);
+                    Debug.Write("Star lost during calibration... blundering on\n");
+                    EvtServer.NotifyStarLost(info);
+                    pFrame->StatusMsg(_("star lost"));
+                    break;
+                case STATE_GUIDING:
                 {
                     GuideLog.FrameDropped(info);
                     EvtServer.NotifyStarLost(info);
@@ -1211,7 +1211,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 }
 
                 case STATE_CALIBRATED:
-				case STATE_STOP:
+                case STATE_STOP:
                     break;
             }
 
@@ -1251,27 +1251,27 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 break;
             case STATE_SELECTED:
                 // nothing to do but wait
-				if (pStaticPaTool && pStaticPaTool->IsAligning())
-				{
-					//Get the current position
-					// Reset the lock position
-					// See if the star has moved enough
-					// If yes then bookmark the position and set up for the next position until aligned
-					// If not then rotate the mount some more
-					if (!pStaticPaTool->RotateMount())
-					{
-						SetState(STATE_UNINITIALIZED);
-						statusMessage = _("alignment failed");
-						throw ERROR_INFO("Alignment failed");
-					}
+                if (pStaticPaTool && pStaticPaTool->IsAligning())
+                {
+                    //Get the current position
+                    // Reset the lock position
+                    // See if the star has moved enough
+                    // If yes then bookmark the position and set up for the next position until aligned
+                    // If not then rotate the mount some more
+                    if (!pStaticPaTool->RotateMount())
+                    {
+                        SetState(STATE_UNINITIALIZED);
+                        statusMessage = _("alignment failed");
+                        throw ERROR_INFO("Alignment failed");
+                    }
 
-					if (!pStaticPaTool->IsAligned())
-					{
-						break;
-					}
-					assert(pStaticPaTool->IsAligned());
-				}
-				break;
+                    if (!pStaticPaTool->IsAligned())
+                    {
+                        break;
+                    }
+                    assert(pStaticPaTool->IsAligned());
+                }
+                break;
             case STATE_CALIBRATING_PRIMARY:
                 if (!pMount->IsCalibrated())
                 {
@@ -1380,7 +1380,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                     pFrame->SchedulePrimaryMove(pMount, CurrentPosition() - LockPosition(), MOVETYPE_ALGO);
                 }
                 break;
-			case STATE_UNINITIALIZED:
+            case STATE_UNINITIALIZED:
             case STATE_STOP:
                 break;
         }

--- a/guider.cpp
+++ b/guider.cpp
@@ -1258,7 +1258,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
 					// See if the star has moved enough
 					// If yes then bookmark the position and set up for the next position until aligned
 					// If not then rotate the mount some more
-					if (!pStaticPaTool->UpdateAlignmentState(CurrentPosition()))
+					if (!pStaticPaTool->RotateMount())
 					{
 						SetState(STATE_UNINITIALIZED);
 						statusMessage = _("alignment failed");

--- a/guider.cpp
+++ b/guider.cpp
@@ -34,6 +34,7 @@
 #include "phd.h"
 #include "nudge_lock.h"
 #include "comet_tool.h"
+#include "staticpa_tool.h"
 #include "guiding_assistant.h"
 
 // un-comment to log star deflections to a file
@@ -143,7 +144,6 @@ Guider::Guider(wxWindow *parent, int xSize, int ySize) :
     SetBackgroundColour(wxColour((unsigned char) 30, (unsigned char) 30,(unsigned char) 30));
 
     s_deflectionLogger.Init();
-    pStaticPaTool = 0;
 }
 
 Guider::~Guider(void)
@@ -622,9 +622,9 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
         
          // draw static polar align stuff
         // Ideally get a pointer to StaticPaTool and let it do the work
-        if (pStaticPaTool)
+        if (pFrame->pStaticPaTool)
         {
-            pStaticPaTool->PaintHelper(dc, m_scaleFactor);
+            StaticPaTool::PaintHelper(dc, m_scaleFactor);
         }
 
         if (IsPaused())
@@ -1251,10 +1251,10 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 break;
             case STATE_SELECTED:
                 // See if a Static PA is underway
-                if (pStaticPaTool && pStaticPaTool->IsAligning())
+                if (pFrame->pStaticPaTool && StaticPaTool::IsAligning())
                 {
                     // Rotate the mount in RA a bit
-                    if (!pStaticPaTool->RotateMount())
+                    if (!StaticPaTool::RotateMount())
                     {
                         SetState(STATE_UNINITIALIZED);
                         statusMessage = _("Static PA rotation failed");

--- a/guider.cpp
+++ b/guider.cpp
@@ -143,6 +143,7 @@ Guider::Guider(wxWindow *parent, int xSize, int ySize) :
     SetBackgroundColour(wxColour((unsigned char) 30, (unsigned char) 30,(unsigned char) 30));
 
     s_deflectionLogger.Init();
+	pStaticPaTool = 0;
 }
 
 Guider::~Guider(void)
@@ -428,7 +429,7 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
         int XImgSize = m_displayedImage->GetWidth();
         int YImgSize = m_displayedImage->GetHeight();
 
-        if (m_overlayMode)
+		if (m_overlayMode)
         {
             dc.SetPen(wxPen(wxColor(200,50,50)));
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
@@ -565,8 +566,8 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
                     }
                     break;
 
-                case OVERLAY_NONE:
-                    break;
+				case OVERLAY_NONE:
+					break;
             }
         }
 
@@ -617,6 +618,14 @@ bool Guider::PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC)
             dc.DrawCircle(m_polarAlignCircleCenter.X * m_scaleFactor,
                 m_polarAlignCircleCenter.Y * m_scaleFactor, radius);
         }
+
+        
+ 		// draw static polar align stuff
+		// Ideally get a pointer to StaticPaTool and let it do the work
+		if (pStaticPaTool)
+		{
+			pStaticPaTool->PaintHelper(dc, m_scaleFactor);
+		}
 
         if (IsPaused())
         {
@@ -848,9 +857,9 @@ void Guider::SetState(GUIDER_STATE newState)
                     // start over...
                     newState = STATE_UNINITIALIZED;
                     break;
-                case STATE_CALIBRATED:
-                case STATE_GUIDING:
-                    newState = STATE_SELECTED;
+				case STATE_CALIBRATED:
+				case STATE_GUIDING:
+					newState = STATE_SELECTED;
                     break;
                 case STATE_STOP:
                     break;
@@ -859,12 +868,11 @@ void Guider::SetState(GUIDER_STATE newState)
 
         assert(newState != STATE_STOP);
 
-        if (newState > m_state + 1)
-        {
-            Debug.Write(wxString::Format("Cannot transition from %d to  newState=%d\n", m_state, newState));
-            throw ERROR_INFO("Illegal state transition");
-        }
-
+		if (newState > m_state + 1)
+		{
+			Debug.Write(wxString::Format("Cannot transition from %d to  newState=%d\n", m_state, newState));
+			throw ERROR_INFO("Illegal state transition");
+		}
         GUIDER_STATE requestedState = newState;
 
         switch (requestedState)
@@ -938,7 +946,7 @@ void Guider::SetState(GUIDER_STATE newState)
 
             case STATE_SELECTING:
             case STATE_CALIBRATED:
-            case STATE_STOP:
+			case STATE_STOP:
                 break;
         }
 
@@ -1176,14 +1184,14 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                     SetState(STATE_UNINITIALIZED);
                     EvtServer.NotifyStarLost(info);
                     break;
-                case STATE_CALIBRATING_PRIMARY:
-                case STATE_CALIBRATING_SECONDARY:
-                    GuideLog.CalibrationFrameDropped(info);
-                    Debug.Write("Star lost during calibration... blundering on\n");
-                    EvtServer.NotifyStarLost(info);
-                    pFrame->StatusMsg(_("star lost"));
-                    break;
-                case STATE_GUIDING:
+				case STATE_CALIBRATING_PRIMARY:
+				case STATE_CALIBRATING_SECONDARY:
+					GuideLog.CalibrationFrameDropped(info);
+					Debug.Write("Star lost during calibration... blundering on\n");
+					EvtServer.NotifyStarLost(info);
+					pFrame->StatusMsg(_("star lost"));
+					break;
+				case STATE_GUIDING:
                 {
                     GuideLog.FrameDropped(info);
                     EvtServer.NotifyStarLost(info);
@@ -1203,7 +1211,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 }
 
                 case STATE_CALIBRATED:
-                case STATE_STOP:
+				case STATE_STOP:
                     break;
             }
 
@@ -1243,7 +1251,27 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                 break;
             case STATE_SELECTED:
                 // nothing to do but wait
-                break;
+				if (pStaticPaTool && pStaticPaTool->IsAligning())
+				{
+					//Get the current position
+					// Reset the lock position
+					// See if the star has moved enough
+					// If yes then bookmark the position and set up for the next position until aligned
+					// If not then rotate the mount some more
+					if (!pStaticPaTool->UpdateAlignmentState(CurrentPosition()))
+					{
+						SetState(STATE_UNINITIALIZED);
+						statusMessage = _("alignment failed");
+						throw ERROR_INFO("Alignment failed");
+					}
+
+					if (!pStaticPaTool->IsAligned())
+					{
+						break;
+					}
+					assert(pStaticPaTool->IsAligned());
+				}
+				break;
             case STATE_CALIBRATING_PRIMARY:
                 if (!pMount->IsCalibrated())
                 {
@@ -1352,8 +1380,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                     pFrame->SchedulePrimaryMove(pMount, CurrentPosition() - LockPosition(), MOVETYPE_ALGO);
                 }
                 break;
-
-            case STATE_UNINITIALIZED:
+			case STATE_UNINITIALIZED:
             case STATE_STOP:
                 break;
         }

--- a/guider.cpp
+++ b/guider.cpp
@@ -873,6 +873,7 @@ void Guider::SetState(GUIDER_STATE newState)
             Debug.Write(wxString::Format("Cannot transition from %d to  newState=%d\n", m_state, newState));
             throw ERROR_INFO("Illegal state transition");
         }
+
         GUIDER_STATE requestedState = newState;
 
         switch (requestedState)
@@ -1370,6 +1371,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
                     pFrame->SchedulePrimaryMove(pMount, CurrentPosition() - LockPosition(), MOVETYPE_ALGO);
                 }
                 break;
+
             case STATE_UNINITIALIZED:
             case STATE_STOP:
                 break;

--- a/guider.h
+++ b/guider.h
@@ -39,16 +39,17 @@
 
 #ifndef GUIDER_H_INCLUDED
 #define GUIDER_H_INCLUDED
+#include "staticpa_toolwin.h"
 
 enum GUIDER_STATE
 {
     STATE_UNINITIALIZED = 0,
     STATE_SELECTING,
     STATE_SELECTED,
-    STATE_CALIBRATING_PRIMARY,
-    STATE_CALIBRATING_SECONDARY,
-    STATE_CALIBRATED,
-    STATE_GUIDING,
+	STATE_CALIBRATING_PRIMARY,
+	STATE_CALIBRATING_SECONDARY,
+	STATE_CALIBRATED,
+	STATE_GUIDING,
     STATE_STOP, // This is a pseudo state
 };
 
@@ -166,7 +167,8 @@ protected:
 
     // Things related to the Advanced Config Dialog
 public:
-    class GuiderConfigDialogPane : public ConfigDialogPane
+	StaticPaToolWin *pStaticPaTool;
+	class GuiderConfigDialogPane : public ConfigDialogPane
     {
         Guider *m_pGuider;
         wxCheckBox *m_pScaleImage;
@@ -192,8 +194,8 @@ protected:
     Guider(wxWindow *parent, int xSize, int ySize);
     virtual ~Guider(void);
 
-    bool PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC);
-    void SetState(GUIDER_STATE newState);
+	bool PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC);
+	void SetState(GUIDER_STATE newState);
     void UpdateCurrentDistance(double distance);
 
     void ToggleBookmark(const wxRealPoint& pt);
@@ -228,9 +230,9 @@ public:
     void GetOverlaySlitCoords(wxPoint *center, wxSize *size, int *angle);
     void SetOverlaySlitCoords(const wxPoint& center, const wxSize& size, int angle);
     void SetDefectMapPreview(const DefectMap *preview);
-    void SetPolarAlignCircle(const PHD_Point& center, double radius);
-    void SetPolarAlignCircleCorrection(double val);
-    double GetPolarAlignCircleCorrection(void) const;
+	void SetPolarAlignCircle(const PHD_Point& center, double radius);
+	void SetPolarAlignCircleCorrection(double val);
+	double GetPolarAlignCircleCorrection(void) const;
     bool SaveCurrentImage(const wxString& fileName);
 
     void StartGuiding(void);

--- a/guider.h
+++ b/guider.h
@@ -39,7 +39,6 @@
 
 #ifndef GUIDER_H_INCLUDED
 #define GUIDER_H_INCLUDED
-#include "staticpa_toolwin.h"
 
 enum GUIDER_STATE
 {
@@ -167,7 +166,7 @@ protected:
 
     // Things related to the Advanced Config Dialog
 public:
-    StaticPaToolWin *pStaticPaTool;
+//    StaticPaToolWin *pStaticPaTool;
     class GuiderConfigDialogPane : public ConfigDialogPane
     {
         Guider *m_pGuider;

--- a/guider.h
+++ b/guider.h
@@ -166,7 +166,6 @@ protected:
 
     // Things related to the Advanced Config Dialog
 public:
-//    StaticPaToolWin *pStaticPaTool;
     class GuiderConfigDialogPane : public ConfigDialogPane
     {
         Guider *m_pGuider;

--- a/guider.h
+++ b/guider.h
@@ -46,10 +46,10 @@ enum GUIDER_STATE
     STATE_UNINITIALIZED = 0,
     STATE_SELECTING,
     STATE_SELECTED,
-	STATE_CALIBRATING_PRIMARY,
-	STATE_CALIBRATING_SECONDARY,
-	STATE_CALIBRATED,
-	STATE_GUIDING,
+    STATE_CALIBRATING_PRIMARY,
+    STATE_CALIBRATING_SECONDARY,
+    STATE_CALIBRATED,
+    STATE_GUIDING,
     STATE_STOP, // This is a pseudo state
 };
 
@@ -167,8 +167,8 @@ protected:
 
     // Things related to the Advanced Config Dialog
 public:
-	StaticPaToolWin *pStaticPaTool;
-	class GuiderConfigDialogPane : public ConfigDialogPane
+    StaticPaToolWin *pStaticPaTool;
+    class GuiderConfigDialogPane : public ConfigDialogPane
     {
         Guider *m_pGuider;
         wxCheckBox *m_pScaleImage;
@@ -194,8 +194,8 @@ protected:
     Guider(wxWindow *parent, int xSize, int ySize);
     virtual ~Guider(void);
 
-	bool PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC);
-	void SetState(GUIDER_STATE newState);
+    bool PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC);
+    void SetState(GUIDER_STATE newState);
     void UpdateCurrentDistance(double distance);
 
     void ToggleBookmark(const wxRealPoint& pt);
@@ -230,9 +230,9 @@ public:
     void GetOverlaySlitCoords(wxPoint *center, wxSize *size, int *angle);
     void SetOverlaySlitCoords(const wxPoint& center, const wxSize& size, int angle);
     void SetDefectMapPreview(const DefectMap *preview);
-	void SetPolarAlignCircle(const PHD_Point& center, double radius);
-	void SetPolarAlignCircleCorrection(double val);
-	double GetPolarAlignCircleCorrection(void) const;
+    void SetPolarAlignCircle(const PHD_Point& center, double radius);
+    void SetPolarAlignCircleCorrection(double val);
+    double GetPolarAlignCircleCorrection(void) const;
     bool SaveCurrentImage(const wxString& fileName);
 
     void StartGuiding(void);

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -1058,7 +1058,6 @@ void MyFrame::UpdateButtonsStatus(void)
         wxPostEvent(pStaticPaTool, event);
     }
 
-
     if (pCometTool)
         CometTool::UpdateCometToolControls(false);
 

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -86,6 +86,7 @@ BEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(EEGG_STICKY_LOCK, MyFrame::OnEEGG)
     EVT_MENU(EEGG_FLIPRACAL, MyFrame::OnEEGG)
     EVT_MENU(MENU_DRIFTTOOL, MyFrame::OnDriftTool)
+    EVT_MENU(MENU_STATICPATOOL, MyFrame::OnStaticPaTool)
     EVT_MENU(MENU_COMETTOOL, MyFrame::OnCometTool)
     EVT_MENU(MENU_GUIDING_ASSISTANT, MyFrame::OnGuidingAssistant)
     EVT_MENU(MENU_HELP_UPGRADE, MyFrame::OnUpgrade)
@@ -344,6 +345,7 @@ MyFrame::MyFrame(int instanceNumber, wxLocale *locale)
     pGearDialog = new GearDialog(this);
 
     pDriftTool = nullptr;
+    pStaticPaTool = nullptr;
     pManualGuide = nullptr;
     pStarCrossDlg = nullptr;
     pNudgeLock = nullptr;
@@ -439,6 +441,8 @@ MyFrame::~MyFrame()
 
     if (pDriftTool)
         pDriftTool->Destroy();
+    if (pStaticPaTool)
+        pStaticPaTool->Destroy();
 
     if (pRefineDefMap)
         pRefineDefMap->Destroy();
@@ -494,6 +498,7 @@ void MyFrame::SetupMenuBar(void)
     tools_menu->Append(MENU_STARCROSS_TEST, _("Star-Cross Test"), _("Run a star-cross test for mount diagnostics"));
     tools_menu->Append(MENU_GUIDING_ASSISTANT, _("&Guiding Assistant"), _("Run the Guiding Assistant"));
     tools_menu->Append(MENU_DRIFTTOOL, _("&Drift Align"), _("Run the Drift Alignment tool"));
+    tools_menu->Append(MENU_STATICPATOOL, _("&Static Polar Align"), _("Run the Static Polar Alignment tool"));
     tools_menu->AppendSeparator();
     tools_menu->AppendCheckItem(MENU_SERVER,_("Enable Server"),_("Enable PHD2 server capability"));
     tools_menu->AppendCheckItem(EEGG_STICKY_LOCK,_("Sticky Lock Position"),_("Keep the same lock position when guiding starts"));
@@ -1045,6 +1050,14 @@ void MyFrame::UpdateButtonsStatus(void)
         event.SetEventObject(this);
         wxPostEvent(pDriftTool, event);
     }
+    if (pStaticPaTool)
+    {
+        // let the static PA tool update its buttons too
+        wxCommandEvent event(APPSTATE_NOTIFY_EVENT, GetId());
+        event.SetEventObject(this);
+        wxPostEvent(pStaticPaTool, event);
+    }
+
 
     if (pCometTool)
         CometTool::UpdateCometToolControls(false);

--- a/myframe.h
+++ b/myframe.h
@@ -229,9 +229,9 @@ public:
     GearDialog *pGearDialog;
     ProfileWindow *pProfile;
     TargetWindow *pTarget;
-	wxWindow *pDriftTool;
-	wxWindow *pStaticPaTool;
-	wxWindow *pManualGuide;
+    wxWindow *pDriftTool;
+    wxWindow *pStaticPaTool;
+    wxWindow *pManualGuide;
     wxDialog * pStarCrossDlg;
     wxWindow *pNudgeLock;
     wxWindow *pCometTool;
@@ -275,9 +275,9 @@ public:
     void OnTestGuide(wxCommandEvent& evt);
     void OnStarCrossTest(wxCommandEvent& evt);
     void OnEEGG(wxCommandEvent& evt);
-	void OnDriftTool(wxCommandEvent& evt);
-	void OnStaticPaTool(wxCommandEvent& evt);
-	void OnCometTool(wxCommandEvent& evt);
+    void OnDriftTool(wxCommandEvent& evt);
+    void OnStaticPaTool(wxCommandEvent& evt);
+    void OnCometTool(wxCommandEvent& evt);
     void OnGuidingAssistant(wxCommandEvent& evt);
     void OnSetupCamera(wxCommandEvent& evt);
     void OnExposureDurationSelected(wxCommandEvent& evt);
@@ -574,7 +574,7 @@ enum {
     MENU_TARGET,
     MENU_AUTOSTAR,
     MENU_DRIFTTOOL,
-	MENU_STATICPATOOL,
+    MENU_STATICPATOOL,
     MENU_COMETTOOL,
     MENU_GUIDING_ASSISTANT,
     MENU_SAVESETTINGS,

--- a/myframe.h
+++ b/myframe.h
@@ -229,8 +229,9 @@ public:
     GearDialog *pGearDialog;
     ProfileWindow *pProfile;
     TargetWindow *pTarget;
-    wxWindow *pDriftTool;
-    wxWindow *pManualGuide;
+	wxWindow *pDriftTool;
+	wxWindow *pStaticPaTool;
+	wxWindow *pManualGuide;
     wxDialog * pStarCrossDlg;
     wxWindow *pNudgeLock;
     wxWindow *pCometTool;
@@ -274,8 +275,9 @@ public:
     void OnTestGuide(wxCommandEvent& evt);
     void OnStarCrossTest(wxCommandEvent& evt);
     void OnEEGG(wxCommandEvent& evt);
-    void OnDriftTool(wxCommandEvent& evt);
-    void OnCometTool(wxCommandEvent& evt);
+	void OnDriftTool(wxCommandEvent& evt);
+	void OnStaticPaTool(wxCommandEvent& evt);
+	void OnCometTool(wxCommandEvent& evt);
     void OnGuidingAssistant(wxCommandEvent& evt);
     void OnSetupCamera(wxCommandEvent& evt);
     void OnExposureDurationSelected(wxCommandEvent& evt);
@@ -572,6 +574,7 @@ enum {
     MENU_TARGET,
     MENU_AUTOSTAR,
     MENU_DRIFTTOOL,
+	MENU_STATICPATOOL,
     MENU_COMETTOOL,
     MENU_GUIDING_ASSISTANT,
     MENU_SAVESETTINGS,

--- a/staticpa_tool.h
+++ b/staticpa_tool.h
@@ -36,9 +36,9 @@
 
 class StaticPaTool
 {
-	StaticPaTool(); // not implemented
+    StaticPaTool(); // not implemented
 public:
-	static wxWindow *CreateStaticPaToolWindow();
+    static wxWindow *CreateStaticPaToolWindow();
 };
 
 #endif

--- a/staticpa_tool.h
+++ b/staticpa_tool.h
@@ -1,0 +1,44 @@
+/*
+ *  staticpa_tool.h
+ *  PHD Guiding
+ *
+ *  Created by Ken Self
+ *  Copyright (c) 2017 Ken Self
+ *  All rights reserved.
+ *
+ *  This source code is distributed under the following "BSD" license
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *    Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *    Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef STATICPA_TOOL_H
+#define STATICPA_TOOL_H
+
+class StaticPaTool
+{
+	StaticPaTool(); // not implemented
+public:
+	static wxWindow *CreateStaticPaToolWindow();
+};
+
+#endif

--- a/staticpa_tool.h
+++ b/staticpa_tool.h
@@ -14,7 +14,7 @@
  *    Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *    Neither the name of openphdguiding.org nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
@@ -34,11 +34,17 @@
 #ifndef STATICPA_TOOL_H
 #define STATICPA_TOOL_H
 
+struct StaticPaToolWin;
+
 class StaticPaTool
 {
     StaticPaTool(); // not implemented
 public:
     static wxWindow *CreateStaticPaToolWindow();
+    static bool IsAligning();
+    static bool RotateMount();
+    static void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
+
 };
 
 #endif

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -41,16 +41,20 @@
 #include <wx/textwrapper.h>
 
 static const std::string  SthStarName[] = {
-"sigma Oct", "HD99828", "HD125371", "HD90105",
-"BQ Oct", "HD99685", "TYC9518-405-1"
+"A: sigma Oct", "B: HD99828", "C: HD125371", "D: HD90105",
+"E: BQ Oct", "F: HD99685", "G: TYC9518-405-1", "H: unnamed"
 };
-static const double SthStarRa[] = { 320.66, 164.22, 248.88, 122.36, 239.62, 130.32, 102.04 };
-static const double SthStarDec[] = { -88.89, -89.33, -89.38, -89.52, -89.83, -89.85, -89.88 };
+static const double SthStarRa[] = { 320.66, 164.22, 248.88, 122.36, 239.62, 130.32, 102.04, 136.63 };
+static const double SthStarDec[] = { -88.89, -89.33, -89.38, -89.52, -89.83, -89.85, -89.88, -89.42 };
+static const double SthStarMag[] = { 4.3, 7.5, 7.8,  7.2, 6.8, 7.8, 8.75, 8.0 };
+static const int SthStarCount = 8;
 static const std::string NthStarName[] = {
-	"Polaris", "HD1687", "TYC4629-37-1", "TYC4661-2-1"
+	"A: Polaris", "B: HD1687", "C: TYC4629-37-1", "D: TYC4661-2-1", "E: unnamed", "F: unnamed"
 };
-static const double NthStarRa[] = { 43.12, 12.14, 85.51, 297.95 };
-static const double NthStarDec[] = { 89.34, 89.54, 89.65, 89.83 };
+static const double NthStarRa[] = { 43.12, 12.14, 85.51, 297.95, 86.11, 358.33 };
+static const double NthStarDec[] = { 89.34, 89.54, 89.65, 89.83, 89.43, 89.54 };
+static const double NthStarMag[] = { 1.95, 8.1, 9.15, 9.65, 9.25, 9.35 };
+static const int NthStarCount = 6;
 
 //==================================
 BEGIN_EVENT_TABLE(StaticPaToolWin, wxFrame)
@@ -59,7 +63,10 @@ EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
 EVT_BUTTON(ID_ADJUST, StaticPaToolWin::OnAdjust)
 EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
 EVT_CHOICE(ID_ALIGNSTAR, StaticPaToolWin::OnAlignStar)
-//EVT_COMMAND(wxID_ANY, APPSTATE_NOTIFY_EVENT, StaticPaToolWin::OnAppStateNotify)
+EVT_CHOICE(ID_HEMI, StaticPaToolWin::OnHemi)
+EVT_CHECKBOX(ID_MANUAL, StaticPaToolWin::OnManual)
+EVT_BUTTON(ID_STAR2, StaticPaToolWin::OnStar2)
+EVT_BUTTON(ID_STAR3, StaticPaToolWin::OnStar3)
 EVT_CLOSE(StaticPaToolWin::OnClose)
 END_EVENT_TABLE()
 
@@ -70,20 +77,38 @@ m_slewing(false), m_devpx(8)
 {
 	pFrame->pGuider->pStaticPaTool = this;
 	m_numPos = 0;
-	
-	SetBackgroundColour(wxColor(0xcccccc));
 
-	SetSizeHints(wxDefaultSize, wxDefaultSize);
-
+/*	SthStars = {
+		Star("A: sigma Oct", 320.66, -88.89, 4.3),
+		Star("B: HD99828", 164.22, -89.33, 7.5),
+		Star("C: HD125371", 248.88, -89.38, 7.8),
+		Star("D: HD90105", 122.36, -89.52, 7.2),
+		Star("E: BQ Oct", 239.62, -89.83, 6.8),
+		Star("F: HD99685", 130.32, -89.85, 7.8),
+		Star("G: TYC9518-405-1", 102.04, -89.88, 8.75),
+		Star("H: unnamed", 136.63, -89.42, 8.0)
+	};
+	NthStars = {
+		Star("A: Polaris", 43.12, 89.34, 1.95),
+		Star("B: HD1687", 12.14, 89.54, 8.1),
+		Star("C: TYC4629-37-1", 85.51, 89.65, 9.15),
+		Star("D: TYC4661-2-1", 297.95, 89.83, 9.65),
+		Star("E: unnamed", 86.11, 89.43, 9.25),
+		Star("F: unnamed", 358.33, 89.54, 9.35)
+	};
+*/
 	// get site lat/long from scope
-	double lat, lon;
-	m_siteLatLong.Invalidate();
-	if (pPointingSource && !pPointingSource->GetSiteLatLong(&lat, &lon))
+	s_hemi = 1;
+	if (pPointingSource)
 	{
-		m_siteLatLong.SetXY(lon, lat);
+		double lat, lon;
+		if (!pPointingSource->GetSiteLatLong(&lat, &lon))
+		{
+			s_hemi = lat >= 0 ? 1 : -1;
+		}
 	}
+	poleStars = s_hemi >= 0 ? &NthStars : &SthStars;
 	m_pxScale = pFrame->GetCameraPixelScale();
-
 	wxCommandEvent dummy;
 	if (!pFrame->CaptureActive)
 	{
@@ -91,6 +116,12 @@ m_slewing(false), m_devpx(8)
 		SetStatusText(_("Start Looping..."));
 		pFrame->OnLoopExposure(dummy);
 	}
+	// Drop down list box for alignment star
+//	m_nstar = (s_hemi < 0) ? SthStarCount : NthStarCount;
+	m_nstar = poleStars->size();
+
+	SetBackgroundColour(wxColor(0xcccccc));
+	SetSizeHints(wxDefaultSize, wxDefaultSize);
 
 	// a vertical sizer holding everything
 	wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
@@ -104,6 +135,15 @@ m_slewing(false), m_devpx(8)
 #endif
 	m_instructions->Wrap(-1);
 	instrSizer->Add(m_instructions, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+	// Put the graph and its legend on the left side
+	//	wxBoxSizer* panelGraphVSizer = new wxBoxSizer(wxVERTICAL);
+	//	panelHSizer->Add(panelGraphVSizer, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+	// Use a bitmap button so we don't have to fool with Paint events
+	wxBitmap theGraph = CreateStarTemplate();
+	wxBitmapButton* graphButton = new wxBitmapButton(this, wxID_ANY, theGraph, wxDefaultPosition, wxSize(320, 240), wxBU_AUTODRAW | wxBU_EXACTFIT);
+	instrSizer->Add(graphButton, 0, wxALIGN_CENTER_HORIZONTAL | wxALL | wxFIXED_MINSIZE, 5);
+	graphButton->SetBitmapDisabled(theGraph);
+	graphButton->Enable(false);
 
 	topSizer->Add(instrSizer);
 
@@ -117,62 +157,62 @@ m_slewing(false), m_devpx(8)
 
 	wxStaticText *txt;
 
-// Alignment star specification
-	txt = new wxStaticText(this, wxID_ANY, _("Alignment Star"));
+	txt = new wxStaticText(this, wxID_ANY, _("px Scale"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Right Ascen (" DEGREES_SYMBOL ")"), wxDefaultPosition, wxDefaultSize, 0);
+	txt = new wxStaticText(this, wxID_ANY, _("Camera Rot"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 1), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Hemisphere"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	// Alignment star specification
+	txt = new wxStaticText(this, wxID_ANY, _("Alignment Star"));
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 3), wxGBSpan(1, 1), wxALL, 5);
+
+/*	txt = new wxStaticText(this, wxID_ANY, _("Right Ascen (" DEGREES_SYMBOL ")"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(0, 1), wxGBSpan(1, 1), wxALL, 5);
 
 	txt = new wxStaticText(this, wxID_ANY, _("Declination (" DEGREES_SYMBOL ")"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(0, 2), wxGBSpan(1, 1), wxALL, 5);
-
-	// Drop down list box for alignment star
-	int nstar = (lat < 0) ? 7 : 4;
-	m_nstar = nstar;
-	wxArrayString choices;
-	std::string starname;
-	for (int is = 0; is < nstar; is++) {
-		starname = (lat < 0) ? SthStarName[is] : NthStarName[is];
-		choices.Add(_(starname));
-	}
-	alignStarChoice = new wxChoice(this, ID_ALIGNSTAR, wxDefaultPosition, wxDefaultSize, choices);
-	alignStarChoice->SetToolTip(_("Select the star used for checking alignment."));
-	gbSizer->Add(alignStarChoice, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALL, 5);
-
-	m_raCurrent = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+*/
+/*	m_raCurrent = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_raCurrent, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
 	m_decCurrent = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_decCurrent, wxGBPosition(1, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
-
-	txt = new wxStaticText(this, wxID_ANY, _("Site"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALL, 5);
-
-	txt = new wxStaticText(this, wxID_ANY, _("Lat"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(2, 1), wxGBSpan(1, 1), wxALL, 5);
-
-	txt = new wxStaticText(this, wxID_ANY, _("Lon"), wxDefaultPosition, wxDefaultSize, 0);
+*/
+/*	txt = new wxStaticText(this, wxID_ANY, _("Lon"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(2, 2), wxGBSpan(1, 1), wxALL, 5);
+*/
+	m_camScale = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_camScale, wxGBPosition(1, 0), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+//	m_siteLat = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+//	gbSizer->Add(m_siteLat, wxGBPosition(3, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Camera Rot"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(2, 3), wxGBSpan(1, 1), wxALL, 5);
-
-	m_siteLat = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_siteLat, wxGBPosition(3, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
-
-	m_siteLon = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_siteLon, wxGBPosition(3, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+//	m_siteLon = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+//	gbSizer->Add(m_siteLon, wxGBPosition(3, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
 	m_camRot = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_camRot, wxGBPosition(3, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+	gbSizer->Add(m_camRot, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	wxArrayString hemi;
+	hemi.Add(_("North"));
+	hemi.Add(_("South"));
+	hemiChoice = new wxChoice(this, ID_HEMI, wxDefaultPosition, wxDefaultSize, hemi);
+	hemiChoice->SetToolTip(_("Select your hemisphere"));
+	gbSizer->Add(hemiChoice, wxGBPosition(1, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	alignStarChoice = new wxChoice(this, ID_ALIGNSTAR, wxDefaultPosition, wxDefaultSize);
+	alignStarChoice->SetToolTip(_("Select the star used for checking alignment."));
+	gbSizer->Add(alignStarChoice, wxGBPosition(1, 3), wxGBSpan(1, 1), wxALL, 5);
 
 	txt = new wxStaticText(this, wxID_ANY, _("X px"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
@@ -181,6 +221,11 @@ m_slewing(false), m_devpx(8)
 	txt = new wxStaticText(this, wxID_ANY, _("Y px"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(4, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	m_manual = new wxCheckBox(this, ID_MANUAL, _("Manual Slew"));
+	gbSizer->Add(m_manual, wxGBPosition(4, 3), wxGBSpan(1, 1), wxALL, 5);
+	m_manual->SetValue(false);
+	m_manual->SetToolTip(_("Manually slew the mount to three alignment positions"));
 
 	txt = new wxStaticText(this, wxID_ANY, _("Pt #1"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
@@ -192,6 +237,9 @@ m_slewing(false), m_devpx(8)
 	m_calPt[0][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_calPt[0][1], wxGBPosition(5, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
+	m_star1 = new wxButton(this, ID_ROTATE, _("Rotate"), wxDefaultPosition, wxDefaultSize, 0);
+	gbSizer->Add(m_star1, wxGBPosition(5, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
 	txt = new wxStaticText(this, wxID_ANY, _("Pt #2"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(6, 0), wxGBSpan(1, 1), wxALL, 5);
@@ -201,6 +249,9 @@ m_slewing(false), m_devpx(8)
 
 	m_calPt[1][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_calPt[1][1], wxGBPosition(6, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_star2 = new wxButton(this, ID_STAR2, _("Get second position"), wxDefaultPosition, wxDefaultSize, 0);
+	gbSizer->Add(m_star2, wxGBPosition(6, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
 	txt = new wxStaticText(this, wxID_ANY, _("Pt #3"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
@@ -212,6 +263,9 @@ m_slewing(false), m_devpx(8)
 	m_calPt[2][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_calPt[2][1], wxGBPosition(7, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
+	m_star3 = new wxButton(this, ID_STAR3, _("Get third position"), wxDefaultPosition, wxDefaultSize, 0);
+	gbSizer->Add(m_star3, wxGBPosition(7, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
 	txt = new wxStaticText(this, wxID_ANY, _("Centre"), wxDefaultPosition, wxDefaultSize, 0);
 	txt->Wrap(-1);
 	gbSizer->Add(txt, wxGBPosition(8, 0), wxGBSpan(1, 1), wxALL, 5);
@@ -222,6 +276,9 @@ m_slewing(false), m_devpx(8)
 	m_calPt[3][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	gbSizer->Add(m_calPt[3][1], wxGBPosition(8, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
+	m_adjust = new wxButton(this, ID_ADJUST, _("Calculate"), wxDefaultPosition, wxDefaultSize, 0);
+	gbSizer->Add(m_adjust, wxGBPosition(8, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
 	// add grid bag sizer to static sizer
 	sbSizer->Add(gbSizer, 1, wxALIGN_CENTER, 5);
 
@@ -231,7 +288,7 @@ m_slewing(false), m_devpx(8)
 	// add some padding below the static sizer
 	topSizer->Add(0, 3, 0, wxEXPAND, 3);
 
-	m_notesLabel = new wxStaticText(this, wxID_ANY, _("Altitude adjustment notes"), wxDefaultPosition, wxDefaultSize, 0);
+	m_notesLabel = new wxStaticText(this, wxID_ANY, _("Adjustment notes"), wxDefaultPosition, wxDefaultSize, 0);
 	m_notesLabel->Wrap(-1);
 	topSizer->Add(m_notesLabel, 0, wxEXPAND | wxTOP | wxLEFT, 8);
 
@@ -246,23 +303,14 @@ m_slewing(false), m_devpx(8)
 	// proportional pad on left of Rotate button
 	hSizer->Add(0, 0, 2, wxEXPAND, 5);
 
-	m_rotate = new wxButton(this, ID_ROTATE, _("Rotate"), wxDefaultPosition, wxDefaultSize, 0);
-	hSizer->Add(m_rotate, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-
 	// proportional pad on right of Rotate button
 	hSizer->Add(0, 0, 1, wxEXPAND, 5);
-
-	m_adjust = new wxButton(this, ID_ADJUST, _("Adjust"), wxDefaultPosition, wxDefaultSize, 0);
-	hSizer->Add(m_adjust, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 	// proportional pad on right of Align button
 	hSizer->Add(0, 0, 2, wxEXPAND, 5);
 
 	m_close = new wxButton(this, ID_CLOSE, _("Close"), wxDefaultPosition, wxDefaultSize, 0);
 	hSizer->Add(m_close, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-
-	//m_phaseBtn = new wxButton(this, ID_PHASE, wxT("???"), wxDefaultPosition, wxDefaultSize, 0);
-	//hSizer->Add(m_phaseBtn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
 	// add button sizer to top level sizer
 	topSizer->Add(hSizer, 1, wxEXPAND | wxALL, 5);
@@ -283,18 +331,25 @@ m_slewing(false), m_devpx(8)
 		"Choose an Alignment Star from the list.\n"
 		"Select it as the guide star on the display.\n"
 		"Press Rotate to calibrate the RA Axis.\n"
-		"Wait for all three calibration points to be measured.\n"
-		"Press Adjust to display the adjustments needed.\n"
-		"Adjust your mount's altitude and azimuth as displayed."
+		"Wait for both calibration points to be measured.\n"
+		"Adjust your mount's altitude and azimuth as displayed.\n"
+		"Orange=Altitude; Green=Azimuth\n"
 		));
 
 	// can mount slew?
+	bauto = true;
 	bool m_can_slew = pPointingSource && pPointingSource->CanSlew();
+	if (!m_can_slew){
+		bauto = false;
+		m_manual->Hide();
+	}
+	SetButtons();
+
 	alignStarChoice->Select(pConfig->Profile.GetInt("/StaticPaTool/AlignStar", 4) - 1);
 	UpdateAlignStar();
 
-	m_siteLat->SetValue(wxString::Format("%+.3f", lat));
-	m_siteLon->SetValue(wxString::Format("%+.3f", lon));
+//	m_siteLat->SetValue(wxString::Format("%+.3f", lat));
+//	m_siteLon->SetValue(wxString::Format("%+.3f", lon));
 
 	double xangle=0.0, yangle;
 	if (pMount && pMount->IsConnected() && pMount->IsCalibrated())
@@ -305,12 +360,7 @@ m_slewing(false), m_devpx(8)
 	m_camRot->SetValue(wxString::Format("%+.3f", xangle));
 	m_dCamRot = xangle;
 
-	m_timer = NULL;
-
-	//m_phase = PHASE_ADJUST_AZ;
 	m_mode = MODE_IDLE;
-	//m_location_prompt_done = false;
-	//UpdatePhaseState();
 	UpdateModeState();
 }
 
@@ -319,11 +369,6 @@ StaticPaToolWin::~StaticPaToolWin()
 	pFrame->pGuider->pStaticPaTool = NULL;
 	pFrame->pStaticPaTool = NULL;
 }
-/*
-void StaticPaToolWin::EnableSlew(bool enable)
-{
-}
-*/
 void StaticPaToolWin::UpdateModeState()
 {
 	wxCommandEvent dummy;
@@ -331,17 +376,14 @@ void StaticPaToolWin::UpdateModeState()
 
 repeat:
 
-	if (m_mode == MODE_ROTATE)
+		if (m_mode == MODE_ROTATE)
 	{
 		//m_rotate->Enable(false);
-		m_rotate->Enable(true);
-		m_adjust->Enable(true);
+//		m_rotate->Enable(true);
+		m_adjust->Enable(false);
 //		EnableSlew(false);
 
-		// restore subframes setting
-		//pCamera->UseSubframes = m_save_use_subframes;
-
-		if (!m_rotating)
+//		if (!m_rotating)
 		{
 			if (!pCamera->Connected ||
 				!pMount || !pMount->IsConnected())
@@ -365,41 +407,13 @@ repeat:
 				pFrame->OnLoopExposure(dummy);
 				return;
 			}
-			/*
-			switch (pFrame->pGuider->GetState())
-			{
-			case STATE_UNINITIALIZED:
-			case STATE_CALIBRATED:
-			case STATE_SELECTING:
-				if (!pFrame->pGuider->IsLocked())
-				{
-					SetStatusText(_("Auto-selecting a star"));
-					pFrame->OnAutoStar(dummy);
-				}
-				return;
-			case STATE_CALIBRATING_PRIMARY:
-			case STATE_CALIBRATING_SECONDARY:
-				if (!pMount->IsCalibrated())
-					SetStatusText(_("Waiting for calibration to complete..."));
-				return;
-			case STATE_SELECTED:
-			case STATE_GUIDING:
-				SetStatusText(_("Start Looping..."));
-				pFrame->OnLoopExposure(dummy);
-				return;
-				m_rotating = true;
-				return;
-			case STATE_STOP:
-				return;
-			}
-			*/
 		}
 	}
 	else if (m_mode == MODE_ADJUST)
 	{
-		m_rotate->Enable(true);
-		m_adjust->Enable(false);
-		m_rotating = false;
+//		m_rotate->Enable(true);
+		m_adjust->Enable(true);
+//		m_rotating = false;
 //		EnableSlew(m_can_slew);
 		SetStatusText(_("Adjust altitude and azimuth, click Rotate when done") );
 
@@ -418,6 +432,9 @@ repeat:
 	}
 	else // MODE_IDLE
 	{
+//		m_rotate->Enable(true);
+		m_adjust->Enable(false);
+//		m_rotating = false;
 	}
 }
 void StaticPaToolWin::UpdateAlignStar()
@@ -425,76 +442,82 @@ void StaticPaToolWin::UpdateAlignStar()
 	int i_alignStar = alignStarChoice->GetSelection();
 	pConfig->Profile.SetInt("/StaticPaTool/AlignStar", alignStarChoice->GetSelection() + 1);
 
-	double ra_deg = m_siteLatLong.Y < 0 ? SthStarRa[i_alignStar] : NthStarRa[i_alignStar];
-	double dec_deg = m_siteLatLong.Y < 0 ? SthStarDec[i_alignStar] : NthStarDec[i_alignStar];
+//	double ra_deg = s_hemi < 0 ? SthStarRa[i_alignStar] : NthStarRa[i_alignStar];
+//	double dec_deg = s_hemi < 0 ? SthStarDec[i_alignStar] : NthStarDec[i_alignStar];
 
 	m_alignStar = i_alignStar;
 	m_alignStar = i_alignStar;
 
-	m_raCurrent->SetValue(wxString::Format("%+.2f", ra_deg));
-	m_decCurrent->SetValue(wxString::Format("%+.2f", dec_deg));
+//	m_raCurrent->SetValue(wxString::Format("%+.2f", ra_deg));
+//	m_decCurrent->SetValue(wxString::Format("%+.2f", dec_deg));
 
 }
 
-//void StaticPaToolWin::OnSlew(wxCommandEvent& evt)
-//{
-//	double cur_ra, cur_dec, cur_st;
-//	if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
-//	{
-//		Debug.AddLine("Rotate tool: slew failed to get scope coordinates");
-//		return;
-//	}
-//
-//	double slew_ra = 0; // cur_st + (raSlew * 24.0 / 360.0);
-//	if (slew_ra >= 24.0)
-//		slew_ra -= 24.0;
-//	else if (slew_ra < 0.0)
-//		slew_ra += 24.0;
-//
-//	//Debug.AddLine(wxString::Format("Rotate tool slew from ra %.2f, dec %.1f to ra %.2f, dec %.1f",
-//	//	cur_ra, cur_dec, slew_ra, decSlew));
-//
-//	if (pPointingSource->CanSlewAsync())
-//	{
-//		struct SlewInBg : public RunInBg
-//		{
-//			double ra, dec;
-//			SlewInBg(wxWindow *parent, double ra_, double dec_)
-//				: RunInBg(parent, _("Slew"), _("Slewing...")), ra(ra_), dec(dec_)
-//			{
-//				SetPopupDelay(100);
-//			}
-//			bool Entry()
-//			{
-//				bool err = pPointingSource->SlewToCoordinatesAsync(ra, dec);
-//				if (err)
-//				{
-//					SetErrorMsg(_("Slew failed!"));
-//					return true;
-//				}
-//				while (pPointingSource->Slewing())
-//				{
-//					wxMilliSleep(500);
-//					if (IsCanceled())
-//					{
-//						pPointingSource->AbortSlew();
-//						SetErrorMsg(_("Slew was canceled"));
-//						break;
-//					}
-//				}
-//				return false;
-//			}
-//		};
-//	}
-//	else
-//	{
-//		wxBusyCursor busy;
-//	}
-//}
+void StaticPaToolWin::OnHemi(wxCommandEvent& evt)
+{
+	int i_hemi = hemiChoice->GetSelection() <= 0 ? 1 : -1;
+	if (i_hemi != s_hemi)
+	{
+		m_alignStar = 0;
+		s_hemi = i_hemi;
+//		m_nstar = s_hemi >= 0 ? NthStarCount : SthStarCount;
+		m_nstar = poleStars->size();
+	}
+	SetButtons();
+}
+void StaticPaToolWin::OnManual(wxCommandEvent& evt)
+{
+	bauto = !m_manual->IsChecked();
+	SetButtons();
+}
+void StaticPaToolWin::SetButtons()
+{
+	m_manual->SetValue(!bauto);
+
+	m_star1->SetLabel(_("Rotate"));
+	m_star2->Hide();
+	m_star3->Hide();
+	m_adjust->Hide();
+	hemiChoice->Enable(false);
+	hemiChoice->SetSelection(s_hemi > 0 ? 0 : 1);
+	if (!bauto)
+	{
+		m_star1->SetLabel(_("Get first position"));
+		m_star2->Show();
+		m_star3->Show();
+		m_adjust->Show();
+		hemiChoice->Enable(true);
+	}
+//	wxArrayString choices;
+	alignStarChoice->Clear();
+	std::string starname;
+	for (int is = 0; is < m_nstar; is++) {
+//		starname = (s_hemi < 0) ? SthStarName[is] : NthStarName[is];
+//		alignStarChoice->AppendString(starname);
+		alignStarChoice->AppendString(poleStars->at(is).name);
+		//		choices.Add(_(starname));
+	}
+	m_camScale->SetValue(wxString::Format("%+.3f", m_pxScale));
+	m_camRot->SetValue(wxString::Format("%+.3f", m_dCamRot));
+	Layout();
+}
+
+void StaticPaToolWin::OnStar2(wxCommandEvent& evt)
+{
+	m_numPos = 2;
+	aligning = true;
+	//	bauto = !m_manual->IsChecked();
+}
+
+void StaticPaToolWin::OnStar3(wxCommandEvent& evt)
+{
+	m_numPos = 3;
+	aligning = true;
+	//	bauto = !m_manual->IsChecked();
+}
 
 void StaticPaToolWin::OnRotate(wxCommandEvent& evt)
 {
-//	m_mode = MODE_ROTATE;
 	UpdateModeState();
 	aligning = false;
 	m_numPos = 1;
@@ -510,21 +533,7 @@ void StaticPaToolWin::OnRotate(wxCommandEvent& evt)
 		return;
 	}
 	aligning = true;
-	/*
-	double testCal[][2] = { { 293.11, 151.18 }, { 274.19, 189.42 }, { 288.95, 256.06 } };
-	for (int i = 0; i < 3; i++)
-	{
-			m_Pospx[i].X = testCal[i][0];
-			m_Pospx[i].Y = testCal[i][1];
-			m_calPt[i][0]->SetValue(wxString::Format("%+.f", m_Pospx[i].X));
-			m_calPt[i][1]->SetValue(wxString::Format("%+.f", m_Pospx[i].Y));
-	}
-	m_numPos = 3;
-	CalcRotationCentre();
-	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
-	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
-	aligning = false;
-	*/
+
 	m_mode = MODE_ROTATE;
 	UpdateModeState();
 }
@@ -536,7 +545,6 @@ void StaticPaToolWin::OnAdjust(wxCommandEvent& evt)
 	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
 	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
 
-	m_mode = MODE_ROTATE;
 	m_mode = MODE_ADJUST;
 	UpdateModeState();
 }
@@ -545,11 +553,6 @@ void StaticPaToolWin::OnAlignStar(wxCommandEvent& evt)
 {
 	UpdateAlignStar();
 }
-
-//void StaticPaToolWin::OnAppStateNotify(wxCommandEvent& evt)
-//{
-//	UpdateModeState();
-//}
 
 void StaticPaToolWin::OnCloseBtn(wxCommandEvent& evt)
 {
@@ -570,53 +573,74 @@ void StaticPaToolWin::OnClose(wxCloseEvent& evt)
 void StaticPaToolWin::CalcRotationCentre(void)
 {
 	double x1, y1, x2, y2, x3, y3;
-	double a, b, c, e, f, g, i, j, k;
-	double m11, m12, m13, m14;
 	double cx, cy, cr;
 	x1 = m_Pospx[0].X;
 	y1 = m_Pospx[0].Y;
 	x2 = m_Pospx[1].X;
 	y2 = m_Pospx[1].Y;
-	x3 = m_Pospx[2].X;
-	y3 = m_Pospx[2].Y;
-	a = x1 * x1 + y1 * y1;
-	b = x1;
-	c = y1;
-	e = x2 * x2 + y2 * y2;
-	f = x2;
-	g = y2;
-	i = x3 * x3 + y3 * y3;
-	j = x3;
-	k = y3;
-	m11 = b * g + c * j + f * k - g * j - c * f - b * k;
-	m12 = a * g + c * i + e * k - g * i - c * e - a * k;
-	m13 = a * f + b * i + e * j - f * i - b * e - a * j;
-	m14 = a * f * k + b * g * i + c * e * j - c * f * i - b * e * k - a * g * j;
-	cx = (1. / 2.) * m12 / m11;
-	cy = (-1. / 2.) * m13 / m11;
-	cr = sqrt(cx * cx + cy *cy + m14 / m11);
-
-	// |A| = aei + bfg + cdh -ceg -bdi -afh
-	// a b c
-	// d e f
-	// g h i
-	// a= x1^2+y1^2; b=x1; c=y1; d=1
-	// e= x2^2+y2^2; f=x2; g=y2; h=1
-	// i= x3^2+y3^2; j=x3; k=y3; l=1
-	//
-	// x0 = 1/2.|M12|/|M11|
-	// y0 = -1/2.|M13|/|M11|
-	// r = x0^2 + y0^2 + |M14| / |M11|
-
-	m_CoRpx.X = cx;
-	m_CoRpx.Y = cy;
-	m_Radius = cr;
+	if (!bauto)
+	{
+		SetStatusText(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+		Debug.AddLine(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+		double a, b, c, e, f, g, i, j, k;
+		double m11, m12, m13, m14;
+		x3 = m_Pospx[2].X;
+		y3 = m_Pospx[2].Y;
+		// |A| = aei + bfg + cdh -ceg -bdi -afh
+		// a b c
+		// d e f
+		// g h i
+		// a= x1^2+y1^2; b=x1; c=y1; d=1
+		// e= x2^2+y2^2; f=x2; g=y2; h=1
+		// i= x3^2+y3^2; j=x3; k=y3; l=1
+		//
+		// x0 = 1/2.|M12|/|M11|
+		// y0 = -1/2.|M13|/|M11|
+		// r = x0^2 + y0^2 + |M14| / |M11|
+		//
+		a = x1 * x1 + y1 * y1;
+		b = x1;
+		c = y1;
+		e = x2 * x2 + y2 * y2;
+		f = x2;
+		g = y2;
+		i = x3 * x3 + y3 * y3;
+		j = x3;
+		k = y3;
+		m11 = b * g + c * j + f * k - g * j - c * f - b * k;
+		m12 = a * g + c * i + e * k - g * i - c * e - a * k;
+		m13 = a * f + b * i + e * j - f * i - b * e - a * j;
+		m14 = a * f * k + b * g * i + c * e * j - c * f * i - b * e * k - a * g * j;
+		cx = (1. / 2.) * m12 / m11;
+		cy = (-1. / 2.) * m13 / m11;
+		cr = sqrt(cx * cx + cy *cy + m14 / m11);
+	}
+	else
+	{
+		SetStatusText(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+		Debug.AddLine(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+		// Alternative algorithm based on two poins and angle rotated
+		double theta2;
+//		theta2 = copysign(1.0, -m_siteLatLong.X) * radians(360.0 / 24.0 * (m_ra_rot[1] - m_ra_rot[0])) / 2.0;
+		theta2 = -s_hemi * radians(360.0 / 24.0 * (m_ra_rot[1] - m_ra_rot[0])) / 2.0;
+		double lenchord = sqrt(pow((x1 - x2), 2.0) + pow((y1 - y2), 2.0));
+		cr = lenchord / 2.0 / sin(theta2);
+		double lenbase = cr*cos(theta2);
+		double slopebase = atan2(y1 - y2, x2 - x1) + M_PI / 2.0;
+		cx = (x1 + x2) / 2.0 + lenbase * cos(slopebase);
+		cy = (y1 + y2) / 2.0 - lenbase * sin(slopebase); // subtract for pixels
+	}
+	m_CoRpx.X = cx; // cx;
+	m_CoRpx.Y = cy; // cy;
+	m_Radius = cr; // cr;
+	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
+	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
 
 	usImage *pCurrImg = pFrame->pGuider->CurrentImage();
 	wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
 	double scalefactor = pFrame->pGuider->ScaleFactor();
-	int xpx = pDispImg->GetWidth();
-	int ypx = pDispImg->GetHeight();
+	int xpx = pDispImg->GetWidth() / scalefactor;
+	int ypx = pDispImg->GetHeight() / scalefactor;
 	m_dispSz[0] = xpx;
 	m_dispSz[1] = ypx;
 
@@ -637,15 +661,17 @@ void StaticPaToolWin::CalcRotationCentre(void)
 	PHD_Point starpx, stardeg;
 	for (int is = 0; is < m_nstar; is++)
 	{
-		stardeg = (m_siteLatLong.Y < 0) ? PHD_Point(SthStarRa[is], SthStarDec[is]) : PHD_Point(NthStarRa[is], NthStarDec[is]);
-		starpx = Radec2Px(stardeg );
+//		stardeg = (m_siteLatLong.Y < 0) ? PHD_Point(SthStarRa[is], SthStarDec[is]) : PHD_Point(NthStarRa[is], NthStarDec[is]);
+//		stardeg = (s_hemi < 0) ? PHD_Point(SthStarRa[is], SthStarDec[is]) : PHD_Point(NthStarRa[is], NthStarDec[is]);
+		stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
+		starpx = Radec2Px(stardeg);
 		m_starpx[is][0] = starpx.X;
 		m_starpx[is][1] = starpx.Y;
 		m_starpx[is][2] = sqrt(pow(cx - starpx.X, 2) + pow(cy - starpx.Y, 2));
 	}
-
-	double xs = m_Pospx[2].X;
-	double ys = m_Pospx[2].Y;
+	int idx = bauto ? 1 : 2;
+	double xs = m_Pospx[idx].X;
+	double ys = m_Pospx[idx].Y;
 	double xt = m_starpx[m_alignStar][0];
 	double yt = m_starpx[m_alignStar][1];
 
@@ -680,21 +706,24 @@ PHD_Point StaticPaToolWin::Radec2Px( PHD_Point radec )
 	double r = (90.0 - fabs(radec.Y)) * 3600 / m_pxScale;
 
 // Rotate by calibration angle and HA f object taking into account mount rotation (HA)
-	double ra_hrs, dec_deg, st_hrs;
+	double ra_hrs, dec_deg, ra_deg, st_hrs;
 	pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs);
-
+	ra_deg = ra_hrs * 15.0;
 // Target hour angle - or rather the rotation needed to correct. 
-// FIXME: check if dec-deg should be that of the mount or the target or the hemisphere
-	double t_ha = st_hrs*15.0 + copysign(radec.X, radec.X);
-	double a = t_ha + m_dCamRot + (st_hrs - ra_hrs)*15.0;
+// HA = LST - RA
+// In NH HA decreases clockwise; RA increases clockwise
+// "Up" is HA=0
+// Sensor "up" is 90deg counterclockwise from mount RA plus rotation
+// Star rotation is RAstar - RAmount
+	double a = m_dCamRot - copysign(radec.X - (ra_deg - 90.0), dec_deg);
 
-	PHD_Point px(m_CoRpx.X + r * cos(radians(a)), m_CoRpx.Y + r * sin(radians(a)));
+	PHD_Point px(m_CoRpx.X + r * cos(radians(a)), m_CoRpx.Y - r * sin(radians(a)));
 	return px;
 }
 
 wxWindow *StaticPaTool::CreateStaticPaToolWindow()
 {
-	if (!pCamera)
+	if (!pCamera || !pCamera->Connected)
 	{
 		wxMessageBox(_("Please connect a camera first."));
 		return 0;
@@ -705,13 +734,13 @@ wxWindow *StaticPaTool::CreateStaticPaToolWindow()
 	if (pFrame->GetCameraPixelScale() == 1.0)
 	{
 		bool confirmed = ConfirmDialog::Confirm(_(
-			"The Rotate Align tool is most effective when PHD2 knows your guide\n"
+			"The Static Align tool is most effective when PHD2 knows your guide\n"
 			"scope focal length and camera pixel size.\n"
 			"\n"
 			"Enter your guide scope focal length on the Global tab in the Brain.\n"
 			"Enter your camera pixel size on the Camera tab in the Brain.\n"
 			"\n"
-			"Would you like to run the rotate tool anyway?"),
+			"Would you like to run the tool anyway?"),
 			"/rotate_tool_without_pixscale");
 
 		if (!confirmed)
@@ -737,23 +766,23 @@ void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
 	{
 		dc.DrawCircle(m_Pospx[i].X*scale, m_Pospx[i].Y*scale, 12 * scale);
 	}
-	if (m_numPos < 3)
+	if (m_numPos <= 3)
 	{
 		return;
 	}
 	dc.SetBrush(*wxTRANSPARENT_BRUSH);
-	//wxPenStyle penStyle = m_polarAlignCircleCorrection == 1.0 ? wxPENSTYLE_DOT : wxPENSTYLE_SOLID;
 	wxPenStyle penStyle = wxPENSTYLE_DOT;
 	dc.SetPen(wxPen(wxColor(255, 0, 255), 1, penStyle));
-	//int radius = ROUND(m_polarAlignCircleRadius * m_polarAlignCircleCorrection * m_scaleFactor);
 	dc.DrawCircle(m_CoRpx.X*scale, m_CoRpx.Y*scale, m_Radius*scale);
+
 	// draw the centre of the circle as a red cross
 	dc.SetBrush(*wxTRANSPARENT_BRUSH);
 	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
 	int region = 5;
 	dc.DrawLine((m_CoRpx.X - region)*scale, m_CoRpx.Y*scale, (m_CoRpx.X + region)*scale, m_CoRpx.Y*scale);
 	dc.DrawLine(m_CoRpx.X*scale, (m_CoRpx.Y - region)*scale, m_CoRpx.X*scale, (m_CoRpx.Y + region)*scale);
-	// Show the centre of the display
+
+	// Show the centre of the display wth a grey cross
 	double xsc = m_dispSz[0] / 2;
 	double ysc = m_dispSz[1] / 2;
 	dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
@@ -771,7 +800,7 @@ void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
 		dc.DrawCircle(m_CoRpx.X * scale, m_CoRpx.Y * scale, m_starpx[is][2] * scale);
 		dc.DrawCircle(m_starpx[is][0] * scale, m_starpx[is][1] * scale, region*scale);
 	}
-	// Draw adjustment lines for centring the CoR on the display
+	// Draw adjustment lines for centring the CoR on the display in blue (dec) and red (cone error)
 	double xr = m_CoRpx.X * scale;
 	double yr = m_CoRpx.Y * scale;
 	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
@@ -784,8 +813,12 @@ void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
 	dc.DrawLine(xr, yr, xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
 		yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
 
-	double xs = m_Pospx[2].X * scale;
-	double ys = m_Pospx[2].Y * scale;
+	// Draw adjustment lines for placing the guide star in its correct position relative to the CoR
+	// Green (azimuth) and orange (altitude)
+	int idx;
+	idx = bauto ? 1 : 2;
+	double xs = m_Pospx[idx].X * scale;
+	double ys = m_Pospx[idx].Y * scale;
 	dc.SetPen(wxPen(wxColor(255, 165, 0), 1, wxPENSTYLE_SOLID));
 	dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale);
 	dc.SetPen(wxPen(wxColor(0, 255, 0), 1, wxPENSTYLE_SOLID));
@@ -796,47 +829,46 @@ void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
 		ys + m_AltCorr.Y * scale + m_AzCorr.Y * scale);
 }
 
-bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npos, bool bauto)
+bool StaticPaToolWin::RotateMount() //const PHD_Point& position)
 {
 	// Initially, assume an offset of 5.0 degrees of the camera from the CoR
 	// Calculate how far to move in RA to get a detectable arc
 	// Calculate the tangential ditance of that movement
 	// Mark the starting position then rotate the mount
-	bool bauto = true;
+//	bool bauto = true;
 	if (m_numPos == 1)
 	{
 		SetStatusText(_("Polar align: star #1"));
 		Debug.AddLine("Polar align: star #1");
 		//   Initially offset is 5 degrees;
-		bool rc = setparams(1.0); // m_rotdg, m_rotpx, m_nstep for assumed 5.0 degree PA error
-		Debug.AddLine(wxString::Format("Polar align: star #1 rotdg=%.1frotpx= %d nstep=%.0f", m_rotdg, m_rotpx, m_nstep));
-		bool isset = setStar(m_numPos);
+		bool rc = SetParams(5.0); // m_rotdg, m_rotpx, m_nstep for assumed 5.0 degree PA error
+		Debug.AddLine(wxString::Format("Polar align: star #1 rotdg=%.1f rotpx= %.0f nstep=%d", m_rotdg, m_rotpx, m_nstep));
+		bool isset = SetStar(m_numPos);
 		if (isset) m_numPos++;
 		tottheta = 0.0;
 		nstep = 0;
-		Debug.AddLine(wxString::Format("Leave Polar align: star #1 rotdg=%.1frotpx= %.1f nstep=%d", m_rotdg, m_rotpx, m_nstep));
+		Debug.AddLine(wxString::Format("Leave Polar align: star #1 rotdg=%.1f rotpx= %.0f nstep=%d", m_rotdg, m_rotpx, m_nstep));
 		return isset;
 	}
 	if (m_numPos == 2)
 	{
 		double theta = m_rotdg - tottheta;
-		Debug.AddLine(wxString::Format("Enter Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
 		SetStatusText(_("Polar align: star #2"));
 		Debug.AddLine("Polar align: star #2");
 		// Once the mount has rotated theta degrees (as indicated by prevtheta);
 		if (!bauto)
 		{
 			// rotate mount manually;
-			bool isset = setStar(m_numPos);
+			bool isset = SetStar(m_numPos);
 			if (isset) m_numPos++;
 			return isset;
 		}
-		Debug.AddLine(wxString::Format("Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
-		SetStatusText(wxString::Format("Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
+		SetStatusText(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
+		Debug.AddLine(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
 		if (tottheta < m_rotdg)
 		{
 			double newtheta = theta / (m_nstep - nstep);
-			movewestby(newtheta); // , exposure);
+			MoveWestBy(newtheta); // , exposure);
 			tottheta += newtheta;
 			// Calclate how far the mount moved compared to the expected movement;
 			// This assumes that the mount was rotated through theta degrees;
@@ -847,11 +879,12 @@ bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npo
 		else
 		{
 			// Recalculate the offset. CAUTION: This might end up in an endless loop. 
-			bool isset = setStar(m_numPos);
+			bool isset = SetStar(m_numPos);
 
 			double actpix = sqrt(pow(m_Pospx[1].X - m_Pospx[0].X, 2) + pow(m_Pospx[1].Y - m_Pospx[0].Y, 2));
 			double actsec = actpix * m_pxScale;
 			double actoffsetdeg = 90 - degrees(acos(actsec / 3600 / m_rotdg));
+			Debug.AddLine(wxString::Format("Polar align: star #2 px=%.1f asec=%.1f pxscale=%.1f", actpix, actsec, m_pxScale));
 
 			if (actoffsetdeg == 0)
 			{
@@ -864,13 +897,13 @@ bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npo
 			double prev_rotdg = m_rotdg;
 			int prev_nstep = m_nstep;
 			// FIXME - alter setparams to take into account rotation so far
-			bool rc = setparams(actoffsetdeg); // m_rotdg, m_rotpx, m_nstep for measures PA error
+			bool rc = SetParams(actoffsetdeg); // m_rotdg, m_rotpx, m_nstep for measures PA error
 			if (!rc)
 			{
 				aligning = false;
 				return false;
 			}
-			if (m_rotdg <= prev_rotdg) // Moved far enough
+			if (m_rotdg <= prev_rotdg) // Moved far enough: show the adjustment chart
 			{
 				if (!isset)
 				{
@@ -880,6 +913,11 @@ bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npo
 				m_numPos++;
 				nstep = 0;
 				tottheta = 0.0;
+				CalcRotationCentre();
+				m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
+				m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
+				m_mode = MODE_ADJUST;
+				UpdateModeState();
 			}
 			else if (m_rotdg > 45)
 			{
@@ -889,47 +927,46 @@ bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npo
 				aligning = false;
 				return false;
 			}
-			else if (m_nstep <= nstep)
+			else //if (m_nstep <= nstep)
 			{
-				nstep = m_nstep - 1;
+				nstep = int(m_nstep * tottheta/m_rotdg);
+				Debug.AddLine(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
 			}
 		}
 		return true;
 	}
 	if (m_numPos == 3)
 	{
-		SetStatusText(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
-		Debug.AddLine(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
+//		double theta = m_rotdg - tottheta;
+//		SetStatusText(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
+//		Debug.AddLine(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
 		if (!bauto)
 		{
 			// rotate mount manually;
-			bool isset = setStar(m_numPos);
+			bool isset = SetStar(m_numPos);
 			if (isset) m_numPos++;
 			return isset;
 		}
-		if (tottheta < m_rotdg)
-		{
-			double newtheta = m_rotdg / (m_nstep - nstep);
-			movewestby(newtheta); // , exposure);
-			tottheta += newtheta;
-		}
-		else
-		{
-			bool isset = setStar(m_numPos);
-			if (isset)  m_numPos++;
-			return isset;
-		}
+		m_numPos++;
+		m_mode = MODE_ADJUST;
+		UpdateModeState();
 		return true;
 	}
 	m_rotpx = 0;
 	return true;
 }
 
-bool StaticPaToolWin::setStar(int npos)
+bool StaticPaToolWin::SetStar(int npos)
 {
 	int idx = npos - 1;
 	// Get X and Y coords from PHD2;
 	// idx: 0=B, 1/2/3 = A[idx];
+	double cur_dec, cur_st;
+	if (pPointingSource->GetCoordinates(&m_ra_rot[idx], &cur_dec, &cur_st))
+	{
+		Debug.AddLine("SetStar: failed to get scope coordinates");
+		return false;
+	}
 	m_Pospx[idx].X = -1;
 	m_Pospx[idx].Y = -1;
 	PHD_Point star = pFrame->pGuider->CurrentPosition();
@@ -942,7 +979,7 @@ bool StaticPaToolWin::setStar(int npos)
 	return star.IsValid();
 }
 
-bool StaticPaToolWin::setparams(double newoffset)
+bool StaticPaToolWin::SetParams(double newoffset)
 {
 	double offsetdeg = newoffset;
 	m_offsetpx = offsetdeg * 3600 / m_pxScale;
@@ -961,30 +998,12 @@ bool StaticPaToolWin::setparams(double newoffset)
 	{
 		m_nstep = int(ceil(m_rotpx / region));
 	}
-	//double gRate = sin(radians(m_rotdg))*self.settings["xRate"];
-	//m_guidedur = m_rotpx / gRate;
-	Debug.AddLine(wxString::Format("PA setparams() rotdg=%.1f rotpx=%.1f nstep=%.0f region=%d", m_rotdg, m_rotpx, m_nstep, region));
+	Debug.AddLine(wxString::Format("PA setparams() rotdg=%.1f rotpx=%.1f nstep=%d region=%d", m_rotdg, m_rotpx, m_nstep, region));
 	return true;
 }
-/*
-bool StaticPaToolWin::rotateMount(double theta, int npulse)
-{
-	double exposure = pFrame->RequestedExposureDuration() / 1000;
-	double newtheta = theta / npulse;
-	for (int n = 0; n < npulse; n++)
-	{
-		movewestby(newtheta); // , exposure);
-		PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
-		bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
-	}
-	return true;
-}
-*/
-void StaticPaToolWin::movewestby(double thetadeg) //, double exp)
+void StaticPaToolWin::MoveWestBy(double thetadeg)
 {
 	m_can_slew = pPointingSource && pPointingSource->CanSlew();
-	// Rates in deg/sec;
-	// Calculate duration for rate 0;
 	double cur_ra, cur_dec, cur_st;
 	if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
 	{
@@ -998,22 +1017,83 @@ void StaticPaToolWin::movewestby(double thetadeg) //, double exp)
 	else if (slew_ra < 0.0)
 		slew_ra += 24.0;
 
-	//Debug.AddLine(wxString::Format("Rotate tool slew from ra %.2f, dec %.1f to ra %.2f, dec %.1f",
-	//	cur_ra, cur_dec, slew_ra, decSlew));
 	wxBusyCursor busy;
 	m_slewing = true;
-	//	GetStatusBar()->PushStatusText(_("Slewing ..."));
 	if (pPointingSource->SlewToCoordinates(slew_ra, cur_dec))
 	{
-		//		GetStatusBar()->PopStatusText();
 		m_slewing = false;
 		Debug.AddLine("Rotate tool: slew failed");
 	}
 	nstep++;
 	PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
 	bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
-	//	wxMilliSleep(exp * 1000);
-	//	pFrame->pGuider->UpdateImageDisplay();
+}
+
+wxBitmap StaticPaToolWin::CreateStarTemplate()
+{
+	wxMemoryDC memDC;
+	wxBitmap bmp(320, 240, -1);
+	memDC.SelectObject(bmp);
+	memDC.SetBackground(*wxBLACK_BRUSH);
+	memDC.Clear();
+	usImage *pCurrImg = pFrame->pGuider->CurrentImage();
+	wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
+	double scalefactor = pFrame->pGuider->ScaleFactor();
+	double xpx = pDispImg->GetWidth() / scalefactor;
+	double ypx = pDispImg->GetHeight() / scalefactor;
+
+	double scale = 320.0/xpx;
+	int region = 5;
+	double cx = xpx/2;
+	double cy = ypx/2;
+	m_CoRpx.X = cx;
+	m_CoRpx.Y = cy;
+
+	m_dCamRot = 0.0;
+	if (pMount && pMount->IsConnected() && pMount->IsCalibrated())
+	{
+		double xangle = 0.0; // , yangle;
+		m_dCamRot = degrees(pMount->xAngle());
+//		yangle = degrees(pMount->yAngle());
+//		m_dCamRot = xangle;
+	}
+	memDC.SetTextForeground(*wxLIGHT_GREY);
+	const wxFont& SmallFont =
+#if defined(__WXOSX__)
+		*wxSMALL_FONT;
+#else
+		*wxSWISS_FONT;
+#endif
+	memDC.SetFont(SmallFont);
+	const std::string alpha = "ABCDEFGHIJKL";
+	PHD_Point starpx, stardeg;
+	double starsz, starmag;
+	// Draw orbits for each alignment star
+	for (int is = 0; is < m_nstar; is++)
+	{
+//		stardeg = (s_hemi < 0) ? PHD_Point(SthStarRa[is], SthStarDec[is]) : PHD_Point(NthStarRa[is], NthStarDec[is]);
+//		starmag = (s_hemi < 0) ? SthStarMag[is] : NthStarMag[is];
+		stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
+		starmag = poleStars->at(is).mag;
+
+		starsz = 356.0*exp(-0.3*starmag) / m_pxScale;
+		starpx = Radec2Px(stardeg);
+		m_starpx[is][0] = starpx.X;
+		m_starpx[is][1] = starpx.Y;
+		m_starpx[is][2] = sqrt(pow(cx - starpx.X, 2) + pow(cy - starpx.Y, 2));
+		memDC.SetPen(wxPen(wxColor(255, 255, 0), 1, wxPENSTYLE_SOLID));
+
+		memDC.DrawCircle(m_starpx[is][0] * scale, m_starpx[is][1] * scale, starsz*scale);
+		memDC.DrawText(wxString::Format("%c", alpha[is]), (m_starpx[is][0] + starsz) * scale, m_starpx[is][1] * scale);
+	}
+	// draw the centre of the circle as a red cross
+	memDC.SetBrush(*wxTRANSPARENT_BRUSH);
+	memDC.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+	memDC.DrawLine((cx - region)*scale, cy*scale, (cx + region)*scale, cy*scale);
+	memDC.DrawLine(cx*scale, (cy - region)*scale, cx*scale, (cy + region)*scale);
+
+	memDC.SelectObject(wxNullBitmap);
+	return bmp;
 }
 
 

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -66,16 +66,12 @@ StaticPaToolWin::PolePanel::PolePanel(StaticPaToolWin* parent):
 void StaticPaToolWin::PolePanel::OnPaint(wxPaintEvent& evt)
 {
     wxPaintDC dc(this);
-    Render(dc);
+	paParent->CreateStarTemplate(dc);
 }
 void StaticPaToolWin::PolePanel::Paint()
 {
     wxClientDC dc(this);
-    Render(dc);
-}
-void StaticPaToolWin::PolePanel::Render(wxDC &dc)
-{
-    paParent->CreateStarTemplate(dc);
+	paParent->CreateStarTemplate(dc);
 }
 
 wxWindow *StaticPaTool::CreateStaticPaToolWindow()
@@ -432,11 +428,6 @@ void StaticPaToolWin::OnManual(wxCommandEvent& evt)
 }
 
 void StaticPaToolWin::OnRefStar(wxCommandEvent& evt)
-{
-    UpdateRefStar();
-}
-
-void StaticPaToolWin::UpdateRefStar()
 {
     int i_refStar = w_refStarChoice->GetSelection();
     pConfig->Profile.SetInt("/StaticPaTool/RefStar", w_refStarChoice->GetSelection());

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -116,7 +116,7 @@ wxCAPTION | wxCLOSE_BOX | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxF
 {
     pFrame->pGuider->pStaticPaTool = this;
     s_numPos = 0;
-    a_devpx = 8;
+    a_devpx = 5;
     s_state = 0;
     s_aligning = false;
     
@@ -584,7 +584,7 @@ void StaticPaToolWin::CalcRotationCentre(void)
         Debug.AddLine(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
         // Alternative algorithm based on two poins and angle rotated
         double theta2;
-        theta2 = -a_hemi * radians(360.0 / 24.0 * (r_raPos[1] - r_raPos[0])) / 2.0;
+        theta2 = a_hemi * radians(360.0 / 24.0 * (r_raPos[1] - r_raPos[0])) / 2.0;
         double lenchord = sqrt(pow((x1 - x2), 2.0) + pow((y1 - y2), 2.0));
         cr = lenchord / 2.0 / sin(theta2);
         double lenbase = cr*cos(theta2);
@@ -857,8 +857,10 @@ bool StaticPaToolWin::RotateMount()
             // So theta is the total rotation needed for the current offset;
             // And prevtheta is how we have already moved;
             // Recalculate the offset based on the actual movement;
+
         }
-        else
+//		if (s_nStep >= 2)
+		else
         {
             // Recalculate the offset. CAUTION: This might end up in an endless loop. 
             bool isset = SetStar(s_numPos);

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -713,8 +713,10 @@ PHD_Point StaticPaToolWin::Radec2Px( PHD_Point radec )
 // Sensor "up" is 90deg counterclockwise from mount RA plus rotation
 // Star rotation is RAstar - RAmount
     double a1 = radec.X - (ra_deg - 90.0);
-    while (a1 < 0.0) a1 += 360.0;
-    a1 = fmod(a1, 360);
+//    while (a1 < 0.0) a1 += 360.0;
+//    a1 = fmod(a1, 360);
+    a1 = a1 - 360.0 * floor(a1 / 360.0);
+
     double a = g_camAngle - copysign(a1, a_hemi);
 
 //    PHD_Point px(r_pxCentre.X + r * cos(radians(a)), r_pxCentre.Y - r * sin(radians(a)));
@@ -1010,11 +1012,12 @@ void StaticPaToolWin::MoveWestBy(double thetadeg)
     }
     double slew_ra = cur_ra - thetadeg * 24.0 / 360.0;
 
-    if (slew_ra >= 24.0)
+    slew_ra = slew_ra - 24.0 * floor(slew_ra / 24.0);
+/*    if (slew_ra >= 24.0)
         slew_ra -= 24.0;
     else if (slew_ra < 0.0)
         slew_ra += 24.0;
-
+*/
     if (pPointingSource->SlewToCoordinates(slew_ra, cur_dec))
     {
         Debug.AddLine("Rotate tool: slew failed");

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -42,15 +42,14 @@
 
 //==================================
 BEGIN_EVENT_TABLE(StaticPaToolWin, wxFrame)
-//EVT_BUTTON(ID_SLEW, StaticPaToolWin::OnSlew)
-EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
-EVT_BUTTON(ID_CALCULATE, StaticPaToolWin::OnCalculate)
-EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
-EVT_CHOICE(ID_REFSTAR, StaticPaToolWin::OnRefStar)
 EVT_CHOICE(ID_HEMI, StaticPaToolWin::OnHemi)
 EVT_CHECKBOX(ID_MANUAL, StaticPaToolWin::OnManual)
+EVT_CHOICE(ID_REFSTAR, StaticPaToolWin::OnRefStar)
+EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
 EVT_BUTTON(ID_STAR2, StaticPaToolWin::OnStar2)
 EVT_BUTTON(ID_STAR3, StaticPaToolWin::OnStar3)
+EVT_BUTTON(ID_CALCULATE, StaticPaToolWin::OnCalculate)
+EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
 EVT_CLOSE(StaticPaToolWin::OnClose)
 END_EVENT_TABLE()
 
@@ -59,994 +58,1004 @@ EVT_PAINT( StaticPaToolWin::PolePanel::OnPaint)
 END_EVENT_TABLE()
 
 StaticPaToolWin::PolePanel::PolePanel(StaticPaToolWin* parent):
-	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240), wxBU_AUTODRAW | wxBU_EXACTFIT),
-	paParent(parent)
+    wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240), wxBU_AUTODRAW | wxBU_EXACTFIT),
+    paParent(parent)
 {
 }
 
 void StaticPaToolWin::PolePanel::OnPaint(wxPaintEvent& evt)
 {
-	wxPaintDC dc(this);
-	Render(dc);
+    wxPaintDC dc(this);
+    Render(dc);
 }
 void StaticPaToolWin::PolePanel::Paint()
 {
-	wxClientDC dc(this);
-	Render(dc);
+    wxClientDC dc(this);
+    Render(dc);
 }
 void StaticPaToolWin::PolePanel::Render(wxDC &dc)
 {
-	paParent->CreateStarTemplate(dc);
+    paParent->CreateStarTemplate(dc);
 }
 
 wxWindow *StaticPaTool::CreateStaticPaToolWindow()
 {
-	if (!pCamera || !pCamera->Connected)
-	{
-		wxMessageBox(_("Please connect a camera first."));
-		return 0;
-	}
+    if (!pCamera || !pCamera->Connected)
+    {
+        wxMessageBox(_("Please connect a camera first."));
+        return 0;
+    }
 
-	// confirm that image scale is specified
+    // confirm that image scale is specified
 
-	if (pFrame->GetCameraPixelScale() == 1.0)
-	{
-		bool confirmed = ConfirmDialog::Confirm(_(
-			"The Static Align tool is most effective when PHD2 knows your guide\n"
-			"scope focal length and camera pixel size.\n"
-			"\n"
-			"Enter your guide scope focal length on the Global tab in the Brain.\n"
-			"Enter your camera pixel size on the Camera tab in the Brain.\n"
-			"\n"
-			"Would you like to run the tool anyway?"),
-			"/rotate_tool_without_pixscale");
+    if (pFrame->GetCameraPixelScale() == 1.0)
+    {
+        bool confirmed = ConfirmDialog::Confirm(_(
+            "The Static Align tool is most effective when PHD2 knows your guide\n"
+            "scope focal length and camera pixel size.\n"
+            "\n"
+            "Enter your guide scope focal length on the Global tab in the Brain.\n"
+            "Enter your camera pixel size on the Camera tab in the Brain.\n"
+            "\n"
+            "Would you like to run the tool anyway?"),
+            "/rotate_tool_without_pixscale");
 
-		if (!confirmed)
-		{
-			return 0;
-		}
-	}
-	if (pFrame->pGuider->IsCalibratingOrGuiding())
-	{
-		wxMessageBox(_("Please wait till Calibration is done and stop guiding"));
-		return 0;
-	}
+        if (!confirmed)
+        {
+            return 0;
+        }
+    }
+    if (pFrame->pGuider->IsCalibratingOrGuiding())
+    {
+        wxMessageBox(_("Please wait till Calibration is done and stop guiding"));
+        return 0;
+    }
 
-	return new StaticPaToolWin();
+    return new StaticPaToolWin();
 }
 
 StaticPaToolWin::StaticPaToolWin()
 : wxFrame(pFrame, wxID_ANY, _("Static Polar Alignment"), wxDefaultPosition, wxDefaultSize,
 wxCAPTION | wxCLOSE_BOX | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxFRAME_FLOAT_ON_PARENT | wxFRAME_NO_TASKBAR)
 {
-	pFrame->pGuider->pStaticPaTool = this;
-	m_numPos = 0;
-	m_devpx = 8;
-	state = 0;
-	
+    pFrame->pGuider->pStaticPaTool = this;
+    s_numPos = 0;
+    a_devpx = 8;
+    s_state = 0;
+    s_aligning = false;
+    
 //Fairly convoluted way to get the camera size in pixels
-	usImage *pCurrImg = pFrame->pGuider->CurrentImage();
-	wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
-	double scalefactor = pFrame->pGuider->ScaleFactor();
-	double xpx = pDispImg->GetWidth() / scalefactor;
-	double ypx = pDispImg->GetHeight() / scalefactor;
-	m_CoRpx.X = xpx/2;
-	m_CoRpx.Y = ypx/2;
-	m_pxScale = pFrame->GetCameraPixelScale();
+    usImage *pCurrImg = pFrame->pGuider->CurrentImage();
+    wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
+    double scalefactor = pFrame->pGuider->ScaleFactor();
+    double xpx = pDispImg->GetWidth() / scalefactor;
+    double ypx = pDispImg->GetHeight() / scalefactor;
+    r_pxCentre.X = xpx/2;
+    r_pxCentre.Y = ypx/2;
+    g_pxScale = pFrame->GetCameraPixelScale();
 // Fullsize is easier but the camera simulator does not set this.
-	wxSize camsize = pCamera->FullSize;
-	m_camXpx = pCamera->FullSize.GetWidth() == 0 ? xpx: pCamera->FullSize.GetWidth();
+//    wxSize camsize = pCamera->FullSize;
+    g_camWidth = pCamera->FullSize.GetWidth() == 0 ? xpx: pCamera->FullSize.GetWidth();
 
-	m_dCamRot = 0.0;
-	if (pMount && pMount->IsConnected() && pMount->IsCalibrated())
-	{
-		m_dCamRot = degrees(pMount->xAngle());
-	}
+    g_camAngle = 0.0;
+    if (pMount && pMount->IsConnected() && pMount->IsCalibrated())
+    {
+        g_camAngle = degrees(pMount->xAngle());
+    }
 
-	SthStars = {
-		Star("A: sigma Oct", 320.66, -88.89, 4.3),
-		Star("B: HD99828", 164.22, -89.33, 7.5),
-		Star("C: HD125371", 248.88, -89.38, 7.8),
-		Star("D: HD90105", 122.36, -89.52, 7.2),
-		Star("E: BQ Oct", 239.62, -89.83, 6.8),
-		Star("F: HD99685", 130.32, -89.85, 7.8),
-		Star("G: HD98784", 99.78, -89.87, 8.9),
-		Star("I: HD92239", 136.63, -89.42, 8.0)
-	};
-	NthStars = {
-		Star("A: Polaris", 43.12, 89.34, 1.95),
-		Star("B: HD1687", 12.14, 89.54, 8.1),
-		Star("C: TYC4629-37-1", 85.51, 89.65, 9.15),
-		Star("D: TYC4661-2-1", 297.95, 89.83, 9.65),
-		Star("E: unnamed", 86.11, 89.43, 9.25),
-		Star("F: unnamed", 358.33, 89.54, 9.35),
-		Star("G: unnamed", 355.75, 89.64, 10.1),
-		Star("H: unnamed", 12.61, 89.76, 10.5),
-		Star("I: HD21070", 152.26, 89.48, 9.0),
-	};
+    c_SthStars = {
+        Star("A: sigma Oct", 320.66, -88.89, 4.3),
+        Star("B: HD99828", 164.22, -89.33, 7.5),
+        Star("C: HD125371", 248.88, -89.38, 7.8),
+        Star("D: HD90105", 122.36, -89.52, 7.2),
+        Star("E: BQ Oct", 239.62, -89.83, 6.8),
+        Star("F: HD99685", 130.32, -89.85, 7.8),
+        Star("G: HD98784", 99.78, -89.87, 8.9),
+        Star("I: HD92239", 136.63, -89.42, 8.0)
+    };
+    c_NthStars = {
+        Star("A: Polaris", 43.12, 89.34, 1.95),
+        Star("B: HD1687", 12.14, 89.54, 8.1),
+        Star("C: TYC4629-37-1", 85.51, 89.65, 9.15),
+        Star("D: TYC4661-2-1", 297.95, 89.83, 9.65),
+        Star("E: unnamed", 86.11, 89.43, 9.25),
+        Star("F: unnamed", 358.33, 89.54, 9.35),
+        Star("G: unnamed", 355.75, 89.64, 10.1),
+        Star("H: unnamed", 12.61, 89.76, 10.5),
+        Star("I: HD21070", 152.26, 89.48, 9.0),
+    };
 
-	// get site lat/long from scope to determine hemisphere.
-	m_refStar = pConfig->Profile.GetInt("/StaticPaTool/RefStar", 4);
-	s_hemi = pConfig->Profile.GetInt("/StaticPaTool/Hemisphere", 4);
-	if (pPointingSource)
-	{
-		double lat, lon;
-		if (!pPointingSource->GetSiteLatLong(&lat, &lon))
-		{
-			s_hemi = lat >= 0 ? 1 : -1;
-		}
-	}
-	if (!pFrame->CaptureActive)
-	{
-		// loop exposures
-		wxCommandEvent dummy;
-		SetStatusText(_("Start Looping..."));
-		pFrame->OnLoopExposure(dummy);
-	}
-	// Drop down list box for alignment star
-	SetBackgroundColour(wxColor(0xcccccc));
-	SetSizeHints(wxDefaultSize, wxDefaultSize);
+    // get site lat/long from scope to determine hemisphere.
+    a_refStar = pConfig->Profile.GetInt("/StaticPaTool/RefStar", 4);
+    a_hemi = pConfig->Profile.GetInt("/StaticPaTool/Hemisphere", 4);
+    if (pPointingSource)
+    {
+        double lat, lon;
+        if (!pPointingSource->GetSiteLatLong(&lat, &lon))
+        {
+            a_hemi = lat >= 0 ? 1 : -1;
+        }
+    }
+    if (!pFrame->CaptureActive)
+    {
+        // loop exposures
+        wxCommandEvent dummy;
+        SetStatusText(_("Start Looping..."));
+        pFrame->OnLoopExposure(dummy);
+    }
+    // Drop down list box for alignment star
+    SetBackgroundColour(wxColor(0xcccccc));
+    SetSizeHints(wxDefaultSize, wxDefaultSize);
 
-	// a vertical sizer holding everything
-	wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+    // a vertical sizer holding everything
+    wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
 
-	// a horizontal box sizer for the bitmap and the instructions
-	wxBoxSizer *instrSizer = new wxBoxSizer(wxHORIZONTAL);
-	pautoInstr = new wxString(_(
-		"Slew to near the Celestial Pole.\n"
-		"Choose a reference star from the list.\n"
-		"Select it as the guide star on the main display.\n"
-		"Click Rotate to calibrate the RA Axis.\n"
-		"Wait for both calibration points to be measured.\n"
-		"Adjust your mount's altitude and azimuth as displayed.\n"
-		"Orange=Altitude; Green=Azimuth\n"
-		));
-	pmanualInstr = new wxString(_(
-		"Slew to near the Celestial Pole.\n"
-		"Choose a Reference Star from the list.\n"
-		"Select it as the guide star on the main display.\n"
-		"Click Get first point\n"
-		"Slew at least 0h20m west in RA\n"
-		"Ensure the Reference Star is still selected\n"
-		"Click Get second point\n"
-		"Repeat for the third point\n"
-		"Click Calculate to show the adjustments needed\n"
-		"Adjust your mount's altitude and azimuth to place"
-		"three reference stars on their orbits\n"
-		));
-	// can mount slew?
-	bauto = true;
-	pinstructions = pautoInstr;
-	m_can_slew = pPointingSource && pPointingSource->CanSlew();
-	if (!m_can_slew){
-		bauto = false;
-		pinstructions = pmanualInstr;
-	}
+    // a horizontal box sizer for the bitmap and the instructions
+    wxBoxSizer *instrSizer = new wxBoxSizer(wxHORIZONTAL);
+    c_autoInstr = new wxString(_(
+        "Slew to near the Celestial Pole.\n"
+        "Choose a reference star from the list.\n"
+        "Select it as the guide star on the main display.\n"
+        "Click Rotate to calibrate the RA Axis.\n"
+        "Wait for both calibration points to be measured.\n"
+        "Adjust your mount's altitude and azimuth as displayed.\n"
+        "Orange=Altitude; Green=Azimuth\n"
+        ));
+    c_manualInstr = new wxString(_(
+        "Slew to near the Celestial Pole.\n"
+        "Choose a Reference Star from the list.\n"
+        "Select it as the guide star on the main display.\n"
+        "Click Get first point\n"
+        "Slew at least 0h20m west in RA\n"
+        "Ensure the Reference Star is still selected\n"
+        "Click Get second point\n"
+        "Repeat for the third point\n"
+        "Click Calculate to show the adjustments needed\n"
+        "Adjust your mount's altitude and azimuth to place"
+        "three reference stars on their orbits\n"
+        ));
 
-	m_instructions = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(240, 240), wxALIGN_LEFT | wxST_NO_AUTORESIZE);
+    // can mount slew?
+    a_auto = true;
+    g_canSlew = pPointingSource && pPointingSource->CanSlew();
+    if (!g_canSlew){
+        a_auto = false;
+    }
+
+    w_instructions = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(240, 240), wxALIGN_LEFT | wxST_NO_AUTORESIZE);
 #ifdef __WXOSX__
-	m_instructions->SetFont(*wxSMALL_FONT);
+    m_instructions->SetFont(*wxSMALL_FONT);
 #endif
-	m_instructions->Wrap(-1);
-	instrSizer->Add(m_instructions, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+    w_instructions->Wrap(-1);
+    instrSizer->Add(w_instructions, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
 
-	pole = new PolePanel(this);
-	instrSizer->Add(pole, 0, wxALIGN_CENTER_HORIZONTAL | wxALL | wxFIXED_MINSIZE, 5);
+    w_pole = new PolePanel(this);
+    instrSizer->Add(w_pole, 0, wxALIGN_CENTER_HORIZONTAL | wxALL | wxFIXED_MINSIZE, 5);
 
-	topSizer->Add(instrSizer);
+    topSizer->Add(instrSizer);
 
-	// static box sizer holding the scope pointing controls
-	wxStaticBoxSizer *sbSizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Alignment Parameters")), wxVERTICAL);
+    // static box sizer holding the scope pointing controls
+    wxStaticBoxSizer *sbSizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Alignment Parameters")), wxVERTICAL);
 
-	// a grid box sizer for laying out scope pointing the controls
-	wxGridBagSizer *gbSizer = new wxGridBagSizer(0, 0);
-	gbSizer->SetFlexibleDirection(wxBOTH);
-	gbSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+    // a grid box sizer for laying out scope pointing the controls
+    wxGridBagSizer *gbSizer = new wxGridBagSizer(0, 0);
+    gbSizer->SetFlexibleDirection(wxBOTH);
+    gbSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
-	wxStaticText *txt;
+    wxStaticText *txt;
 
-	txt = new wxStaticText(this, wxID_ANY, _("px Scale"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALL, 5);
+// First row of grid
+    int gridRow = 0;
+    txt = new wxStaticText(this, wxID_ANY, _("Camera arcsec/pixel"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Camera Rot"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(0, 1), wxGBSpan(1, 1), wxALL, 5);
+    txt = new wxStaticText(this, wxID_ANY, _("Camera Angle"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Hemisphere"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(0, 2), wxGBSpan(1, 1), wxALL, 5);
+    txt = new wxStaticText(this, wxID_ANY, _("Hemisphere"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxALL, 5);
 
-	// Alignment star specification
-	txt = new wxStaticText(this, wxID_ANY, _("Reference Star"));
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(0, 3), wxGBSpan(1, 1), wxALL, 5);
+    // Alignment star specification
+    txt = new wxStaticText(this, wxID_ANY, _("Reference Star"));
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxALL, 5);
 
-	m_camScale = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_camScale, wxGBPosition(1, 0), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    w_camScale = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_camScale, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_camRot = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_camRot, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_camRot = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_camRot, wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	wxArrayString hemi;
-	hemi.Add(_("North"));
-	hemi.Add(_("South"));
-	hemiChoice = new wxChoice(this, ID_HEMI, wxDefaultPosition, wxDefaultSize, hemi);
-	hemiChoice->SetToolTip(_("Select your hemisphere"));
-	gbSizer->Add(hemiChoice, wxGBPosition(1, 2), wxGBSpan(1, 1), wxALL, 5);
+    wxArrayString hemi;
+    hemi.Add(_("North"));
+    hemi.Add(_("South"));
+    w_hemiChoice = new wxChoice(this, ID_HEMI, wxDefaultPosition, wxDefaultSize, hemi);
+    w_hemiChoice->SetToolTip(_("Select your hemisphere"));
+    gbSizer->Add(w_hemiChoice, wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxALL, 5);
 
-	refStarChoice = new wxChoice(this, ID_REFSTAR, wxDefaultPosition, wxDefaultSize);
-	refStarChoice->SetToolTip(_("Select the star used for checking alignment."));
-	gbSizer->Add(refStarChoice, wxGBPosition(1, 3), wxGBSpan(1, 1), wxALL, 5);
+    w_refStarChoice = new wxChoice(this, ID_REFSTAR, wxDefaultPosition, wxDefaultSize);
+    w_refStarChoice->SetToolTip(_("Select the star used for checking alignment."));
+    gbSizer->Add(w_refStarChoice, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("X px"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(4, 1), wxGBSpan(1, 1), wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    txt = new wxStaticText(this, wxID_ANY, _("X px"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Y px"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(4, 2), wxGBSpan(1, 1), wxALL, 5);
+    txt = new wxStaticText(this, wxID_ANY, _("Y px"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxALL, 5);
 
-	m_manual = new wxCheckBox(this, ID_MANUAL, _("Manual Slew"));
-	gbSizer->Add(m_manual, wxGBPosition(4, 3), wxGBSpan(1, 1), wxALL, 5);
-	m_manual->SetValue(false);
-	m_manual->SetToolTip(_("Manually slew the mount to three alignment positions"));
+    w_manual = new wxCheckBox(this, ID_MANUAL, _("Manual Slew"));
+    gbSizer->Add(w_manual, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxALL, 5);
+    w_manual->SetValue(false);
+    w_manual->SetToolTip(_("Manually slew the mount to three alignment positions"));
 
-	txt = new wxStaticText(this, wxID_ANY, _("Pt #1"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(5, 0), wxGBSpan(1, 1), wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    txt = new wxStaticText(this, wxID_ANY, _("Pt #1"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	m_calPt[0][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[0][0], wxGBPosition(5, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[0][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[0][0], wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_calPt[0][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[0][1], wxGBPosition(5, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[0][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[0][1], wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_star1 = new wxButton(this, ID_ROTATE, _("Rotate"), wxDefaultPosition, wxDefaultSize, 0);
-	gbSizer->Add(m_star1, wxGBPosition(5, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_star1 = new wxButton(this, ID_ROTATE, _("Rotate"), wxDefaultPosition, wxDefaultSize, 0);
+    gbSizer->Add(w_star1, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Pt #2"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(6, 0), wxGBSpan(1, 1), wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    txt = new wxStaticText(this, wxID_ANY, _("Pt #2"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	m_calPt[1][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[1][0], wxGBPosition(6, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[1][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[1][0], wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_calPt[1][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[1][1], wxGBPosition(6, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[1][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[1][1], wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_star2 = new wxButton(this, ID_STAR2, _("Get second position"), wxDefaultPosition, wxDefaultSize, 0);
-	gbSizer->Add(m_star2, wxGBPosition(6, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_star2 = new wxButton(this, ID_STAR2, _("Get second position"), wxDefaultPosition, wxDefaultSize, 0);
+    gbSizer->Add(w_star2, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Pt #3"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(7, 0), wxGBSpan(1, 1), wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    txt = new wxStaticText(this, wxID_ANY, _("Pt #3"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	m_calPt[2][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[2][0], wxGBPosition(7, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[2][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[2][0], wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_calPt[2][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[2][1], wxGBPosition(7, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[2][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[2][1], wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_star3 = new wxButton(this, ID_STAR3, _("Get third position"), wxDefaultPosition, wxDefaultSize, 0);
-	gbSizer->Add(m_star3, wxGBPosition(7, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_star3 = new wxButton(this, ID_STAR3, _("Get third position"), wxDefaultPosition, wxDefaultSize, 0);
+    gbSizer->Add(w_star3, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	txt = new wxStaticText(this, wxID_ANY, _("Centre"), wxDefaultPosition, wxDefaultSize, 0);
-	txt->Wrap(-1);
-	gbSizer->Add(txt, wxGBPosition(8, 0), wxGBSpan(1, 1), wxALL, 5);
+    // Next row of grid
+    gridRow++;
+    txt = new wxStaticText(this, wxID_ANY, _("Centre"), wxDefaultPosition, wxDefaultSize, 0);
+    txt->Wrap(-1);
+    gbSizer->Add(txt, wxGBPosition(gridRow, 0), wxGBSpan(1, 1), wxALL, 5);
 
-	m_calPt[3][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[3][0], wxGBPosition(8, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[3][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[3][0], wxGBPosition(gridRow, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_calPt[3][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	gbSizer->Add(m_calPt[3][1], wxGBPosition(8, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calPt[3][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+    gbSizer->Add(w_calPt[3][1], wxGBPosition(gridRow, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	m_adjust = new wxButton(this, ID_CALCULATE, _("Calculate"), wxDefaultPosition, wxDefaultSize, 0);
-	gbSizer->Add(m_adjust, wxGBPosition(8, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+    w_calculate = new wxButton(this, ID_CALCULATE, _("Calculate"), wxDefaultPosition, wxDefaultSize, 0);
+    gbSizer->Add(w_calculate, wxGBPosition(gridRow, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
 
-	// add grid bag sizer to static sizer
-	sbSizer->Add(gbSizer, 1, wxALIGN_CENTER, 5);
+    // add grid bag sizer to static sizer
+    sbSizer->Add(gbSizer, 1, wxALIGN_CENTER, 5);
 
-	// add static sizer to top-level sizer
-	topSizer->Add(sbSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+    // add static sizer to top-level sizer
+    topSizer->Add(sbSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
 
-	// add some padding below the static sizer
-	topSizer->Add(0, 3, 0, wxEXPAND, 3);
+    // add some padding below the static sizer
+    topSizer->Add(0, 3, 0, wxEXPAND, 3);
 
-	m_notesLabel = new wxStaticText(this, wxID_ANY, _("Adjustment notes"), wxDefaultPosition, wxDefaultSize, 0);
-	m_notesLabel->Wrap(-1);
-	topSizer->Add(m_notesLabel, 0, wxEXPAND | wxTOP | wxLEFT, 8);
+    w_notesLabel = new wxStaticText(this, wxID_ANY, _("Adjustment notes"), wxDefaultPosition, wxDefaultSize, 0);
+    w_notesLabel->Wrap(-1);
+    topSizer->Add(w_notesLabel, 0, wxEXPAND | wxTOP | wxLEFT, 8);
 
-	m_notes = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(-1, 54), wxTE_MULTILINE);
-	pFrame->RegisterTextCtrl(m_notes);
-	topSizer->Add(m_notes, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+    w_notes = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(-1, 54), wxTE_MULTILINE);
+    pFrame->RegisterTextCtrl(w_notes);
+    topSizer->Add(w_notes, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-	// horizontal sizer for the buttons
-	wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
+    // horizontal sizer for the buttons
+    wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	// proportional pad on left of Rotate button
-	hSizer->Add(0, 0, 2, wxEXPAND, 5);
+    // proportional pad on left of Rotate button
+    hSizer->Add(0, 0, 2, wxEXPAND, 5);
 
-	// proportional pad on right of Rotate button
-	hSizer->Add(0, 0, 1, wxEXPAND, 5);
+    // proportional pad on right of Rotate button
+    hSizer->Add(0, 0, 1, wxEXPAND, 5);
 
-	// proportional pad on right of Align button
-	hSizer->Add(0, 0, 2, wxEXPAND, 5);
+    // proportional pad on right of Align button
+    hSizer->Add(0, 0, 2, wxEXPAND, 5);
 
-	m_close = new wxButton(this, ID_CLOSE, _("Close"), wxDefaultPosition, wxDefaultSize, 0);
-	hSizer->Add(m_close, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+    w_close = new wxButton(this, ID_CLOSE, _("Close"), wxDefaultPosition, wxDefaultSize, 0);
+    hSizer->Add(w_close, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-	// add button sizer to top level sizer
-	topSizer->Add(hSizer, 1, wxEXPAND | wxALL, 5);
+    // add button sizer to top level sizer
+    topSizer->Add(hSizer, 1, wxEXPAND | wxALL, 5);
 
-	SetSizer(topSizer);
+    SetSizer(topSizer);
 
-	m_statusBar = CreateStatusBar(1, wxST_SIZEGRIP, wxID_ANY);
+    w_statusBar = CreateStatusBar(1, wxST_SIZEGRIP, wxID_ANY);
 
-	Layout();
-	topSizer->Fit(this);
+    Layout();
+    topSizer->Fit(this);
 
-	int xpos = pConfig->Global.GetInt("/StaticPaTool/pos.x", -1);
-	int ypos = pConfig->Global.GetInt("/StaticPaTool/pos.y", -1);
-	MyFrame::PlaceWindowOnScreen(this, xpos, ypos);
+    int xpos = pConfig->Global.GetInt("/StaticPaTool/pos.x", -1);
+    int ypos = pConfig->Global.GetInt("/StaticPaTool/pos.y", -1);
+    MyFrame::PlaceWindowOnScreen(this, xpos, ypos);
 
 // Different instructions for manual versus auto
+    FillPanel();
 
-	SetButtons();
-
-//	refStarChoice->Select(pConfig->Profile.GetInt("/StaticPaTool/RefStar", 4) - 1);
-//	UpdateRefStar();
 }
 
 StaticPaToolWin::~StaticPaToolWin()
 {
-	pFrame->pGuider->pStaticPaTool = NULL;
-	pFrame->pStaticPaTool = NULL;
+    pFrame->pGuider->pStaticPaTool = NULL;
+    pFrame->pStaticPaTool = NULL;
 }
 
 void StaticPaToolWin::OnHemi(wxCommandEvent& evt)
 {
-	int i_hemi = hemiChoice->GetSelection() <= 0 ? 1 : -1;
-	pConfig->Profile.SetInt("/StaticPaTool/Hemisphere", i_hemi);
-	if (i_hemi != s_hemi)
-	{
-		m_refStar = 0;
-		s_hemi = i_hemi;
-	}
-	SetButtons();
+    int i_hemi = w_hemiChoice->GetSelection() <= 0 ? 1 : -1;
+    pConfig->Profile.SetInt("/StaticPaTool/Hemisphere", i_hemi);
+    if (i_hemi != a_hemi)
+    {
+        a_refStar = 0;
+        a_hemi = i_hemi;
+    }
+    FillPanel();
 }
 void StaticPaToolWin::OnManual(wxCommandEvent& evt)
 {
-	bauto = !m_manual->IsChecked();
-	SetButtons();
+    a_auto = !w_manual->IsChecked();
+    FillPanel();
 }
 
 void StaticPaToolWin::OnRefStar(wxCommandEvent& evt)
 {
-	UpdateRefStar();
+    UpdateRefStar();
 }
 
 void StaticPaToolWin::UpdateRefStar()
 {
-	int i_refStar = refStarChoice->GetSelection();
-	pConfig->Profile.SetInt("/StaticPaTool/RefStar", refStarChoice->GetSelection());
+    int i_refStar = w_refStarChoice->GetSelection();
+    pConfig->Profile.SetInt("/StaticPaTool/RefStar", w_refStarChoice->GetSelection());
 
-	m_refStar = i_refStar;
+    a_refStar = i_refStar;
 }
 
 void StaticPaToolWin::OnRotate(wxCommandEvent& evt)
 {
-	if (aligning){ // STOP rotating
-		aligning = false;
-		m_numPos = 0;
-		state = 0;
-		SetButtons();
-		return;
-	}
-	if (pFrame->pGuider->IsCalibratingOrGuiding())
-	{
-		SetStatusText(_("Please wait till Calibration is done and/or stop guiding"));
-		return;
-	}
-	if (!pFrame->pGuider->IsLocked())
-	{
-		SetStatusText(_("Please select a star"));
-		return;
-	}
-	m_numPos = 1;
-	state = bauto ? 0 : state;
-	aligning = true;
-	SetButtons();
-	return;
+    if (s_aligning){ // STOP rotating
+        s_aligning = false;
+        s_numPos = 0;
+        s_state = 0;
+        FillPanel();
+        return;
+    }
+    if (pFrame->pGuider->IsCalibratingOrGuiding())
+    {
+        SetStatusText(_("Please wait till Calibration is done and/or stop guiding"));
+        return;
+    }
+    if (!pFrame->pGuider->IsLocked())
+    {
+        SetStatusText(_("Please select a star"));
+        return;
+    }
+    s_numPos = 1;
+    s_state = a_auto ? 0 : s_state;
+    s_aligning = true;
+    FillPanel();
+    return;
 }
 
 void StaticPaToolWin::OnStar2(wxCommandEvent& evt)
 {
-	m_numPos = 2;
-	aligning = true;
+    s_numPos = 2;
+    s_aligning = true;
 }
 
 void StaticPaToolWin::OnStar3(wxCommandEvent& evt)
 {
-	m_numPos = 3;
-	aligning = true;
+    s_numPos = 3;
+    s_aligning = true;
 }
 
 void StaticPaToolWin::OnCalculate(wxCommandEvent& evt)
 {
-	m_numPos = 3;
-	CalcRotationCentre();
-	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
-	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
+    s_numPos = 3;
+    CalcRotationCentre();
+    w_calPt[3][0]->SetValue(wxString::Format("%+.f", r_pxCentre.X));
+    w_calPt[3][1]->SetValue(wxString::Format("%+.f", r_pxCentre.Y));
 }
 
 void StaticPaToolWin::OnCloseBtn(wxCommandEvent& evt)
 {
-	Debug.AddLine("Close StaticPaTool");
-	if (IsAligning())
-	{
-		aligning = false;
-	}
-	Destroy();
+    Debug.AddLine("Close StaticPaTool");
+    if (IsAligning())
+    {
+        s_aligning = false;
+    }
+    Destroy();
 }
 
 void StaticPaToolWin::OnClose(wxCloseEvent& evt)
 {
-	Debug.AddLine("Close StaticPaTool");
-	Destroy();
+    Debug.AddLine("Close StaticPaTool");
+    Destroy();
 }
 
-void StaticPaToolWin::SetButtons()
+void StaticPaToolWin::FillPanel()
 {
-	if (!m_can_slew){
-		m_manual->Hide();
-	}
-	m_manual->SetValue(!bauto);
-	pinstructions = bauto? pautoInstr: pmanualInstr;
-	m_instructions->SetLabel(*pinstructions);
+    if (!g_canSlew){
+        w_manual->Hide();
+    }
+    w_manual->SetValue(!a_auto);
+    w_instructions->SetLabel(a_auto ? *c_autoInstr :*c_manualInstr);
 
-	m_star1->SetLabel(_("Rotate"));
-	if (aligning) {
-		m_star1->SetLabel(_("Stop"));
-	}
-	m_star2->Hide();
-	m_star3->Hide();
-	m_adjust->Hide();
-	hemiChoice->Enable(false);
-	hemiChoice->SetSelection(s_hemi > 0 ? 0 : 1);
-	if (!bauto)
-	{
-		m_star1->SetLabel(_("Get first position"));
-		m_star2->Show();
-		m_star3->Show();
-		m_adjust->Show();
-		hemiChoice->Enable(true);
-	}
-	poleStars = s_hemi >= 0 ? &NthStars : &SthStars;
-	refStarChoice->Clear();
-	std::string starname;
-	for (int is = 0; is < poleStars->size(); is++) {
-		refStarChoice->AppendString(poleStars->at(is).name);
-	}
-	refStarChoice->SetSelection(m_refStar);
-	m_camScale->SetValue(wxString::Format("%+.3f", m_pxScale));
-	m_camRot->SetValue(wxString::Format("%+.3f", m_dCamRot));
+    w_star1->SetLabel(_("Rotate"));
+    if (s_aligning) {
+        w_star1->SetLabel(_("Stop"));
+    }
+    w_star2->Hide();
+    w_star3->Hide();
+//    w_calculate->Hide();
+    w_hemiChoice->Enable(false);
+    w_hemiChoice->SetSelection(a_hemi > 0 ? 0 : 1);
+    if (!a_auto)
+    {
+        w_star1->SetLabel(_("Get first position"));
+        w_star2->Show();
+        w_star3->Show();
+//        w_calculate->Show();
+        w_hemiChoice->Enable(true);
+    }
+    poleStars = a_hemi >= 0 ? &c_NthStars : &c_SthStars;
+    w_refStarChoice->Clear();
+    std::string starname;
+    for (int is = 0; is < poleStars->size(); is++) {
+        w_refStarChoice->AppendString(poleStars->at(is).name);
+    }
+    w_refStarChoice->SetSelection(a_refStar);
+    w_camScale->SetValue(wxString::Format("%+.3f", g_pxScale));
+    w_camRot->SetValue(wxString::Format("%+.3f", g_camAngle));
 
-	pole->Paint();
-	Layout();
+    w_pole->Paint();
+    Layout();
 
 }
 
 void StaticPaToolWin::CalcRotationCentre(void)
 {
-	double x1, y1, x2, y2, x3, y3;
-	double cx, cy, cr;
-	x1 = m_Pospx[0].X;
-	y1 = m_Pospx[0].Y;
-	x2 = m_Pospx[1].X;
-	y2 = m_Pospx[1].Y;
-	if (!bauto)
-	{
-		SetStatusText(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
-		Debug.AddLine(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
-		double a, b, c, e, f, g, i, j, k;
-		double m11, m12, m13, m14;
-		x3 = m_Pospx[2].X;
-		y3 = m_Pospx[2].Y;
-		// |A| = aei + bfg + cdh -ceg -bdi -afh
-		// a b c
-		// d e f
-		// g h i
-		// a= x1^2+y1^2; b=x1; c=y1; d=1
-		// e= x2^2+y2^2; f=x2; g=y2; h=1
-		// i= x3^2+y3^2; j=x3; k=y3; l=1
-		//
-		// x0 = 1/2.|M12|/|M11|
-		// y0 = -1/2.|M13|/|M11|
-		// r = x0^2 + y0^2 + |M14| / |M11|
-		//
-		a = x1 * x1 + y1 * y1;
-		b = x1;
-		c = y1;
-		e = x2 * x2 + y2 * y2;
-		f = x2;
-		g = y2;
-		i = x3 * x3 + y3 * y3;
-		j = x3;
-		k = y3;
-		m11 = b * g + c * j + f * k - g * j - c * f - b * k;
-		m12 = a * g + c * i + e * k - g * i - c * e - a * k;
-		m13 = a * f + b * i + e * j - f * i - b * e - a * j;
-		m14 = a * f * k + b * g * i + c * e * j - c * f * i - b * e * k - a * g * j;
-		cx = (1. / 2.) * m12 / m11;
-		cy = (-1. / 2.) * m13 / m11;
-		cr = sqrt(cx * cx + cy *cy + m14 / m11);
-	}
-	else
-	{
-		SetStatusText(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
-		Debug.AddLine(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
-		// Alternative algorithm based on two poins and angle rotated
-		double theta2;
-		theta2 = -s_hemi * radians(360.0 / 24.0 * (m_ra_rot[1] - m_ra_rot[0])) / 2.0;
-		double lenchord = sqrt(pow((x1 - x2), 2.0) + pow((y1 - y2), 2.0));
-		cr = lenchord / 2.0 / sin(theta2);
-		double lenbase = cr*cos(theta2);
-		double slopebase = atan2(y1 - y2, x2 - x1) + M_PI / 2.0;
-		cx = (x1 + x2) / 2.0 + lenbase * cos(slopebase);
-		cy = (y1 + y2) / 2.0 - lenbase * sin(slopebase); // subtract for pixels
-	}
-	m_CoRpx.X = cx;
-	m_CoRpx.Y = cy;
-	m_Radius = cr;
-	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
-	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
+    double x1, y1, x2, y2, x3, y3;
+    double cx, cy, cr;
+    x1 = r_pxPos[0].X;
+    y1 = r_pxPos[0].Y;
+    x2 = r_pxPos[1].X;
+    y2 = r_pxPos[1].Y;
+    if (!a_auto)
+    {
+        SetStatusText(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+        Debug.AddLine(wxString::Format("Manual CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+        double a, b, c, e, f, g, i, j, k;
+        double m11, m12, m13, m14;
+        x3 = r_pxPos[2].X;
+        y3 = r_pxPos[2].Y;
+        // |A| = aei + bfg + cdh -ceg -bdi -afh
+        // a b c
+        // d e f
+        // g h i
+        // a= x1^2+y1^2; b=x1; c=y1; d=1
+        // e= x2^2+y2^2; f=x2; g=y2; h=1
+        // i= x3^2+y3^2; j=x3; k=y3; l=1
+        //
+        // x0 = 1/2.|M12|/|M11|
+        // y0 = -1/2.|M13|/|M11|
+        // r = x0^2 + y0^2 + |M14| / |M11|
+        //
+        a = x1 * x1 + y1 * y1;
+        b = x1;
+        c = y1;
+        e = x2 * x2 + y2 * y2;
+        f = x2;
+        g = y2;
+        i = x3 * x3 + y3 * y3;
+        j = x3;
+        k = y3;
+        m11 = b * g + c * j + f * k - g * j - c * f - b * k;
+        m12 = a * g + c * i + e * k - g * i - c * e - a * k;
+        m13 = a * f + b * i + e * j - f * i - b * e - a * j;
+        m14 = a * f * k + b * g * i + c * e * j - c * f * i - b * e * k - a * g * j;
+        cx = (1. / 2.) * m12 / m11;
+        cy = (-1. / 2.) * m13 / m11;
+        cr = sqrt(cx * cx + cy *cy + m14 / m11);
+    }
+    else
+    {
+        SetStatusText(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+        Debug.AddLine(wxString::Format("SPA CalcCoR: (%.1f,%.1f); (%.1f,%.1f)", x1, y1, x2, y2));
+        // Alternative algorithm based on two poins and angle rotated
+        double theta2;
+        theta2 = -a_hemi * radians(360.0 / 24.0 * (r_raPos[1] - r_raPos[0])) / 2.0;
+        double lenchord = sqrt(pow((x1 - x2), 2.0) + pow((y1 - y2), 2.0));
+        cr = lenchord / 2.0 / sin(theta2);
+        double lenbase = cr*cos(theta2);
+        double slopebase = atan2(y1 - y2, x2 - x1) + M_PI / 2.0;
+        cx = (x1 + x2) / 2.0 + lenbase * cos(slopebase);
+        cy = (y1 + y2) / 2.0 - lenbase * sin(slopebase); // subtract for pixels
+    }
+    r_pxCentre.X = cx;
+    r_pxCentre.Y = cy;
+    r_radius = cr;
+    w_calPt[3][0]->SetValue(wxString::Format("%+.f", r_pxCentre.X));
+    w_calPt[3][1]->SetValue(wxString::Format("%+.f", r_pxCentre.Y));
 
-	usImage *pCurrImg = pFrame->pGuider->CurrentImage();
-	wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
-	double scalefactor = pFrame->pGuider->ScaleFactor();
-	int xpx = pDispImg->GetWidth() / scalefactor;
-	int ypx = pDispImg->GetHeight() / scalefactor;
-	m_dispSz[0] = xpx;
-	m_dispSz[1] = ypx;
+    usImage *pCurrImg = pFrame->pGuider->CurrentImage();
+    wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
+    double scalefactor = pFrame->pGuider->ScaleFactor();
+    int xpx = pDispImg->GetWidth() / scalefactor;
+    int ypx = pDispImg->GetHeight() / scalefactor;
+    g_dispSz[0] = xpx;
+    g_dispSz[1] = ypx;
 
 // Diatance and angle of CoR from centre of sensor
-	double cor_r = sqrt(pow(xpx / 2 - cx, 2) + pow(ypx / 2 - cy, 2));
-	double cor_a = degrees(atan2((ypx / 2 - cy), (xpx / 2 - cx)));
-	double rarot = -m_dCamRot;
+    double cor_r = sqrt(pow(xpx / 2 - cx, 2) + pow(ypx / 2 - cy, 2));
+    double cor_a = degrees(atan2((ypx / 2 - cy), (xpx / 2 - cx)));
+    double rarot = -g_camAngle;
 // Cone and Dec components of CoR vector
-	double dec_r = cor_r * sin(radians(cor_a - rarot));
-	m_DecCorr.X = -dec_r * sin(radians(rarot));
-	m_DecCorr.Y = dec_r * cos(radians(rarot));
-	double cone_r = cor_r * cos(radians(cor_a - rarot));
-	m_ConeCorr.X = cone_r * cos(radians(rarot));
-	m_ConeCorr.Y = cone_r * sin(radians(rarot));
-	double decCorr_deg = dec_r * m_pxScale / 3600;
+    double dec_r = cor_r * sin(radians(cor_a - rarot));
+    m_DecCorr.X = -dec_r * sin(radians(rarot));
+    m_DecCorr.Y = dec_r * cos(radians(rarot));
+    double cone_r = cor_r * cos(radians(cor_a - rarot));
+    m_ConeCorr.X = cone_r * cos(radians(rarot));
+    m_ConeCorr.Y = cone_r * sin(radians(rarot));
+    double decCorr_deg = dec_r * g_pxScale / 3600;
 
 // Caclulate pixel values for the alignment stars
-	PHD_Point starpx, stardeg;
-	stardeg = PHD_Point(poleStars->at(m_refStar).ra, poleStars->at(m_refStar).dec);
-	starpx = Radec2Px(stardeg);
-	double xt = starpx.X;
-	double yt = starpx.Y;
+    PHD_Point starpx, stardeg;
+    stardeg = PHD_Point(poleStars->at(a_refStar).ra, poleStars->at(a_refStar).dec);
+    starpx = Radec2Px(stardeg);
+    double xt = starpx.X;
+    double yt = starpx.Y;
 
-	int idx = bauto ? 1 : 2;
-	double xs = m_Pospx[idx].X;
-	double ys = m_Pospx[idx].Y;
+    int idx = a_auto ? 1 : 2;
+    double xs = r_pxPos[idx].X;
+    double ys = r_pxPos[idx].Y;
 
-	//	// Calculate the camera rotation from the Azimuth axis
-	//	// Alt angle aligns to HA=0, Azimuth (East) to HA = -90
-	//	// In home position Az aligns with Dec
-	//	// So at HA +/-90 (home pos) Alt rotation is 0 (HA+90)
-	//	// At the meridian, HA=0 Alt aligns with dec so Rotation is +/-90
-	//	// Let harot =  camera rotation from Alt axis
-	//	// Alt axis is at HA+90
-	//	// This is camera rotation from RA minus(?) LST angle 
-	double	hcor_r = sqrt(pow(xt - xs, 2) + pow(yt - ys, 2));
-	double	hcor_a = degrees(atan2((yt - ys), (xt - xs)));
-	double ra_hrs, dec_deg, st_hrs;
-	pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs);
-	double harot = rarot - (90 + (st_hrs - ra_hrs)*15.0);
-	double hrot = hcor_a - harot;
+    //    // Calculate the camera rotation from the Azimuth axis
+    //    // Alt angle aligns to HA=0, Azimuth (East) to HA = -90
+    //    // In home position Az aligns with Dec
+    //    // So at HA +/-90 (home pos) Alt rotation is 0 (HA+90)
+    //    // At the meridian, HA=0 Alt aligns with dec so Rotation is +/-90
+    //    // Let harot =  camera rotation from Alt axis
+    //    // Alt axis is at HA+90
+    //    // This is camera rotation from RA minus(?) LST angle 
+    double    hcor_r = sqrt(pow(xt - xs, 2) + pow(yt - ys, 2));
+    double    hcor_a = degrees(atan2((yt - ys), (xt - xs)));
+    double ra_hrs, dec_deg, st_hrs;
+    pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs);
+    double harot = rarot - (90 + (st_hrs - ra_hrs)*15.0);
+    double hrot = hcor_a - harot;
 
-	double az_r = hcor_r * sin(radians(hrot));
-	double alt_r = hcor_r * cos(radians(hrot));
+    double az_r = hcor_r * sin(radians(hrot));
+    double alt_r = hcor_r * cos(radians(hrot));
 
-	m_AzCorr.X = -az_r * sin(radians(harot));
-	m_AzCorr.Y = az_r * cos(radians(harot));
-	m_AltCorr.X = alt_r * cos(radians(harot));
-	m_AltCorr.Y = alt_r * sin(radians(harot));
+    m_AzCorr.X = -az_r * sin(radians(harot));
+    m_AzCorr.Y = az_r * cos(radians(harot));
+    m_AltCorr.X = alt_r * cos(radians(harot));
+    m_AltCorr.Y = alt_r * sin(radians(harot));
 
 }
 
 PHD_Point StaticPaToolWin::Radec2Px( PHD_Point radec )
 {
 // Convert dec to pixel radius
-	double r = (90.0 - fabs(radec.Y)) * 3600 / m_pxScale;
+    double r = (90.0 - fabs(radec.Y)) * 3600 / g_pxScale;
 
 // Rotate by calibration angle and HA f object taking into account mount rotation (HA)
-	double ra_hrs, dec_deg, ra_deg, st_hrs;
-	ra_deg = 0.0;
-	if (pPointingSource && !pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs))
-	{
-		ra_deg = ra_hrs * 15.0;
-	}
-	else
-	{
-		// If not a goto mount calculate ra_deg from LST assuming mount is in the home position (HA=18h)
-		tm j2000_info;
-		j2000_info.tm_year = 100;
-		j2000_info.tm_mon = 1;
-		j2000_info.tm_mday = 1;
-		j2000_info.tm_hour = 12;
-		j2000_info.tm_min = 0;
-		j2000_info.tm_sec = 0;
-		j2000_info.tm_isdst = 0;
-		time_t j2000 = mktime(&j2000_info);
-		time_t nowutc = time(NULL);
-		tm *nowinfo = localtime(&nowutc);
-		time_t now = mktime(nowinfo);
-		double since = difftime(now, j2000) / 86400.0;
-		ra_deg = fmod(280.46061837 + 360.98564736629 * since - 270.0, 360.0);
-		// RA = LST - HA 
-		// For for HA 270; RA_deg = LST_deg - 270.0
-	}
+    double ra_hrs, dec_deg, ra_deg, st_hrs;
+    ra_deg = 0.0;
+    if (pPointingSource && !pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs))
+    {
+        ra_deg = ra_hrs * 15.0;
+    }
+    else
+    {
+        // If not a goto mount calculate ra_deg from LST assuming mount is in the home position (HA=18h)
+        tm j2000_info;
+        j2000_info.tm_year = 100;
+        j2000_info.tm_mon = 1;
+        j2000_info.tm_mday = 1;
+        j2000_info.tm_hour = 12;
+        j2000_info.tm_min = 0;
+        j2000_info.tm_sec = 0;
+        j2000_info.tm_isdst = 0;
+        time_t j2000 = mktime(&j2000_info);
+        time_t nowutc = time(NULL);
+        tm *nowinfo = localtime(&nowutc);
+        time_t now = mktime(nowinfo);
+        double since = difftime(now, j2000) / 86400.0;
+        ra_deg = fmod(280.46061837 + 360.98564736629 * since - 270.0, 360.0);
+        // RA = LST - HA 
+        // For for HA 270; RA_deg = LST_deg - 270.0
+    }
 
 
-	// Target hour angle - or rather the rotation needed to correct. 
+    // Target hour angle - or rather the rotation needed to correct. 
 // HA = LST - RA
 // In NH HA decreases clockwise; RA increases clockwise
 // "Up" is HA=0
 // Sensor "up" is 90deg counterclockwise from mount RA plus rotation
 // Star rotation is RAstar - RAmount
-	double a1 = radec.X - (ra_deg - 90.0);
-	while (a1 < 0.0) a1 += 360.0;
-	a1 = fmod(a1, 360);
-	double a = m_dCamRot - copysign(a1, s_hemi);
+    double a1 = radec.X - (ra_deg - 90.0);
+    while (a1 < 0.0) a1 += 360.0;
+    a1 = fmod(a1, 360);
+    double a = g_camAngle - copysign(a1, a_hemi);
 
-	PHD_Point px(m_CoRpx.X + r * cos(radians(a)), m_CoRpx.Y - r * sin(radians(a)));
-	return px;
+    PHD_Point px(r_pxCentre.X + r * cos(radians(a)), r_pxCentre.Y - r * sin(radians(a)));
+    return px;
 }
 
 void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
 {
-	dc.SetPen(wxPen(wxColour(0, 255, 255), 1, wxSOLID));
-	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(wxColour(0, 255, 255), 1, wxSOLID));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
 
-	int npos = std::min(bauto? 2:3, m_numPos);
+    int npos = std::min(a_auto? 2:3, s_numPos);
 
-	for (int i = 0; i < npos; i++)
-	{
-		dc.DrawCircle(m_Pospx[i].X*scale, m_Pospx[i].Y*scale, 12 * scale);
-	}
-	if (!IsAligned())
-	{
-		return;
-	}
-	dc.SetBrush(*wxTRANSPARENT_BRUSH);
-	wxPenStyle penStyle = wxPENSTYLE_DOT;
-	dc.SetPen(wxPen(wxColor(255, 0, 255), 1, penStyle));
-	dc.DrawCircle(m_CoRpx.X*scale, m_CoRpx.Y*scale, m_Radius*scale);
+    for (int i = 0; i < npos; i++)
+    {
+        dc.DrawCircle(r_pxPos[i].X*scale, r_pxPos[i].Y*scale, 12 * scale);
+    }
+    if (!IsAligned())
+    {
+        return;
+    }
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    wxPenStyle penStyle = wxPENSTYLE_DOT;
+    dc.SetPen(wxPen(wxColor(255, 0, 255), 1, penStyle));
+    dc.DrawCircle(r_pxCentre.X*scale, r_pxCentre.Y*scale, r_radius*scale);
 
-	// draw the centre of the circle as a red cross
-	dc.SetBrush(*wxTRANSPARENT_BRUSH);
-	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
-	int region = 5;
-	dc.DrawLine((m_CoRpx.X - region)*scale, m_CoRpx.Y*scale, (m_CoRpx.X + region)*scale, m_CoRpx.Y*scale);
-	dc.DrawLine(m_CoRpx.X*scale, (m_CoRpx.Y - region)*scale, m_CoRpx.X*scale, (m_CoRpx.Y + region)*scale);
+    // draw the centre of the circle as a red cross
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+    int region = 5;
+    dc.DrawLine((r_pxCentre.X - region)*scale, r_pxCentre.Y*scale, (r_pxCentre.X + region)*scale, r_pxCentre.Y*scale);
+    dc.DrawLine(r_pxCentre.X*scale, (r_pxCentre.Y - region)*scale, r_pxCentre.X*scale, (r_pxCentre.Y + region)*scale);
 
-	// Show the centre of the display wth a grey cross
-	double xsc = m_dispSz[0] / 2;
-	double ysc = m_dispSz[1] / 2;
-	dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
-	dc.DrawLine((xsc - region * 4)*scale, ysc*scale, (xsc + region * 4)*scale, ysc*scale);
-	dc.DrawLine(xsc*scale, (ysc - region * 4)*scale, xsc*scale, (ysc + region * 4)*scale);
+    // Show the centre of the display wth a grey cross
+    double xsc = g_dispSz[0] / 2;
+    double ysc = g_dispSz[1] / 2;
+    dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+    dc.DrawLine((xsc - region * 4)*scale, ysc*scale, (xsc + region * 4)*scale, ysc*scale);
+    dc.DrawLine(xsc*scale, (ysc - region * 4)*scale, xsc*scale, (ysc + region * 4)*scale);
 
-	// Draw orbits for each reference star
-	// Caclulate pixel values for the reference stars
-	PHD_Point starpx, stardeg;
-	double radpx;
-	for (int is = 0; is < poleStars->size(); is++)
-	{
-		stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
-		starpx = Radec2Px(stardeg);
-		radpx = sqrt(pow(m_CoRpx.X - starpx.X, 2) + pow(m_CoRpx.Y - starpx.Y, 2));
+    // Draw orbits for each reference star
+    // Caclulate pixel values for the reference stars
+    PHD_Point starpx, stardeg;
+    double radpx;
+    for (int is = 0; is < poleStars->size(); is++)
+    {
+        stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
+        starpx = Radec2Px(stardeg);
+        radpx = sqrt(pow(r_pxCentre.X - starpx.X, 2) + pow(r_pxCentre.Y - starpx.Y, 2));
 
-		dc.SetPen(wxPen(wxColor(255, 255, 0), 1, wxPENSTYLE_DOT));
-		if (is == m_refStar)
-		{
-			dc.SetPen(wxPen(wxColor(0, 255, 0), 1, wxPENSTYLE_DOT));
-		}
-		dc.DrawCircle(m_CoRpx.X * scale, m_CoRpx.Y * scale, radpx * scale);
-		dc.DrawCircle(starpx.X * scale, starpx.Y * scale, region*scale);
-	}
-	// Draw adjustment lines for centring the CoR on the display in blue (dec) and red (cone error)
-	bool drawCone = false;
-	if (drawCone){
-		double xr = m_CoRpx.X * scale;
-		double yr = m_CoRpx.Y * scale;
-		dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xr, yr, xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale);
-		dc.SetPen(wxPen(wxColor(0, 0, 255), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale,
-			xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
-			yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
-		dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xr, yr, xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
-			yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
-	}
-	// Draw adjustment lines for placing the guide star in its correct position relative to the CoR
-	// Blue (azimuth) and Red (altitude)
-	bool drawCorr = true;
-	if (drawCorr)
-	{
-		int idx;
-		idx = bauto ? 1 : 2;
-		double xs = m_Pospx[idx].X * scale;
-		double ys = m_Pospx[idx].Y * scale;
-		dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale);
-		dc.SetPen(wxPen(wxColor(0, 0, 255), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale,
-			xs + m_AltCorr.X * scale + m_AzCorr.X * scale, ys + m_AzCorr.Y * scale + m_AltCorr.Y * scale);
-		dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
-		dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale + m_AzCorr.X * scale,
-			ys + m_AltCorr.Y * scale + m_AzCorr.Y * scale);
-	}
+        dc.SetPen(wxPen(wxColor(255, 255, 0), 1, wxPENSTYLE_DOT));
+        if (is == a_refStar)
+        {
+            dc.SetPen(wxPen(wxColor(0, 255, 0), 1, wxPENSTYLE_DOT));
+        }
+        dc.DrawCircle(r_pxCentre.X * scale, r_pxCentre.Y * scale, radpx * scale);
+        dc.DrawCircle(starpx.X * scale, starpx.Y * scale, region*scale);
+    }
+    // Draw adjustment lines for centring the CoR on the display in blue (dec) and red (cone error)
+    bool drawCone = false;
+    if (drawCone){
+        double xr = r_pxCentre.X * scale;
+        double yr = r_pxCentre.Y * scale;
+        dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xr, yr, xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale);
+        dc.SetPen(wxPen(wxColor(0, 0, 255), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale,
+            xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
+            yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
+        dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xr, yr, xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
+            yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
+    }
+    // Draw adjustment lines for placing the guide star in its correct position relative to the CoR
+    // Blue (azimuth) and Red (altitude)
+    bool drawCorr = true;
+    if (drawCorr)
+    {
+        int idx;
+        idx = a_auto ? 1 : 2;
+        double xs = r_pxPos[idx].X * scale;
+        double ys = r_pxPos[idx].Y * scale;
+        dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale);
+        dc.SetPen(wxPen(wxColor(0, 0, 255), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale,
+            xs + m_AltCorr.X * scale + m_AzCorr.X * scale, ys + m_AzCorr.Y * scale + m_AltCorr.Y * scale);
+        dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+        dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale + m_AzCorr.X * scale,
+            ys + m_AltCorr.Y * scale + m_AzCorr.Y * scale);
+    }
 }
 
 bool StaticPaToolWin::RotateMount() 
 {
-	// Initially, assume an offset of 5.0 degrees of the camera from the CoR
-	// Calculate how far to move in RA to get a detectable arc
-	// Calculate the tangential ditance of that movement
-	// Mark the starting position then rotate the mount
-	if (m_numPos == 1)
-	{
-		SetStatusText(_("Polar align: star #1"));
-		Debug.AddLine("Polar align: star #1");
-		//   Initially offset is 5 degrees;
-		bool rc = SetParams(5.0); // m_rotdg, m_rotpx, m_nstep for assumed 5.0 degree PA error
-		Debug.AddLine(wxString::Format("Polar align: star #1 rotdg=%.1f nstep=%d", m_rotdg, m_nstep));
-		bool isset = SetStar(m_numPos);
-		if (isset)
-		{
-			state = state | (1 << 1);
-			m_numPos++;
-		}
-		if (!bauto)
-		{
-			aligning = false;
-		}
-		tottheta = 0.0;
-		nstep = 0;
-		Debug.AddLine(wxString::Format("Leave Polar align: star #1 rotdg=%.1f nstep=%d", m_rotdg, m_nstep));
-		return isset;
-	}
-	if (m_numPos == 2)
-	{
-		double theta = m_rotdg - tottheta;
-		SetStatusText(_("Polar align: star #2"));
-		Debug.AddLine("Polar align: star #2");
-		// Once the mount has rotated theta degrees (as indicated by prevtheta);
-		if (!bauto)
-		{
-			// rotate mount manually;
-			bool isset = SetStar(m_numPos);
-			if (isset)
-			{
-				state = state | (1 << 2);
-				m_numPos++;
-			}
-			aligning = false;
-			return isset;
-		}
-		SetStatusText(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
-		Debug.AddLine(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
-		if (tottheta < m_rotdg)
-		{
-			double newtheta = theta / (m_nstep - nstep);
-			MoveWestBy(newtheta);
-			tottheta += newtheta;
-			// Calclate how far the mount moved compared to the expected movement;
-			// This assumes that the mount was rotated through theta degrees;
-			// So theta is the total rotation needed for the current offset;
-			// And prevtheta is how we have already moved;
-			// Recalculate the offset based on the actual movement;
-		}
-		else
-		{
-			// Recalculate the offset. CAUTION: This might end up in an endless loop. 
-			bool isset = SetStar(m_numPos);
+    // Initially, assume an offset of 5.0 degrees of the camera from the CoR
+    // Calculate how far to move in RA to get a detectable arc
+    // Calculate the tangential ditance of that movement
+    // Mark the starting position then rotate the mount
+    if (s_numPos == 1)
+    {
+        SetStatusText(_("Polar align: star #1"));
+        Debug.AddLine("Polar align: star #1");
+        //   Initially offset is 5 degrees;
+        bool rc = SetParams(5.0); // s_reqRot, m_rotpx, s_reqStep for assumed 5.0 degree PA error
+        Debug.AddLine(wxString::Format("Polar align: star #1 rotdg=%.1f s_nStep=%d", s_reqRot, s_reqStep));
+        bool isset = SetStar(s_numPos);
+        if (isset)
+        {
+            s_state = s_state | (1 << 1);
+            s_numPos++;
+        }
+        if (!a_auto)
+        {
+            s_aligning = false;
+        }
+        s_totRot = 0.0;
+        s_nStep = 0;
+        Debug.AddLine(wxString::Format("Leave Polar align: star #1 rotdg=%.1f s_nStep=%d", s_reqRot, s_reqStep));
+        return isset;
+    }
+    if (s_numPos == 2)
+    {
+        double theta = s_reqRot - s_totRot;
+        SetStatusText(_("Polar align: star #2"));
+        Debug.AddLine("Polar align: star #2");
+        // Once the mount has rotated theta degrees (as indicated by prevtheta);
+        if (!a_auto)
+        {
+            // rotate mount manually;
+            bool isset = SetStar(s_numPos);
+            if (isset)
+            {
+                s_state = s_state | (1 << 2);
+                s_numPos++;
+            }
+            s_aligning = false;
+            return isset;
+        }
+        SetStatusText(wxString::Format("Polar align: star #2 s_nStep=%d / %d theta=%.1f / %.1f", s_nStep, s_reqStep, s_totRot, s_reqRot));
+        Debug.AddLine(wxString::Format("Polar align: star #2 s_nStep=%d / %d theta=%.1f / %.1f", s_nStep, s_reqStep, s_totRot, s_reqRot));
+        if (s_totRot < s_reqRot)
+        {
+            double newtheta = theta / (s_reqStep - s_nStep);
+            MoveWestBy(newtheta);
+            s_totRot += newtheta;
+            // Calclate how far the mount moved compared to the expected movement;
+            // This assumes that the mount was rotated through theta degrees;
+            // So theta is the total rotation needed for the current offset;
+            // And prevtheta is how we have already moved;
+            // Recalculate the offset based on the actual movement;
+        }
+        else
+        {
+            // Recalculate the offset. CAUTION: This might end up in an endless loop. 
+            bool isset = SetStar(s_numPos);
 
-			double actpix = sqrt(pow(m_Pospx[1].X - m_Pospx[0].X, 2) + pow(m_Pospx[1].Y - m_Pospx[0].Y, 2));
-			double actsec = actpix * m_pxScale;
-			double actoffsetdeg = 90 - degrees(acos(actsec / 3600 / m_rotdg));
-			Debug.AddLine(wxString::Format("Polar align: star #2 px=%.1f asec=%.1f pxscale=%.1f", actpix, actsec, m_pxScale));
+            double actpix = sqrt(pow(r_pxPos[1].X - r_pxPos[0].X, 2) + pow(r_pxPos[1].Y - r_pxPos[0].Y, 2));
+            double actsec = actpix * g_pxScale;
+            double actoffsetdeg = 90 - degrees(acos(actsec / 3600 / s_reqRot));
+            Debug.AddLine(wxString::Format("Polar align: star #2 px=%.1f asec=%.1f pxscale=%.1f", actpix, actsec, g_pxScale));
 
-			if (actoffsetdeg == 0)
-			{
-				Debug.AddLine(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
-				SetStatusText(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
-				//self.settings["msg"] = "Mount did not move - check settings";
-				PHD_Point cor = m_Pospx[m_numPos - 1];
-				return false;
-			}
-			double prev_rotdg = m_rotdg;
-			int prev_nstep = m_nstep;
-			// FIXME - alter setparams to take into account rotation so far
-			bool rc = SetParams(actoffsetdeg); // m_rotdg, m_rotpx, m_nstep for measures PA error
-			if (!rc)
-			{
-				aligning = false;
-				return false;
-			}
-			if (m_rotdg <= prev_rotdg) // Moved far enough: show the adjustment chart
-			{
-				if (!isset)
-				{
-					aligning = false;
-					return false;
-				}
-				state = state | (1 << 2);
-				m_numPos++;
-				nstep = 0;
-				tottheta = 0.0;
-				CalcRotationCentre();
-				m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
-				m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
-			}
-			else if (m_rotdg > 45)
-			{
-				Debug.AddLine(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, m_rotdg));
-				SetStatusText(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, m_rotdg));
-				PHD_Point cor = m_Pospx[m_numPos - 1];
-				aligning = false;
-				return false;
-			}
-			else
-			{
-				nstep = int(m_nstep * tottheta/m_rotdg);
-				Debug.AddLine(wxString::Format("Polar align: star #2 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
-			}
-		}
-		return true;
-	}
-	if (m_numPos == 3)
-	{
-		if (!bauto)
-		{
-			// rotate mount manually;
-			bool isset = SetStar(m_numPos);
-			if (isset)
-			{
-				state = state | (1 << 3);
-				m_numPos++;
-			}
-			aligning = false;
-			if (IsAligned()){
-				CalcRotationCentre();
-			}
-			return isset;
-		}
-		m_numPos++;
-		return true;
-	}
-	return true;
+            if (actoffsetdeg == 0)
+            {
+                Debug.AddLine(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
+                SetStatusText(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
+                //self.settings["msg"] = "Mount did not move - check settings";
+                PHD_Point cor = r_pxPos[s_numPos - 1];
+                return false;
+            }
+            double prev_rotdg = s_reqRot;
+            int prev_nstep = s_reqStep;
+            // FIXME - alter setparams to take into account rotation so far
+            bool rc = SetParams(actoffsetdeg); // s_reqRot, m_rotpx, s_reqStep for measures PA error
+            if (!rc)
+            {
+                s_aligning = false;
+                return false;
+            }
+            if (s_reqRot <= prev_rotdg) // Moved far enough: show the adjustment chart
+            {
+                if (!isset)
+                {
+                    s_aligning = false;
+                    return false;
+                }
+                s_state = s_state | (1 << 2);
+                s_numPos++;
+                s_nStep = 0;
+                s_totRot = 0.0;
+                CalcRotationCentre();
+                w_calPt[3][0]->SetValue(wxString::Format("%+.f", r_pxCentre.X));
+                w_calPt[3][1]->SetValue(wxString::Format("%+.f", r_pxCentre.Y));
+            }
+            else if (s_reqRot > 45)
+            {
+                Debug.AddLine(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, s_reqRot));
+                SetStatusText(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, s_reqRot));
+                PHD_Point cor = r_pxPos[s_numPos - 1];
+                s_aligning = false;
+                return false;
+            }
+            else
+            {
+                s_nStep = int(s_reqStep * s_totRot/s_reqRot);
+                Debug.AddLine(wxString::Format("Polar align: star #2 s_nStep=%d / %d theta=%.1f / %.1f", s_nStep, s_reqStep, s_totRot, s_reqRot));
+            }
+        }
+        return true;
+    }
+    if (s_numPos == 3)
+    {
+        if (!a_auto)
+        {
+            // rotate mount manually;
+            bool isset = SetStar(s_numPos);
+            if (isset)
+            {
+                s_state = s_state | (1 << 3);
+                s_numPos++;
+            }
+            s_aligning = false;
+            if (IsAligned()){
+                CalcRotationCentre();
+            }
+            return isset;
+        }
+        s_numPos++;
+        return true;
+    }
+    return true;
 }
 
 bool StaticPaToolWin::SetStar(int npos)
 {
-	int idx = npos - 1;
-	// Get X and Y coords from PHD2;
-	// idx: 0=B, 1/2/3 = A[idx];
-	double cur_dec, cur_st;
-	if (bauto && pPointingSource->GetCoordinates(&m_ra_rot[idx], &cur_dec, &cur_st))
-	{
-		Debug.AddLine("SetStar: failed to get scope coordinates");
-		return false;
-	}
-	m_Pospx[idx].X = -1;
-	m_Pospx[idx].Y = -1;
-	PHD_Point star = pFrame->pGuider->CurrentPosition();
-	m_Pospx[idx] = star;
-	m_calPt[idx][0]->SetValue(wxString::Format("%+.f", m_Pospx[idx].X));
-	m_calPt[idx][1]->SetValue(wxString::Format("%+.f", m_Pospx[idx].Y));
+    int idx = npos - 1;
+    // Get X and Y coords from PHD2;
+    // idx: 0=B, 1/2/3 = A[idx];
+    double cur_dec, cur_st;
+    if (a_auto && pPointingSource->GetCoordinates(&r_raPos[idx], &cur_dec, &cur_st))
+    {
+        Debug.AddLine("SetStar: failed to get scope coordinates");
+        return false;
+    }
+    r_pxPos[idx].X = -1;
+    r_pxPos[idx].Y = -1;
+    PHD_Point star = pFrame->pGuider->CurrentPosition();
+    r_pxPos[idx] = star;
+    w_calPt[idx][0]->SetValue(wxString::Format("%+.f", r_pxPos[idx].X));
+    w_calPt[idx][1]->SetValue(wxString::Format("%+.f", r_pxPos[idx].Y));
 
-	Debug.AddLine(wxString::Format("Setstar #%d %.0f, %.0f", npos, m_Pospx[idx].X, m_Pospx[idx].Y));
-	SetStatusText(wxString::Format("Setstar #%d %.0f, %.0f", npos, m_Pospx[idx].X, m_Pospx[idx].Y));
-	return star.IsValid();
+    Debug.AddLine(wxString::Format("Setstar #%d %.0f, %.0f", npos, r_pxPos[idx].X, r_pxPos[idx].Y));
+    SetStatusText(wxString::Format("Setstar #%d %.0f, %.0f", npos, r_pxPos[idx].X, r_pxPos[idx].Y));
+    return star.IsValid();
 }
 
 bool StaticPaToolWin::SetParams(double newoffset)
 {
-	double offsetdeg = newoffset;
-	double m_offsetpx = offsetdeg * 3600 / m_pxScale;
-	Debug.AddLine(wxString::Format("PA setparams(new=%.1f) px=%.1f offset=%.1f dev=%.1f", newoffset, m_pxScale, m_offsetpx, m_devpx));
-	if (m_offsetpx < m_devpx)
-	{
-		Debug.AddLine(wxString::Format("PA setparams() Too close to CoR: offsetpx=%.1f devpx=%.1f", m_offsetpx, m_devpx));
-		return false;
-	}
-	m_rotdg = degrees(acos(1 - m_devpx / m_offsetpx));
-	double m_rotpx = m_rotdg * 3600.0 / m_pxScale * sin(radians(offsetdeg));
+    double offsetdeg = newoffset;
+    double m_offsetpx = offsetdeg * 3600 / g_pxScale;
+    Debug.AddLine(wxString::Format("PA setparams(new=%.1f) px=%.1f offset=%.1f dev=%.1f", newoffset, g_pxScale, m_offsetpx, a_devpx));
+    if (m_offsetpx < a_devpx)
+    {
+        Debug.AddLine(wxString::Format("PA setparams() Too close to CoR: offsetpx=%.1f devpx=%.1f", m_offsetpx, a_devpx));
+        return false;
+    }
+    s_reqRot = degrees(acos(1 - a_devpx / m_offsetpx));
+    double m_rotpx = s_reqRot * 3600.0 / g_pxScale * sin(radians(offsetdeg));
 
-	int region = pFrame->pGuider->GetSearchRegion();
-	m_nstep = 1;
-	if (m_rotpx > region)
-	{
-		m_nstep = int(ceil(m_rotpx / region));
-	}
-	Debug.AddLine(wxString::Format("PA setparams() rotdg=%.1f rotpx=%.1f nstep=%d region=%d", m_rotdg, m_rotpx, m_nstep, region));
-	return true;
+    int region = pFrame->pGuider->GetSearchRegion();
+    s_reqStep = 1;
+    if (m_rotpx > region)
+    {
+        s_reqStep = int(ceil(m_rotpx / region));
+    }
+    Debug.AddLine(wxString::Format("PA setparams() rotdg=%.1f rotpx=%.1f s_nStep=%d region=%d", s_reqRot, m_rotpx, s_reqStep, region));
+    return true;
 }
 void StaticPaToolWin::MoveWestBy(double thetadeg)
 {
-	bool m_can_slew = pPointingSource && pPointingSource->CanSlew();
-	double cur_ra, cur_dec, cur_st;
-	if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
-	{
-		Debug.AddLine("Rotate tool: slew failed to get scope coordinates");
-		return;
-	}
-	double slew_ra = cur_ra - thetadeg * 24.0 / 360.0;
+    bool m_can_slew = pPointingSource && pPointingSource->CanSlew();
+    double cur_ra, cur_dec, cur_st;
+    if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
+    {
+        Debug.AddLine("Rotate tool: slew failed to get scope coordinates");
+        return;
+    }
+    double slew_ra = cur_ra - thetadeg * 24.0 / 360.0;
 
-	if (slew_ra >= 24.0)
-		slew_ra -= 24.0;
-	else if (slew_ra < 0.0)
-		slew_ra += 24.0;
+    if (slew_ra >= 24.0)
+        slew_ra -= 24.0;
+    else if (slew_ra < 0.0)
+        slew_ra += 24.0;
 
-	if (pPointingSource->SlewToCoordinates(slew_ra, cur_dec))
-	{
-		Debug.AddLine("Rotate tool: slew failed");
-	}
-	nstep++;
-	PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
-	bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
+    if (pPointingSource->SlewToCoordinates(slew_ra, cur_dec))
+    {
+        Debug.AddLine("Rotate tool: slew failed");
+    }
+    s_nStep++;
+    PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
+    bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
 }
 
 void StaticPaToolWin::CreateStarTemplate(wxDC& dc)
 {
-	dc.SetBackground(*wxGREY_BRUSH);
-	dc.Clear();
+    dc.SetBackground(*wxGREY_BRUSH);
+    dc.Clear();
 
-	double scale = 320.0 / m_camXpx;
-	int region = 5;
+    double scale = 320.0 / g_camWidth;
+    int region = 5;
 
-//	memDC.SetTextForeground(*wxLIGHT_GREY);
-	dc.SetTextForeground(*wxYELLOW);
-	const wxFont& SmallFont =
+//    memDC.SetTextForeground(*wxLIGHT_GREY);
+    dc.SetTextForeground(*wxYELLOW);
+    const wxFont& SmallFont =
 #if defined(__WXOSX__)
-		*wxSMALL_FONT;
+        *wxSMALL_FONT;
 #else
-		*wxSWISS_FONT;
+        *wxSWISS_FONT;
 #endif
-	dc.SetFont(SmallFont);
+    dc.SetFont(SmallFont);
 
-	const std::string alpha = "ABCDEFGHIJKL";
-	PHD_Point starpx, stardeg;
-	double starsz, starmag;
-	// Draw orbits for each alignment star
-	for (int is = 4; is < poleStars->size(); is++)
+    const std::string alpha = "ABCDEFGHIJKL";
+    PHD_Point starpx, stardeg;
+    double starsz, starmag;
+    // Draw orbits for each alignment star
+    for (int is = 4; is < poleStars->size(); is++)
 // for (int is = 0; is < poleStars->size(); is++)
-		{
-		stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
-		starmag = poleStars->at(is).mag;
+        {
+        stardeg = PHD_Point(poleStars->at(is).ra, poleStars->at(is).dec);
+        starmag = poleStars->at(is).mag;
 
-		starsz = 356.0*exp(-0.3*starmag) / m_pxScale;
-		starpx = Radec2Px(stardeg);
-		dc.SetPen(*wxYELLOW_PEN);
-		dc.SetBrush(*wxYELLOW_BRUSH);
+        starsz = 356.0*exp(-0.3*starmag) / g_pxScale;
+        starpx = Radec2Px(stardeg);
+        dc.SetPen(*wxYELLOW_PEN);
+        dc.SetBrush(*wxYELLOW_BRUSH);
 
-		dc.DrawCircle(starpx.X * scale, starpx.Y * scale, starsz*scale);
-		dc.DrawText(wxString::Format("%c", alpha[is]), (starpx.X + starsz) * scale, starpx.Y * scale);
-	}
-	// draw the centre of the circle as a red cross
-	dc.SetBrush(*wxTRANSPARENT_BRUSH);
-	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
-	dc.DrawLine((m_CoRpx.X - region)*scale, m_CoRpx.Y*scale, (m_CoRpx.X + region)*scale, m_CoRpx.Y*scale);
-	dc.DrawLine(m_CoRpx.X*scale, (m_CoRpx.Y - region)*scale, m_CoRpx.X*scale, (m_CoRpx.Y + region)*scale);
-	return;
+        dc.DrawCircle(starpx.X * scale, starpx.Y * scale, starsz*scale);
+        dc.DrawText(wxString::Format("%c", alpha[is]), (starpx.X + starsz) * scale, starpx.Y * scale);
+    }
+    // draw the centre of the circle as a red cross
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+    dc.DrawLine((r_pxCentre.X - region)*scale, r_pxCentre.Y*scale, (r_pxCentre.X + region)*scale, r_pxCentre.Y*scale);
+    dc.DrawLine(r_pxCentre.X*scale, (r_pxCentre.Y - region)*scale, r_pxCentre.X*scale, (r_pxCentre.Y + region)*scale);
+    return;
 }
 
 

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -1,0 +1,1020 @@
+/*
+ *  staticpa_toolwin.cpp
+ *  PHD Guiding
+ *
+ *  Created by Ken Self
+ *  Copyright (c) 2017 Ken Self
+ *  All rights reserved.
+ *
+ *  This source code is distributed under the following "BSD" license
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *    Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *    Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "phd.h"
+#include "staticpa_tool.h"
+#include "staticpa_toolwin.h"
+
+#include <wx/gbsizer.h>
+#include <wx/valnum.h>
+#include <wx/textwrapper.h>
+
+static const std::string  SthStarName[] = {
+"sigma Oct", "HD99828", "HD125371", "HD90105",
+"BQ Oct", "HD99685", "TYC9518-405-1"
+};
+static const double SthStarRa[] = { 320.66, 164.22, 248.88, 122.36, 239.62, 130.32, 102.04 };
+static const double SthStarDec[] = { -88.89, -89.33, -89.38, -89.52, -89.83, -89.85, -89.88 };
+static const std::string NthStarName[] = {
+	"Polaris", "HD1687", "TYC4629-37-1", "TYC4661-2-1"
+};
+static const double NthStarRa[] = { 43.12, 12.14, 85.51, 297.95 };
+static const double NthStarDec[] = { 89.34, 89.54, 89.65, 89.83 };
+
+//==================================
+BEGIN_EVENT_TABLE(StaticPaToolWin, wxFrame)
+//EVT_BUTTON(ID_SLEW, StaticPaToolWin::OnSlew)
+EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
+EVT_BUTTON(ID_ADJUST, StaticPaToolWin::OnAdjust)
+EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
+EVT_CHOICE(ID_ALIGNSTAR, StaticPaToolWin::OnAlignStar)
+//EVT_COMMAND(wxID_ANY, APPSTATE_NOTIFY_EVENT, StaticPaToolWin::OnAppStateNotify)
+EVT_CLOSE(StaticPaToolWin::OnClose)
+END_EVENT_TABLE()
+
+StaticPaToolWin::StaticPaToolWin()
+: wxFrame(pFrame, wxID_ANY, _("Static Polar Alignment"), wxDefaultPosition, wxDefaultSize,
+wxCAPTION | wxCLOSE_BOX | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxFRAME_FLOAT_ON_PARENT | wxFRAME_NO_TASKBAR),
+m_slewing(false), m_devpx(8)
+{
+	pFrame->pGuider->pStaticPaTool = this;
+	m_numPos = 0;
+	
+	SetBackgroundColour(wxColor(0xcccccc));
+
+	SetSizeHints(wxDefaultSize, wxDefaultSize);
+
+	// get site lat/long from scope
+	double lat, lon;
+	m_siteLatLong.Invalidate();
+	if (pPointingSource && !pPointingSource->GetSiteLatLong(&lat, &lon))
+	{
+		m_siteLatLong.SetXY(lon, lat);
+	}
+	m_pxScale = pFrame->GetCameraPixelScale();
+
+	wxCommandEvent dummy;
+	if (!pFrame->CaptureActive)
+	{
+		// loop exposures
+		SetStatusText(_("Start Looping..."));
+		pFrame->OnLoopExposure(dummy);
+	}
+
+	// a vertical sizer holding everything
+	wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+
+	// a horizontal box sizer for the bitmap and the instructions
+	wxBoxSizer *instrSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	m_instructions = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(400, 120), wxALIGN_LEFT | wxST_NO_AUTORESIZE);
+#ifdef __WXOSX__
+	m_instructions->SetFont(*wxSMALL_FONT);
+#endif
+	m_instructions->Wrap(-1);
+	instrSizer->Add(m_instructions, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+
+	topSizer->Add(instrSizer);
+
+	// static box sizer holding the scope pointing controls
+	wxStaticBoxSizer *sbSizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Scope Pointing")), wxVERTICAL);
+
+	// a grid box sizer for laying out scope pointing the controls
+	wxGridBagSizer *gbSizer = new wxGridBagSizer(0, 0);
+	gbSizer->SetFlexibleDirection(wxBOTH);
+	gbSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+	wxStaticText *txt;
+
+// Alignment star specification
+	txt = new wxStaticText(this, wxID_ANY, _("Alignment Star"));
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Right Ascen (" DEGREES_SYMBOL ")"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 1), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Declination (" DEGREES_SYMBOL ")"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(0, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	// Drop down list box for alignment star
+	int nstar = (lat < 0) ? 7 : 4;
+	m_nstar = nstar;
+	wxArrayString choices;
+	std::string starname;
+	for (int is = 0; is < nstar; is++) {
+		starname = (lat < 0) ? SthStarName[is] : NthStarName[is];
+		choices.Add(_(starname));
+	}
+	alignStarChoice = new wxChoice(this, ID_ALIGNSTAR, wxDefaultPosition, wxDefaultSize, choices);
+	alignStarChoice->SetToolTip(_("Select the star used for checking alignment."));
+	gbSizer->Add(alignStarChoice, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	m_raCurrent = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_raCurrent, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_decCurrent = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_decCurrent, wxGBPosition(1, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Site"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Lat"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(2, 1), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Lon"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(2, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Camera Rot"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(2, 3), wxGBSpan(1, 1), wxALL, 5);
+
+	m_siteLat = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_siteLat, wxGBPosition(3, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_siteLon = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_siteLon, wxGBPosition(3, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_camRot = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_camRot, wxGBPosition(3, 3), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("X px"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(4, 1), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Y px"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(4, 2), wxGBSpan(1, 1), wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Pt #1"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(5, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	m_calPt[0][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[0][0], wxGBPosition(5, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_calPt[0][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[0][1], wxGBPosition(5, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Pt #2"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(6, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	m_calPt[1][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[1][0], wxGBPosition(6, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_calPt[1][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[1][1], wxGBPosition(6, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Pt #3"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(7, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	m_calPt[2][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[2][0], wxGBPosition(7, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_calPt[2][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[2][1], wxGBPosition(7, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	txt = new wxStaticText(this, wxID_ANY, _("Centre"), wxDefaultPosition, wxDefaultSize, 0);
+	txt->Wrap(-1);
+	gbSizer->Add(txt, wxGBPosition(8, 0), wxGBSpan(1, 1), wxALL, 5);
+
+	m_calPt[3][0] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[3][0], wxGBPosition(8, 1), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	m_calPt[3][1] = new wxTextCtrl(this, wxID_ANY, _T("--"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	gbSizer->Add(m_calPt[3][1], wxGBPosition(8, 2), wxGBSpan(1, 1), wxEXPAND | wxALL, 5);
+
+	// add grid bag sizer to static sizer
+	sbSizer->Add(gbSizer, 1, wxALIGN_CENTER, 5);
+
+	// add static sizer to top-level sizer
+	topSizer->Add(sbSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+
+	// add some padding below the static sizer
+	topSizer->Add(0, 3, 0, wxEXPAND, 3);
+
+	m_notesLabel = new wxStaticText(this, wxID_ANY, _("Altitude adjustment notes"), wxDefaultPosition, wxDefaultSize, 0);
+	m_notesLabel->Wrap(-1);
+	topSizer->Add(m_notesLabel, 0, wxEXPAND | wxTOP | wxLEFT, 8);
+
+	m_notes = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(-1, 54), wxTE_MULTILINE);
+	pFrame->RegisterTextCtrl(m_notes);
+	topSizer->Add(m_notes, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	//m_notes->Bind(wxEVT_COMMAND_TEXT_UPDATED, &StaticPaToolWin::OnNotesText, this);
+
+	// horizontal sizer for the buttons
+	wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	// proportional pad on left of Rotate button
+	hSizer->Add(0, 0, 2, wxEXPAND, 5);
+
+	m_rotate = new wxButton(this, ID_ROTATE, _("Rotate"), wxDefaultPosition, wxDefaultSize, 0);
+	hSizer->Add(m_rotate, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+	// proportional pad on right of Rotate button
+	hSizer->Add(0, 0, 1, wxEXPAND, 5);
+
+	m_adjust = new wxButton(this, ID_ADJUST, _("Adjust"), wxDefaultPosition, wxDefaultSize, 0);
+	hSizer->Add(m_adjust, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+	// proportional pad on right of Align button
+	hSizer->Add(0, 0, 2, wxEXPAND, 5);
+
+	m_close = new wxButton(this, ID_CLOSE, _("Close"), wxDefaultPosition, wxDefaultSize, 0);
+	hSizer->Add(m_close, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+	//m_phaseBtn = new wxButton(this, ID_PHASE, wxT("???"), wxDefaultPosition, wxDefaultSize, 0);
+	//hSizer->Add(m_phaseBtn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	// add button sizer to top level sizer
+	topSizer->Add(hSizer, 1, wxEXPAND | wxALL, 5);
+
+	SetSizer(topSizer);
+
+	m_statusBar = CreateStatusBar(1, wxST_SIZEGRIP, wxID_ANY);
+
+	Layout();
+	topSizer->Fit(this);
+
+	int xpos = pConfig->Global.GetInt("/StaticPaTool/pos.x", -1);
+	int ypos = pConfig->Global.GetInt("/StaticPaTool/pos.y", -1);
+	MyFrame::PlaceWindowOnScreen(this, xpos, ypos);
+
+	m_instructions->SetLabel(
+		_("Slew to near the Celestial Pole.\n"
+		"Choose an Alignment Star from the list.\n"
+		"Select it as the guide star on the display.\n"
+		"Press Rotate to calibrate the RA Axis.\n"
+		"Wait for all three calibration points to be measured.\n"
+		"Press Adjust to display the adjustments needed.\n"
+		"Adjust your mount's altitude and azimuth as displayed."
+		));
+
+	// can mount slew?
+	bool m_can_slew = pPointingSource && pPointingSource->CanSlew();
+	alignStarChoice->Select(pConfig->Profile.GetInt("/StaticPaTool/AlignStar", 4) - 1);
+	UpdateAlignStar();
+
+	m_siteLat->SetValue(wxString::Format("%+.3f", lat));
+	m_siteLon->SetValue(wxString::Format("%+.3f", lon));
+
+	double xangle=0.0, yangle;
+	if (pMount && pMount->IsConnected() && pMount->IsCalibrated())
+	{
+		xangle = degrees(pMount->xAngle());
+		yangle = degrees(pMount->yAngle());
+	}
+	m_camRot->SetValue(wxString::Format("%+.3f", xangle));
+	m_dCamRot = xangle;
+
+	m_timer = NULL;
+
+	//m_phase = PHASE_ADJUST_AZ;
+	m_mode = MODE_IDLE;
+	//m_location_prompt_done = false;
+	//UpdatePhaseState();
+	UpdateModeState();
+}
+
+StaticPaToolWin::~StaticPaToolWin()
+{
+	pFrame->pGuider->pStaticPaTool = NULL;
+	pFrame->pStaticPaTool = NULL;
+}
+/*
+void StaticPaToolWin::EnableSlew(bool enable)
+{
+}
+*/
+void StaticPaToolWin::UpdateModeState()
+{
+	wxCommandEvent dummy;
+	wxString idleStatus;
+
+repeat:
+
+	if (m_mode == MODE_ROTATE)
+	{
+		//m_rotate->Enable(false);
+		m_rotate->Enable(true);
+		m_adjust->Enable(true);
+//		EnableSlew(false);
+
+		// restore subframes setting
+		//pCamera->UseSubframes = m_save_use_subframes;
+
+		if (!m_rotating)
+		{
+			if (!pCamera->Connected ||
+				!pMount || !pMount->IsConnected())
+			{
+				idleStatus = _("Please connect a camera and a mount");
+				m_mode = MODE_IDLE;
+				goto repeat;
+			}
+
+			if (!pMount->IsCalibrated())
+			{
+				idleStatus = _("Please calibrate before starting static alignment");
+				m_mode = MODE_IDLE;
+				goto repeat;
+			}
+
+			if (!pFrame->CaptureActive)
+			{
+				// loop exposures
+				SetStatusText(_("Start Looping..."));
+				pFrame->OnLoopExposure(dummy);
+				return;
+			}
+			/*
+			switch (pFrame->pGuider->GetState())
+			{
+			case STATE_UNINITIALIZED:
+			case STATE_CALIBRATED:
+			case STATE_SELECTING:
+				if (!pFrame->pGuider->IsLocked())
+				{
+					SetStatusText(_("Auto-selecting a star"));
+					pFrame->OnAutoStar(dummy);
+				}
+				return;
+			case STATE_CALIBRATING_PRIMARY:
+			case STATE_CALIBRATING_SECONDARY:
+				if (!pMount->IsCalibrated())
+					SetStatusText(_("Waiting for calibration to complete..."));
+				return;
+			case STATE_SELECTED:
+			case STATE_GUIDING:
+				SetStatusText(_("Start Looping..."));
+				pFrame->OnLoopExposure(dummy);
+				return;
+				m_rotating = true;
+				return;
+			case STATE_STOP:
+				return;
+			}
+			*/
+		}
+	}
+	else if (m_mode == MODE_ADJUST)
+	{
+		m_rotate->Enable(true);
+		m_adjust->Enable(false);
+		m_rotating = false;
+//		EnableSlew(m_can_slew);
+		SetStatusText(_("Adjust altitude and azimuth, click Rotate when done") );
+
+		// use full frames for adjust phase
+		pCamera->UseSubframes = false;
+
+		if (pFrame->pGuider->IsGuiding())
+		{
+			// stop guiding but continue looping
+			pFrame->OnLoopExposure(dummy);
+
+			// Set the lock position to the where the star has rotateed to. This will be the center of the polar align circle.
+			pFrame->pGuider->SetLockPosition(pFrame->pGuider->CurrentPosition());
+			pFrame->pGraphLog->Refresh();  // polar align circle is updated in graph window"s OnPaint handler
+		}
+	}
+	else // MODE_IDLE
+	{
+	}
+}
+void StaticPaToolWin::UpdateAlignStar()
+{
+	int i_alignStar = alignStarChoice->GetSelection();
+	pConfig->Profile.SetInt("/StaticPaTool/AlignStar", alignStarChoice->GetSelection() + 1);
+
+	double ra_deg = m_siteLatLong.Y < 0 ? SthStarRa[i_alignStar] : NthStarRa[i_alignStar];
+	double dec_deg = m_siteLatLong.Y < 0 ? SthStarDec[i_alignStar] : NthStarDec[i_alignStar];
+
+	m_alignStar = i_alignStar;
+	m_alignStar = i_alignStar;
+
+	m_raCurrent->SetValue(wxString::Format("%+.2f", ra_deg));
+	m_decCurrent->SetValue(wxString::Format("%+.2f", dec_deg));
+
+}
+
+//void StaticPaToolWin::OnSlew(wxCommandEvent& evt)
+//{
+//	double cur_ra, cur_dec, cur_st;
+//	if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
+//	{
+//		Debug.AddLine("Rotate tool: slew failed to get scope coordinates");
+//		return;
+//	}
+//
+//	double slew_ra = 0; // cur_st + (raSlew * 24.0 / 360.0);
+//	if (slew_ra >= 24.0)
+//		slew_ra -= 24.0;
+//	else if (slew_ra < 0.0)
+//		slew_ra += 24.0;
+//
+//	//Debug.AddLine(wxString::Format("Rotate tool slew from ra %.2f, dec %.1f to ra %.2f, dec %.1f",
+//	//	cur_ra, cur_dec, slew_ra, decSlew));
+//
+//	if (pPointingSource->CanSlewAsync())
+//	{
+//		struct SlewInBg : public RunInBg
+//		{
+//			double ra, dec;
+//			SlewInBg(wxWindow *parent, double ra_, double dec_)
+//				: RunInBg(parent, _("Slew"), _("Slewing...")), ra(ra_), dec(dec_)
+//			{
+//				SetPopupDelay(100);
+//			}
+//			bool Entry()
+//			{
+//				bool err = pPointingSource->SlewToCoordinatesAsync(ra, dec);
+//				if (err)
+//				{
+//					SetErrorMsg(_("Slew failed!"));
+//					return true;
+//				}
+//				while (pPointingSource->Slewing())
+//				{
+//					wxMilliSleep(500);
+//					if (IsCanceled())
+//					{
+//						pPointingSource->AbortSlew();
+//						SetErrorMsg(_("Slew was canceled"));
+//						break;
+//					}
+//				}
+//				return false;
+//			}
+//		};
+//	}
+//	else
+//	{
+//		wxBusyCursor busy;
+//	}
+//}
+
+void StaticPaToolWin::OnRotate(wxCommandEvent& evt)
+{
+//	m_mode = MODE_ROTATE;
+	UpdateModeState();
+	aligning = false;
+	m_numPos = 1;
+
+	if (pFrame->pGuider->IsCalibratingOrGuiding() )
+	{
+		SetStatusText(_("Please wait till Calibration is done and/or stop guiding"));
+		return;
+	}
+	if (!pFrame->pGuider->IsLocked())
+	{
+		SetStatusText(_("Please select a star"));
+		return;
+	}
+	aligning = true;
+	/*
+	double testCal[][2] = { { 293.11, 151.18 }, { 274.19, 189.42 }, { 288.95, 256.06 } };
+	for (int i = 0; i < 3; i++)
+	{
+			m_Pospx[i].X = testCal[i][0];
+			m_Pospx[i].Y = testCal[i][1];
+			m_calPt[i][0]->SetValue(wxString::Format("%+.f", m_Pospx[i].X));
+			m_calPt[i][1]->SetValue(wxString::Format("%+.f", m_Pospx[i].Y));
+	}
+	m_numPos = 3;
+	CalcRotationCentre();
+	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
+	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
+	aligning = false;
+	*/
+	m_mode = MODE_ROTATE;
+	UpdateModeState();
+}
+
+void StaticPaToolWin::OnAdjust(wxCommandEvent& evt)
+{
+	m_numPos = 3;
+	CalcRotationCentre();
+	m_calPt[3][0]->SetValue(wxString::Format("%+.f", m_CoRpx.X));
+	m_calPt[3][1]->SetValue(wxString::Format("%+.f", m_CoRpx.Y));
+
+	m_mode = MODE_ROTATE;
+	m_mode = MODE_ADJUST;
+	UpdateModeState();
+}
+
+void StaticPaToolWin::OnAlignStar(wxCommandEvent& evt)
+{
+	UpdateAlignStar();
+}
+
+//void StaticPaToolWin::OnAppStateNotify(wxCommandEvent& evt)
+//{
+//	UpdateModeState();
+//}
+
+void StaticPaToolWin::OnCloseBtn(wxCommandEvent& evt)
+{
+	Debug.AddLine("Close StaticPaTool");
+	if (IsAligning())
+	{
+		aligning = false;
+	}
+	Destroy();
+}
+
+void StaticPaToolWin::OnClose(wxCloseEvent& evt)
+{
+	Debug.AddLine("Close StaticPaTool");
+	Destroy();
+}
+
+void StaticPaToolWin::CalcRotationCentre(void)
+{
+	double x1, y1, x2, y2, x3, y3;
+	double a, b, c, e, f, g, i, j, k;
+	double m11, m12, m13, m14;
+	double cx, cy, cr;
+	x1 = m_Pospx[0].X;
+	y1 = m_Pospx[0].Y;
+	x2 = m_Pospx[1].X;
+	y2 = m_Pospx[1].Y;
+	x3 = m_Pospx[2].X;
+	y3 = m_Pospx[2].Y;
+	a = x1 * x1 + y1 * y1;
+	b = x1;
+	c = y1;
+	e = x2 * x2 + y2 * y2;
+	f = x2;
+	g = y2;
+	i = x3 * x3 + y3 * y3;
+	j = x3;
+	k = y3;
+	m11 = b * g + c * j + f * k - g * j - c * f - b * k;
+	m12 = a * g + c * i + e * k - g * i - c * e - a * k;
+	m13 = a * f + b * i + e * j - f * i - b * e - a * j;
+	m14 = a * f * k + b * g * i + c * e * j - c * f * i - b * e * k - a * g * j;
+	cx = (1. / 2.) * m12 / m11;
+	cy = (-1. / 2.) * m13 / m11;
+	cr = sqrt(cx * cx + cy *cy + m14 / m11);
+
+	// |A| = aei + bfg + cdh -ceg -bdi -afh
+	// a b c
+	// d e f
+	// g h i
+	// a= x1^2+y1^2; b=x1; c=y1; d=1
+	// e= x2^2+y2^2; f=x2; g=y2; h=1
+	// i= x3^2+y3^2; j=x3; k=y3; l=1
+	//
+	// x0 = 1/2.|M12|/|M11|
+	// y0 = -1/2.|M13|/|M11|
+	// r = x0^2 + y0^2 + |M14| / |M11|
+
+	m_CoRpx.X = cx;
+	m_CoRpx.Y = cy;
+	m_Radius = cr;
+
+	usImage *pCurrImg = pFrame->pGuider->CurrentImage();
+	wxImage *pDispImg = pFrame->pGuider->DisplayedImage();
+	double scalefactor = pFrame->pGuider->ScaleFactor();
+	int xpx = pDispImg->GetWidth();
+	int ypx = pDispImg->GetHeight();
+	m_dispSz[0] = xpx;
+	m_dispSz[1] = ypx;
+
+// Diatance and angle of CoR from centre of sensor
+	double cor_r = sqrt(pow(xpx / 2 - cx, 2) + pow(ypx / 2 - cy, 2));
+	double cor_a = degrees(atan2((ypx / 2 - cy), (xpx / 2 - cx)));
+	double rarot = -m_dCamRot;
+// Cone and Dec components of CoR vector
+	double dec_r = cor_r * sin(radians(cor_a - rarot));
+	m_DecCorr.X = -dec_r * sin(radians(rarot));
+	m_DecCorr.Y = dec_r * cos(radians(rarot));
+	double cone_r = cor_r * cos(radians(cor_a - rarot));
+	m_ConeCorr.X = cone_r * cos(radians(rarot));
+	m_ConeCorr.Y = cone_r * sin(radians(rarot));
+	double decCorr_deg = dec_r * m_pxScale / 3600;
+
+// Caclulate pixel values for the alignment stars
+	PHD_Point starpx, stardeg;
+	for (int is = 0; is < m_nstar; is++)
+	{
+		stardeg = (m_siteLatLong.Y < 0) ? PHD_Point(SthStarRa[is], SthStarDec[is]) : PHD_Point(NthStarRa[is], NthStarDec[is]);
+		starpx = Radec2Px(stardeg );
+		m_starpx[is][0] = starpx.X;
+		m_starpx[is][1] = starpx.Y;
+		m_starpx[is][2] = sqrt(pow(cx - starpx.X, 2) + pow(cy - starpx.Y, 2));
+	}
+
+	double xs = m_Pospx[2].X;
+	double ys = m_Pospx[2].Y;
+	double xt = m_starpx[m_alignStar][0];
+	double yt = m_starpx[m_alignStar][1];
+
+	//	// Calculate the camera rotation from the Azimuth axis
+	//	// Alt angle aligns to HA=0, Azimuth (East) to HA = -90
+	//	// In home position Az aligns with Dec
+	//	// So at HA +/-90 (home pos) Alt rotation is 0 (HA+90)
+	//	// At the meridian, HA=0 Alt aligns with dec so Rotation is +/-90
+	//	// Let harot =  camera rotation from Alt axis
+	//	// Alt axis is at HA+90
+	//	// This is camera rotation from RA minus(?) LST angle 
+	double	hcor_r = sqrt(pow(xt - xs, 2) + pow(yt - ys, 2));
+	double	hcor_a = degrees(atan2((yt - ys), (xt - xs)));
+	double ra_hrs, dec_deg, st_hrs;
+	pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs);
+	double harot = rarot - (90 + (st_hrs - ra_hrs)*15.0);
+	double hrot = hcor_a - harot;
+
+	double az_r = hcor_r * sin(radians(hrot));
+	double alt_r = hcor_r * cos(radians(hrot));
+
+	m_AzCorr.X = -az_r * sin(radians(harot));
+	m_AzCorr.Y = az_r * cos(radians(harot));
+	m_AltCorr.X = alt_r * cos(radians(harot));
+	m_AltCorr.Y = alt_r * sin(radians(harot));
+
+}
+
+PHD_Point StaticPaToolWin::Radec2Px( PHD_Point radec )
+{
+// Convert dec to pixel radius
+	double r = (90.0 - fabs(radec.Y)) * 3600 / m_pxScale;
+
+// Rotate by calibration angle and HA f object taking into account mount rotation (HA)
+	double ra_hrs, dec_deg, st_hrs;
+	pPointingSource->GetCoordinates(&ra_hrs, &dec_deg, &st_hrs);
+
+// Target hour angle - or rather the rotation needed to correct. 
+// FIXME: check if dec-deg should be that of the mount or the target or the hemisphere
+	double t_ha = st_hrs*15.0 + copysign(radec.X, radec.X);
+	double a = t_ha + m_dCamRot + (st_hrs - ra_hrs)*15.0;
+
+	PHD_Point px(m_CoRpx.X + r * cos(radians(a)), m_CoRpx.Y + r * sin(radians(a)));
+	return px;
+}
+
+wxWindow *StaticPaTool::CreateStaticPaToolWindow()
+{
+	if (!pCamera)
+	{
+		wxMessageBox(_("Please connect a camera first."));
+		return 0;
+	}
+
+	// confirm that image scale is specified
+
+	if (pFrame->GetCameraPixelScale() == 1.0)
+	{
+		bool confirmed = ConfirmDialog::Confirm(_(
+			"The Rotate Align tool is most effective when PHD2 knows your guide\n"
+			"scope focal length and camera pixel size.\n"
+			"\n"
+			"Enter your guide scope focal length on the Global tab in the Brain.\n"
+			"Enter your camera pixel size on the Camera tab in the Brain.\n"
+			"\n"
+			"Would you like to run the rotate tool anyway?"),
+			"/rotate_tool_without_pixscale");
+
+		if (!confirmed)
+		{
+			return 0;
+		}
+	}
+	if (pFrame->pGuider->IsCalibratingOrGuiding() )
+	{
+		wxMessageBox(_("Please wait till Calibration is done and stop guiding"));
+		return 0;
+	}
+
+	return new StaticPaToolWin();
+}
+
+void StaticPaToolWin::PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale)
+{
+	dc.SetPen(wxPen(wxColour(0, 255, 255), 1, wxSOLID));
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+
+	for (int i = 0; i < m_numPos; i++)
+	{
+		dc.DrawCircle(m_Pospx[i].X*scale, m_Pospx[i].Y*scale, 12 * scale);
+	}
+	if (m_numPos < 3)
+	{
+		return;
+	}
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+	//wxPenStyle penStyle = m_polarAlignCircleCorrection == 1.0 ? wxPENSTYLE_DOT : wxPENSTYLE_SOLID;
+	wxPenStyle penStyle = wxPENSTYLE_DOT;
+	dc.SetPen(wxPen(wxColor(255, 0, 255), 1, penStyle));
+	//int radius = ROUND(m_polarAlignCircleRadius * m_polarAlignCircleCorrection * m_scaleFactor);
+	dc.DrawCircle(m_CoRpx.X*scale, m_CoRpx.Y*scale, m_Radius*scale);
+	// draw the centre of the circle as a red cross
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+	int region = 5;
+	dc.DrawLine((m_CoRpx.X - region)*scale, m_CoRpx.Y*scale, (m_CoRpx.X + region)*scale, m_CoRpx.Y*scale);
+	dc.DrawLine(m_CoRpx.X*scale, (m_CoRpx.Y - region)*scale, m_CoRpx.X*scale, (m_CoRpx.Y + region)*scale);
+	// Show the centre of the display
+	double xsc = m_dispSz[0] / 2;
+	double ysc = m_dispSz[1] / 2;
+	dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine((xsc - region * 4)*scale, ysc*scale, (xsc + region * 4)*scale, ysc*scale);
+	dc.DrawLine(xsc*scale, (ysc - region * 4)*scale, xsc*scale, (ysc + region * 4)*scale);
+
+	// Draw orbits for each alignment star
+	for (int is = 0; is < m_nstar; is++)
+	{
+		dc.SetPen(wxPen(wxColor(255, 255, 0), 1, wxPENSTYLE_SOLID));
+		if (is == m_alignStar)
+		{
+			dc.SetPen(wxPen(wxColor(0, 255, 0), 1, wxPENSTYLE_SOLID));
+		}
+		dc.DrawCircle(m_CoRpx.X * scale, m_CoRpx.Y * scale, m_starpx[is][2] * scale);
+		dc.DrawCircle(m_starpx[is][0] * scale, m_starpx[is][1] * scale, region*scale);
+	}
+	// Draw adjustment lines for centring the CoR on the display
+	double xr = m_CoRpx.X * scale;
+	double yr = m_CoRpx.Y * scale;
+	dc.SetPen(wxPen(wxColor(255, 0, 0), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xr, yr, xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale);
+	dc.SetPen(wxPen(wxColor(0, 0, 255), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xr + m_ConeCorr.X * scale, yr + m_ConeCorr.Y * scale,
+		xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
+		yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
+	dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xr, yr, xr + m_DecCorr.X * scale + m_ConeCorr.X * scale,
+		yr + m_DecCorr.Y * scale + m_ConeCorr.Y * scale);
+
+	double xs = m_Pospx[2].X * scale;
+	double ys = m_Pospx[2].Y * scale;
+	dc.SetPen(wxPen(wxColor(255, 165, 0), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale);
+	dc.SetPen(wxPen(wxColor(0, 255, 0), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xs + m_AltCorr.X * scale, ys + m_AltCorr.Y * scale,
+		xs + m_AltCorr.X * scale + m_AzCorr.X * scale, ys + m_AzCorr.Y * scale + m_AltCorr.Y * scale);
+	dc.SetPen(wxPen(wxColor(127, 127, 127), 1, wxPENSTYLE_SOLID));
+	dc.DrawLine(xs, ys, xs + m_AltCorr.X * scale + m_AzCorr.X * scale,
+		ys + m_AltCorr.Y * scale + m_AzCorr.Y * scale);
+}
+
+bool StaticPaToolWin::UpdateAlignmentState(const PHD_Point& position) //(int npos, bool bauto)
+{
+	// Initially, assume an offset of 5.0 degrees of the camera from the CoR
+	// Calculate how far to move in RA to get a detectable arc
+	// Calculate the tangential ditance of that movement
+	// Mark the starting position then rotate the mount
+	bool bauto = true;
+	if (m_numPos == 1)
+	{
+		SetStatusText(_("Polar align: star #1"));
+		Debug.AddLine("Polar align: star #1");
+		//   Initially offset is 5 degrees;
+		bool rc = setparams(1.0); // m_rotdg, m_rotpx, m_nstep for assumed 5.0 degree PA error
+		Debug.AddLine(wxString::Format("Polar align: star #1 rotdg=%.1frotpx= %d nstep=%.0f", m_rotdg, m_rotpx, m_nstep));
+		bool isset = setStar(m_numPos);
+		if (isset) m_numPos++;
+		tottheta = 0.0;
+		nstep = 0;
+		Debug.AddLine(wxString::Format("Leave Polar align: star #1 rotdg=%.1frotpx= %.1f nstep=%d", m_rotdg, m_rotpx, m_nstep));
+		return isset;
+	}
+	if (m_numPos == 2)
+	{
+		double theta = m_rotdg - tottheta;
+		Debug.AddLine(wxString::Format("Enter Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
+		SetStatusText(_("Polar align: star #2"));
+		Debug.AddLine("Polar align: star #2");
+		// Once the mount has rotated theta degrees (as indicated by prevtheta);
+		if (!bauto)
+		{
+			// rotate mount manually;
+			bool isset = setStar(m_numPos);
+			if (isset) m_numPos++;
+			return isset;
+		}
+		Debug.AddLine(wxString::Format("Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
+		SetStatusText(wxString::Format("Polar align: star #2 theta= %.1f rotdg=%.1f nstep=%d / %d", theta, m_rotdg, nstep, m_nstep));
+		if (tottheta < m_rotdg)
+		{
+			double newtheta = theta / (m_nstep - nstep);
+			movewestby(newtheta); // , exposure);
+			tottheta += newtheta;
+			// Calclate how far the mount moved compared to the expected movement;
+			// This assumes that the mount was rotated through theta degrees;
+			// So theta is the total rotation needed for the current offset;
+			// And prevtheta is how we have already moved;
+			// Recalculate the offset based on the actual movement;
+		}
+		else
+		{
+			// Recalculate the offset. CAUTION: This might end up in an endless loop. 
+			bool isset = setStar(m_numPos);
+
+			double actpix = sqrt(pow(m_Pospx[1].X - m_Pospx[0].X, 2) + pow(m_Pospx[1].Y - m_Pospx[0].Y, 2));
+			double actsec = actpix * m_pxScale;
+			double actoffsetdeg = 90 - degrees(acos(actsec / 3600 / m_rotdg));
+
+			if (actoffsetdeg == 0)
+			{
+				Debug.AddLine(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
+				SetStatusText(wxString::Format("Polar align: star #2 Mount did not move actual offset =%.1f", actoffsetdeg));
+				//self.settings["msg"] = "Mount did not move - check settings";
+				PHD_Point cor = m_Pospx[m_numPos - 1];
+				return false;
+			}
+			double prev_rotdg = m_rotdg;
+			int prev_nstep = m_nstep;
+			// FIXME - alter setparams to take into account rotation so far
+			bool rc = setparams(actoffsetdeg); // m_rotdg, m_rotpx, m_nstep for measures PA error
+			if (!rc)
+			{
+				aligning = false;
+				return false;
+			}
+			if (m_rotdg <= prev_rotdg) // Moved far enough
+			{
+				if (!isset)
+				{
+					aligning = false;
+					return false;
+				}
+				m_numPos++;
+				nstep = 0;
+				tottheta = 0.0;
+			}
+			else if (m_rotdg > 45)
+			{
+				Debug.AddLine(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, m_rotdg));
+				SetStatusText(wxString::Format("Polar align: star #2 Too close to CoR offset =%.1f Rot=%.1f", actoffsetdeg, m_rotdg));
+				PHD_Point cor = m_Pospx[m_numPos - 1];
+				aligning = false;
+				return false;
+			}
+			else if (m_nstep <= nstep)
+			{
+				nstep = m_nstep - 1;
+			}
+		}
+		return true;
+	}
+	if (m_numPos == 3)
+	{
+		SetStatusText(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
+		Debug.AddLine(wxString::Format("Polar align: star #3 nstep=%d / %d theta=%.1f / %.1f", nstep, m_nstep, tottheta, m_rotdg));
+		if (!bauto)
+		{
+			// rotate mount manually;
+			bool isset = setStar(m_numPos);
+			if (isset) m_numPos++;
+			return isset;
+		}
+		if (tottheta < m_rotdg)
+		{
+			double newtheta = m_rotdg / (m_nstep - nstep);
+			movewestby(newtheta); // , exposure);
+			tottheta += newtheta;
+		}
+		else
+		{
+			bool isset = setStar(m_numPos);
+			if (isset)  m_numPos++;
+			return isset;
+		}
+		return true;
+	}
+	m_rotpx = 0;
+	return true;
+}
+
+bool StaticPaToolWin::setStar(int npos)
+{
+	int idx = npos - 1;
+	// Get X and Y coords from PHD2;
+	// idx: 0=B, 1/2/3 = A[idx];
+	m_Pospx[idx].X = -1;
+	m_Pospx[idx].Y = -1;
+	PHD_Point star = pFrame->pGuider->CurrentPosition();
+	m_Pospx[idx] = star;
+	m_calPt[idx][0]->SetValue(wxString::Format("%+.f", m_Pospx[idx].X));
+	m_calPt[idx][1]->SetValue(wxString::Format("%+.f", m_Pospx[idx].Y));
+
+	Debug.AddLine(wxString::Format("Setstar #%d %.0f, %.0f", npos, m_Pospx[idx].X, m_Pospx[idx].Y));
+	SetStatusText(wxString::Format("Setstar #%d %.0f, %.0f", npos, m_Pospx[idx].X, m_Pospx[idx].Y));
+	return star.IsValid();
+}
+
+bool StaticPaToolWin::setparams(double newoffset)
+{
+	double offsetdeg = newoffset;
+	m_offsetpx = offsetdeg * 3600 / m_pxScale;
+	Debug.AddLine(wxString::Format("PA setparams(new=%.1f) px=%.1f offset=%.1f dev=%.1f", newoffset, m_pxScale, m_offsetpx, m_devpx));
+	if (m_offsetpx < m_devpx)
+	{
+		Debug.AddLine(wxString::Format("PA setparams() Too close to CoR: offsetpx=%.1f devpx=%.1f", m_offsetpx, m_devpx));
+		return false;
+	}
+	m_rotdg = degrees(acos(1 - m_devpx / m_offsetpx));
+	m_rotpx = m_rotdg * 3600.0 / m_pxScale * sin(radians(offsetdeg));
+
+	int region = pFrame->pGuider->GetSearchRegion();
+	m_nstep = 1;
+	if (m_rotpx > region)
+	{
+		m_nstep = int(ceil(m_rotpx / region));
+	}
+	//double gRate = sin(radians(m_rotdg))*self.settings["xRate"];
+	//m_guidedur = m_rotpx / gRate;
+	Debug.AddLine(wxString::Format("PA setparams() rotdg=%.1f rotpx=%.1f nstep=%.0f region=%d", m_rotdg, m_rotpx, m_nstep, region));
+	return true;
+}
+/*
+bool StaticPaToolWin::rotateMount(double theta, int npulse)
+{
+	double exposure = pFrame->RequestedExposureDuration() / 1000;
+	double newtheta = theta / npulse;
+	for (int n = 0; n < npulse; n++)
+	{
+		movewestby(newtheta); // , exposure);
+		PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
+		bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
+	}
+	return true;
+}
+*/
+void StaticPaToolWin::movewestby(double thetadeg) //, double exp)
+{
+	m_can_slew = pPointingSource && pPointingSource->CanSlew();
+	// Rates in deg/sec;
+	// Calculate duration for rate 0;
+	double cur_ra, cur_dec, cur_st;
+	if (pPointingSource->GetCoordinates(&cur_ra, &cur_dec, &cur_st))
+	{
+		Debug.AddLine("Rotate tool: slew failed to get scope coordinates");
+		return;
+	}
+	double slew_ra = cur_ra - thetadeg * 24.0 / 360.0;
+
+	if (slew_ra >= 24.0)
+		slew_ra -= 24.0;
+	else if (slew_ra < 0.0)
+		slew_ra += 24.0;
+
+	//Debug.AddLine(wxString::Format("Rotate tool slew from ra %.2f, dec %.1f to ra %.2f, dec %.1f",
+	//	cur_ra, cur_dec, slew_ra, decSlew));
+	wxBusyCursor busy;
+	m_slewing = true;
+	//	GetStatusBar()->PushStatusText(_("Slewing ..."));
+	if (pPointingSource->SlewToCoordinates(slew_ra, cur_dec))
+	{
+		//		GetStatusBar()->PopStatusText();
+		m_slewing = false;
+		Debug.AddLine("Rotate tool: slew failed");
+	}
+	nstep++;
+	PHD_Point lockpos = pFrame->pGuider->CurrentPosition();
+	bool error = pFrame->pGuider->SetLockPosToStarAtPosition(lockpos);
+	//	wxMilliSleep(exp * 1000);
+	//	pFrame->pGuider->UpdateImageDisplay();
+}
+
+
+

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -1,0 +1,136 @@
+/*
+ *  staticpa_toolwin.h
+ *  PHD Guiding
+ *
+ *  Created by Ken Self
+ *  Copyright (c) 2017 Ken Self
+ *  All rights reserved.
+ *
+ *  This source code is distributed under the following "BSD" license
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *    Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *    Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef STATICPA_TOOLWIN_H
+#define STATICPA_TOOLWIN_H
+
+#include "phd.h"
+
+#include <wx/gbsizer.h>
+#include <wx/valnum.h>
+#include <wx/textwrapper.h>
+
+//==================================
+struct StaticPaToolWin : public wxFrame
+{
+	StaticPaToolWin();
+	~StaticPaToolWin();
+
+	wxStaticText *m_instructions;
+	wxTextCtrl *m_raCurrent;
+	wxTextCtrl *m_decCurrent;
+	wxTextCtrl *m_siteLat;
+	wxTextCtrl *m_siteLon;
+	wxTextCtrl *m_camRot;
+	wxTextCtrl *m_calPt[5][2];
+
+	wxStaticText *m_notesLabel;
+	wxTextCtrl *m_notes;
+	wxButton *m_rotate;
+	wxButton *m_adjust;
+	wxButton *m_close;
+	wxButton *m_phaseBtn;
+	wxStatusBar *m_statusBar;
+	wxTimer *m_timer;
+// Added from testguide
+	wxChoice *alignStarChoice;
+
+	enum StaticPaMode
+	{
+		MODE_IDLE,
+		MODE_ROTATE,
+		MODE_ADJUST,
+	};
+
+	enum StaticPaCtrlIds
+	{
+		ID_SLEW = 10001,
+		ID_ROTATE,
+		ID_ADJUST,
+		ID_CLOSE,
+		ID_PULSEDURATION = 330001,
+		ID_ALIGNSTAR,
+	};
+	StaticPaMode m_mode;
+	bool m_rotating;
+
+	PHD_Point m_siteLatLong;
+	double m_pxScale;
+	double m_dCamRot;
+	int m_alignStar;
+
+	PHD_Point m_Pospx[3];
+	int m_numPos;
+	PHD_Point m_CoRpx;
+	double m_dispSz[2];
+	double m_Radius;
+	int m_nstar;
+	double m_starpx[10][3];
+	PHD_Point m_AzCorr, m_AltCorr;
+	PHD_Point m_ConeCorr, m_DecCorr;
+	double m_rotdg, m_rotpx, m_prevtheta;
+	int nstep, m_nstep;
+	double m_offsetpx, m_devpx, offsetdeg, m_guidedur;
+	bool m_can_slew;
+	bool m_slewing;
+	bool aligning = false;
+	bool aligned = false;
+
+	double tottheta = 0.0;
+
+	void UpdateModeState();
+	void UpdateAlignStar();
+
+	//void OnSlew(wxCommandEvent& evt);
+	void OnRotate(wxCommandEvent& evt);
+	void OnAdjust(wxCommandEvent& evt);
+	void OnAlignStar(wxCommandEvent& evt);
+	//void OnAppStateNotify(wxCommandEvent& evt);
+	void OnCloseBtn(wxCommandEvent& evt);
+	void OnClose(wxCloseEvent& evt);
+	void CalcRotationCentre(void);
+	PHD_Point Radec2Px(PHD_Point radec);
+	bool IsAligning(){ return aligning; };
+	bool IsAligned(){ return aligned; }
+	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
+	bool UpdateAlignmentState(const PHD_Point& position);
+	bool setStar(int idx);
+	bool setparams(double newoffset);
+	bool rotateMount(double theta, int npulse);
+	void movewestby(double thetadeg); //, double exp);
+
+	DECLARE_EVENT_TABLE()
+};
+
+#endif
+

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -71,7 +71,6 @@ struct StaticPaToolWin : public wxFrame
         StaticPaToolWin *paParent;
         void OnPaint(wxPaintEvent &evt);
         void Paint();
-        void Render(wxDC &dc);
         DECLARE_EVENT_TABLE()
     };
     PolePanel *w_pole; // Panel for drawing of pole stars 
@@ -127,11 +126,10 @@ struct StaticPaToolWin : public wxFrame
     PHD_Point r_pxCentre;   // Centre of Rotation in pixels
     double r_radius;        // Radius of centre of rotation to reference star
 
-    double g_dispSz[2];    // Display size (dynamic)
+    double g_dispSz[2];     // Display size (dynamic)
     PHD_Point m_AzCorr, m_AltCorr; // Calculated Alt and Az corrections
     PHD_Point m_ConeCorr, m_DecCorr;  //Calculated Dec and Cone offsets
 
-    void UpdateRefStar();
     void FillPanel();
 
     void OnHemi(wxCommandEvent& evt);
@@ -148,7 +146,7 @@ struct StaticPaToolWin : public wxFrame
     bool IsAligning(){ return s_aligning; };
     bool RotateMount();
     bool SetParams(double newoffset);
-    void MoveWestBy(double thetadeg); //, double exp);
+    void MoveWestBy(double thetadeg);
     bool SetStar(int idx);
     bool IsAligned(){ return a_auto ? s_state == (3 << 1) : s_state == (7 << 1); }
     void CalcRotationCentre(void);

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -62,6 +62,12 @@ struct StaticPaToolWin : public wxFrame
 	wxStatusBar *m_statusBar;
 	wxChoice *refStarChoice;  // Listbox for reference stars
 	wxChoice *hemiChoice;     // Listbox for manual hemisphere choice 
+
+	bool m_can_slew;
+	wxString *pinstructions;
+	wxString *pautoInstr;
+	wxString *pmanualInstr;
+
 	class PolePanel : public wxPanel
 	{
 	public:
@@ -105,7 +111,6 @@ struct StaticPaToolWin : public wxFrame
 	int s_hemi;        // Hemisphere
 
 	bool aligning = false; // Collecting points
-//	bool aligned = false;
 	double m_devpx;
 
 	unsigned int state;

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -14,7 +14,7 @@
  *    Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *    Neither the name of openphdguiding.org nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -47,25 +47,32 @@ struct StaticPaToolWin : public wxFrame
 	~StaticPaToolWin();
 
 	wxStaticText *m_instructions;
-//	wxTextCtrl *m_raCurrent;
-//	wxTextCtrl *m_decCurrent;
-//	wxTextCtrl *m_siteLat;
-//	wxTextCtrl *m_siteLon;
-	wxTextCtrl *m_camScale;
-	wxTextCtrl *m_camRot;
-	wxCheckBox *m_manual;
-	wxTextCtrl *m_calPt[5][2];
-	wxButton *m_star1;
-	wxButton *m_star2;
-	wxButton *m_star3;
+	wxTextCtrl *m_camScale; // Text box for camera pixel scale
+	wxTextCtrl *m_camRot;   // Text box for camera rotation
+	wxCheckBox *m_manual;   // Checkbox for auto/manual slewing
+	wxTextCtrl *m_calPt[4][2];  // Text boxes for each point plus the CoR
+	wxButton *m_star1;      // Button for manual get of point 1
+	wxButton *m_star2;      // Button for manual get of point 2
+	wxButton *m_star3;      // Button for manual get of point 3
 
 	wxStaticText *m_notesLabel;
 	wxTextCtrl *m_notes;
-	wxButton *m_adjust;
-	wxButton *m_close;
+	wxButton *m_adjust;     // Button to calculate CoR
+	wxButton *m_close;      // Close button
 	wxStatusBar *m_statusBar;
-	wxChoice *alignStarChoice;
-	wxChoice *hemiChoice;
+	wxChoice *refStarChoice;  // Listbox for reference stars
+	wxChoice *hemiChoice;     // Listbox for manual hemisphere choice 
+	class PolePanel : public wxPanel
+	{
+	public:
+		PolePanel(StaticPaToolWin* parent);
+		StaticPaToolWin *paParent;
+		void OnPaint(wxPaintEvent &evt);
+		void Paint();
+		void Render(wxDC &dc);
+		DECLARE_EVENT_TABLE()
+	};
+	PolePanel *pole; // Panel for drawing of pole stars 
 
 	class Star
 	{
@@ -76,12 +83,6 @@ struct StaticPaToolWin : public wxFrame
 	};
 	std::vector<Star> SthStars, NthStars;
 	std::vector<Star> *poleStars;
-	enum StaticPaMode
-	{
-		MODE_IDLE,
-		MODE_ROTATE,
-		MODE_ADJUST,
-	};
 
 	enum StaticPaCtrlIds
 	{
@@ -96,58 +97,55 @@ struct StaticPaToolWin : public wxFrame
 		ID_ALIGNSTAR,
 		ID_HEMI
 	};
-	StaticPaMode m_mode;
-	double m_pxScale;
-	double m_dCamRot;
-	int m_alignStar;
+	double m_pxScale;  // Camera pixel scale
+	double m_dCamRot;  // Camera rotation
+	double m_camXpx;   // Camera width
+	int m_alignStar;   // Selected reference star
+	bool bauto;        // Auto slewing
+	int s_hemi;        // Hemisphere
 
-	PHD_Point m_Pospx[3];
-	int m_numPos;
-	PHD_Point m_CoRpx;
-	double m_dispSz[2];
-	double m_Radius;
-	int m_nstar;
-	double m_starpx[10][3];
-	double m_ra_rot[3];
+	bool aligning = false; // Collecting points
+	bool aligned = false;
+	double m_devpx;
+
+	int m_numPos;          // Number of alignment points
+	double m_rotdg;        // Amount of rotation required
+	int m_nstep;           //Number of steps needed
+	double tottheta = 0.0; // Rotation so far
+	int nstep;             // Number of steps taken so far
+
+	double m_ra_rot[3];    // RA readings at each point
+	PHD_Point m_Pospx[3];  // Alignment points - in pixels
+	PHD_Point m_CoRpx;     // Centre of Rotation in pixels
+	double m_Radius;       // Radius of centre of rotation to reference star
+
+	double m_dispSz[2];    // Display size
 	PHD_Point m_AzCorr, m_AltCorr;
 	PHD_Point m_ConeCorr, m_DecCorr;
-	double m_rotdg, m_rotpx, m_prevtheta;
-	int nstep, m_nstep;
-	double m_offsetpx, m_devpx, offsetdeg, m_guidedur;
-	bool m_can_slew;
-	bool m_slewing;
-	bool aligning = false;
-	bool aligned = false;
-	bool bauto;
-	int s_hemi;
 
-	double tottheta = 0.0;
-
-	void UpdateModeState();
 	void UpdateAlignStar();
+	void SetButtons();
 
-	//void OnSlew(wxCommandEvent& evt);
 	void OnHemi(wxCommandEvent& evt);
-	void OnRotate(wxCommandEvent& evt);
-	void OnAdjust(wxCommandEvent& evt);
 	void OnAlignStar(wxCommandEvent& evt);
 	void OnManual(wxCommandEvent& evt);
+	void OnRotate(wxCommandEvent& evt);
 	void OnStar2(wxCommandEvent& evt);
 	void OnStar3(wxCommandEvent& evt);
-	void SetButtons();
+	void OnAdjust(wxCommandEvent& evt);
 	void OnCloseBtn(wxCommandEvent& evt);
 	void OnClose(wxCloseEvent& evt);
-	void CalcRotationCentre(void);
-	PHD_Point Radec2Px(PHD_Point radec);
+		
+	void CreateStarTemplate(wxDC &dc);
 	bool IsAligning(){ return aligning; };
-	bool IsAligned(){ return aligned; }
-	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
-	bool RotateMount(); 
-	bool SetStar(int idx);
+	bool RotateMount();
 	bool SetParams(double newoffset);
 	void MoveWestBy(double thetadeg); //, double exp);
-	wxBitmap CreateStarTemplate();
-
+	bool SetStar(int idx);
+	bool IsAligned(){ return aligned; }
+	void CalcRotationCentre(void);
+	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
+	PHD_Point Radec2Px(PHD_Point radec);
 
 	DECLARE_EVENT_TABLE()
 };

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -91,23 +91,24 @@ struct StaticPaToolWin : public wxFrame
 		ID_STAR2,
 		ID_STAR3,
 		ID_ROTATE,
-		ID_ADJUST,
+		ID_CALCULATE,
 		ID_CLOSE,
 		ID_MANUAL,
-		ID_ALIGNSTAR,
+		ID_REFSTAR,
 		ID_HEMI
 	};
 	double m_pxScale;  // Camera pixel scale
 	double m_dCamRot;  // Camera rotation
 	double m_camXpx;   // Camera width
-	int m_alignStar;   // Selected reference star
+	int m_refStar;     // Selected reference star
 	bool bauto;        // Auto slewing
 	int s_hemi;        // Hemisphere
 
 	bool aligning = false; // Collecting points
-	bool aligned = false;
+//	bool aligned = false;
 	double m_devpx;
 
+	unsigned int state;
 	int m_numPos;          // Number of alignment points
 	double m_rotdg;        // Amount of rotation required
 	int m_nstep;           //Number of steps needed
@@ -123,16 +124,16 @@ struct StaticPaToolWin : public wxFrame
 	PHD_Point m_AzCorr, m_AltCorr;
 	PHD_Point m_ConeCorr, m_DecCorr;
 
-	void UpdateAlignStar();
+	void UpdateRefStar();
 	void SetButtons();
 
 	void OnHemi(wxCommandEvent& evt);
-	void OnAlignStar(wxCommandEvent& evt);
+	void OnRefStar(wxCommandEvent& evt);
 	void OnManual(wxCommandEvent& evt);
 	void OnRotate(wxCommandEvent& evt);
 	void OnStar2(wxCommandEvent& evt);
 	void OnStar3(wxCommandEvent& evt);
-	void OnAdjust(wxCommandEvent& evt);
+	void OnCalculate(wxCommandEvent& evt);
 	void OnCloseBtn(wxCommandEvent& evt);
 	void OnClose(wxCloseEvent& evt);
 		
@@ -142,7 +143,7 @@ struct StaticPaToolWin : public wxFrame
 	bool SetParams(double newoffset);
 	void MoveWestBy(double thetadeg); //, double exp);
 	bool SetStar(int idx);
-	bool IsAligned(){ return aligned; }
+	bool IsAligned(){ return bauto ? state == (3 << 1) : state == (7 << 1); }
 	void CalcRotationCentre(void);
 	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
 	PHD_Point Radec2Px(PHD_Point radec);

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -43,117 +43,119 @@
 //==================================
 struct StaticPaToolWin : public wxFrame
 {
-	StaticPaToolWin();
-	~StaticPaToolWin();
+    StaticPaToolWin();
+    ~StaticPaToolWin();
+    /*
+    Tool window controls
+    */
+    wxStaticText *w_instructions;
+    wxTextCtrl *w_camScale; // Text box for camera pixel scale
+    wxTextCtrl *w_camRot;   // Text box for camera rotation
+    wxCheckBox *w_manual;   // Checkbox for auto/manual slewing
+    wxTextCtrl *w_calPt[4][2];  // Text boxes for each point plus the CoR
+    wxButton *w_star1;      // Button for manual get of point 1
+    wxButton *w_star2;      // Button for manual get of point 2
+    wxButton *w_star3;      // Button for manual get of point 3
+    wxStaticText *w_notesLabel;
+    wxTextCtrl *w_notes;
+    wxButton *w_calculate;     // Button to calculate CoR
+    wxButton *w_close;      // Close button
+    wxStatusBar *w_statusBar;
+    wxChoice *w_refStarChoice;  // Listbox for reference stars
+    wxChoice *w_hemiChoice;     // Listbox for manual hemisphere choice 
 
-	wxStaticText *m_instructions;
-	wxTextCtrl *m_camScale; // Text box for camera pixel scale
-	wxTextCtrl *m_camRot;   // Text box for camera rotation
-	wxCheckBox *m_manual;   // Checkbox for auto/manual slewing
-	wxTextCtrl *m_calPt[4][2];  // Text boxes for each point plus the CoR
-	wxButton *m_star1;      // Button for manual get of point 1
-	wxButton *m_star2;      // Button for manual get of point 2
-	wxButton *m_star3;      // Button for manual get of point 3
+    class PolePanel : public wxPanel
+    {
+    public:
+        PolePanel(StaticPaToolWin* parent);
+        StaticPaToolWin *paParent;
+        void OnPaint(wxPaintEvent &evt);
+        void Paint();
+        void Render(wxDC &dc);
+        DECLARE_EVENT_TABLE()
+    };
+    PolePanel *w_pole; // Panel for drawing of pole stars 
 
-	wxStaticText *m_notesLabel;
-	wxTextCtrl *m_notes;
-	wxButton *m_adjust;     // Button to calculate CoR
-	wxButton *m_close;      // Close button
-	wxStatusBar *m_statusBar;
-	wxChoice *refStarChoice;  // Listbox for reference stars
-	wxChoice *hemiChoice;     // Listbox for manual hemisphere choice 
+    /*
+    Constants used in the tool window controls
+    */
+    wxString *c_autoInstr;
+    wxString *c_manualInstr;
 
-	bool m_can_slew;
-	wxString *pinstructions;
-	wxString *pautoInstr;
-	wxString *pmanualInstr;
+    class Star
+    {
+    public:
+        std::string name;
+        double ra, dec, mag;
+        Star(const char* a, const double b, const double c, const double d) :name(a), ra(b), dec(c), mag(d) {};
+    };
+    std::vector<Star> c_SthStars, c_NthStars; // Stars around the poles
+    std::vector<Star> *poleStars;
 
-	class PolePanel : public wxPanel
-	{
-	public:
-		PolePanel(StaticPaToolWin* parent);
-		StaticPaToolWin *paParent;
-		void OnPaint(wxPaintEvent &evt);
-		void Paint();
-		void Render(wxDC &dc);
-		DECLARE_EVENT_TABLE()
-	};
-	PolePanel *pole; // Panel for drawing of pole stars 
+    enum StaticPaCtrlIds
+    {
+        ID_HEMI = 10001,
+        ID_MANUAL,
+        ID_REFSTAR,
+        ID_ROTATE,
+        ID_STAR2,
+        ID_STAR3,
+        ID_CALCULATE,
+        ID_CLOSE,
+    };
 
-	class Star
-	{
-	public:
-		std::string name;
-		double ra, dec, mag;
-		Star(const char* a, const double b, const double c, const double d) :name(a), ra(b), dec(c), mag(d) {};
-	};
-	std::vector<Star> SthStars, NthStars;
-	std::vector<Star> *poleStars;
+    bool g_canSlew;     // Mount can slew
+    double g_pxScale;   // Camera pixel scale
+    double g_camAngle;  // Camera angle to RA
+    double g_camWidth;  // Camera width
 
-	enum StaticPaCtrlIds
-	{
-		ID_SLEW = 10001,
-		ID_STAR1,
-		ID_STAR2,
-		ID_STAR3,
-		ID_ROTATE,
-		ID_CALCULATE,
-		ID_CLOSE,
-		ID_MANUAL,
-		ID_REFSTAR,
-		ID_HEMI
-	};
-	double m_pxScale;  // Camera pixel scale
-	double m_dCamRot;  // Camera rotation
-	double m_camXpx;   // Camera width
-	int m_refStar;     // Selected reference star
-	bool bauto;        // Auto slewing
-	int s_hemi;        // Hemisphere
+    double a_devpx;     // Number of pixels deviation needed to detect an arc
+    int a_refStar;      // Selected reference star
+    bool a_auto;        // Auto slewing - must be manual if mount cannot slew
+    int a_hemi;         // Hemisphere of the observer
 
-	bool aligning = false; // Collecting points
-	double m_devpx;
+    bool s_aligning;        // Indicates that alignment points are being collected
+    unsigned int s_state;   // state of the alignment process
+    int s_numPos;           // Number of alignment points
+    double s_reqRot;        // Amount of rotation required
+    int s_reqStep;          // Number of steps needed
+    double s_totRot;        // Rotation so far
+    int s_nStep;            // Number of steps taken so far
 
-	unsigned int state;
-	int m_numPos;          // Number of alignment points
-	double m_rotdg;        // Amount of rotation required
-	int m_nstep;           //Number of steps needed
-	double tottheta = 0.0; // Rotation so far
-	int nstep;             // Number of steps taken so far
+    double r_raPos[3];      // RA readings at each point
+    PHD_Point r_pxPos[3];   // Alignment points - in pixels
+    PHD_Point r_pxCentre;   // Centre of Rotation in pixels
+    double r_radius;        // Radius of centre of rotation to reference star
 
-	double m_ra_rot[3];    // RA readings at each point
-	PHD_Point m_Pospx[3];  // Alignment points - in pixels
-	PHD_Point m_CoRpx;     // Centre of Rotation in pixels
-	double m_Radius;       // Radius of centre of rotation to reference star
+    double g_dispSz[2];    // Display size (dynamic)
+    PHD_Point m_AzCorr, m_AltCorr; // Calculated Alt and Az corrections
+    PHD_Point m_ConeCorr, m_DecCorr;  //Calculated Dec and Cone offsets
 
-	double m_dispSz[2];    // Display size
-	PHD_Point m_AzCorr, m_AltCorr;
-	PHD_Point m_ConeCorr, m_DecCorr;
+    void UpdateRefStar();
+    void FillPanel();
 
-	void UpdateRefStar();
-	void SetButtons();
+    void OnHemi(wxCommandEvent& evt);
+    void OnRefStar(wxCommandEvent& evt);
+    void OnManual(wxCommandEvent& evt);
+    void OnRotate(wxCommandEvent& evt);
+    void OnStar2(wxCommandEvent& evt);
+    void OnStar3(wxCommandEvent& evt);
+    void OnCalculate(wxCommandEvent& evt);
+    void OnCloseBtn(wxCommandEvent& evt);
+    void OnClose(wxCloseEvent& evt);
 
-	void OnHemi(wxCommandEvent& evt);
-	void OnRefStar(wxCommandEvent& evt);
-	void OnManual(wxCommandEvent& evt);
-	void OnRotate(wxCommandEvent& evt);
-	void OnStar2(wxCommandEvent& evt);
-	void OnStar3(wxCommandEvent& evt);
-	void OnCalculate(wxCommandEvent& evt);
-	void OnCloseBtn(wxCommandEvent& evt);
-	void OnClose(wxCloseEvent& evt);
-		
-	void CreateStarTemplate(wxDC &dc);
-	bool IsAligning(){ return aligning; };
-	bool RotateMount();
-	bool SetParams(double newoffset);
-	void MoveWestBy(double thetadeg); //, double exp);
-	bool SetStar(int idx);
-	bool IsAligned(){ return bauto ? state == (3 << 1) : state == (7 << 1); }
-	void CalcRotationCentre(void);
-	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
-	PHD_Point Radec2Px(PHD_Point radec);
+    void CreateStarTemplate(wxDC &dc);
+    bool IsAligning(){ return s_aligning; };
+    bool RotateMount();
+    bool SetParams(double newoffset);
+    void MoveWestBy(double thetadeg); //, double exp);
+    bool SetStar(int idx);
+    bool IsAligned(){ return a_auto ? s_state == (3 << 1) : s_state == (7 << 1); }
+    void CalcRotationCentre(void);
+    void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
+    PHD_Point Radec2Px(PHD_Point radec);
 
-	DECLARE_EVENT_TABLE()
+    DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -47,24 +47,35 @@ struct StaticPaToolWin : public wxFrame
 	~StaticPaToolWin();
 
 	wxStaticText *m_instructions;
-	wxTextCtrl *m_raCurrent;
-	wxTextCtrl *m_decCurrent;
-	wxTextCtrl *m_siteLat;
-	wxTextCtrl *m_siteLon;
+//	wxTextCtrl *m_raCurrent;
+//	wxTextCtrl *m_decCurrent;
+//	wxTextCtrl *m_siteLat;
+//	wxTextCtrl *m_siteLon;
+	wxTextCtrl *m_camScale;
 	wxTextCtrl *m_camRot;
+	wxCheckBox *m_manual;
 	wxTextCtrl *m_calPt[5][2];
+	wxButton *m_star1;
+	wxButton *m_star2;
+	wxButton *m_star3;
 
 	wxStaticText *m_notesLabel;
 	wxTextCtrl *m_notes;
-	wxButton *m_rotate;
 	wxButton *m_adjust;
 	wxButton *m_close;
-	wxButton *m_phaseBtn;
 	wxStatusBar *m_statusBar;
-	wxTimer *m_timer;
-// Added from testguide
 	wxChoice *alignStarChoice;
+	wxChoice *hemiChoice;
 
+	class Star
+	{
+	public:
+		std::string name;
+		double ra, dec, mag;
+		Star(const char* a, const double b, const double c, const double d) :name(a), ra(b), dec(c), mag(d) {};
+	};
+	std::vector<Star> SthStars, NthStars;
+	std::vector<Star> *poleStars;
 	enum StaticPaMode
 	{
 		MODE_IDLE,
@@ -75,16 +86,17 @@ struct StaticPaToolWin : public wxFrame
 	enum StaticPaCtrlIds
 	{
 		ID_SLEW = 10001,
+		ID_STAR1,
+		ID_STAR2,
+		ID_STAR3,
 		ID_ROTATE,
 		ID_ADJUST,
 		ID_CLOSE,
-		ID_PULSEDURATION = 330001,
+		ID_MANUAL,
 		ID_ALIGNSTAR,
+		ID_HEMI
 	};
 	StaticPaMode m_mode;
-	bool m_rotating;
-
-	PHD_Point m_siteLatLong;
 	double m_pxScale;
 	double m_dCamRot;
 	int m_alignStar;
@@ -96,6 +108,7 @@ struct StaticPaToolWin : public wxFrame
 	double m_Radius;
 	int m_nstar;
 	double m_starpx[10][3];
+	double m_ra_rot[3];
 	PHD_Point m_AzCorr, m_AltCorr;
 	PHD_Point m_ConeCorr, m_DecCorr;
 	double m_rotdg, m_rotpx, m_prevtheta;
@@ -105,6 +118,8 @@ struct StaticPaToolWin : public wxFrame
 	bool m_slewing;
 	bool aligning = false;
 	bool aligned = false;
+	bool bauto;
+	int s_hemi;
 
 	double tottheta = 0.0;
 
@@ -112,10 +127,14 @@ struct StaticPaToolWin : public wxFrame
 	void UpdateAlignStar();
 
 	//void OnSlew(wxCommandEvent& evt);
+	void OnHemi(wxCommandEvent& evt);
 	void OnRotate(wxCommandEvent& evt);
 	void OnAdjust(wxCommandEvent& evt);
 	void OnAlignStar(wxCommandEvent& evt);
-	//void OnAppStateNotify(wxCommandEvent& evt);
+	void OnManual(wxCommandEvent& evt);
+	void OnStar2(wxCommandEvent& evt);
+	void OnStar3(wxCommandEvent& evt);
+	void SetButtons();
 	void OnCloseBtn(wxCommandEvent& evt);
 	void OnClose(wxCloseEvent& evt);
 	void CalcRotationCentre(void);
@@ -123,11 +142,12 @@ struct StaticPaToolWin : public wxFrame
 	bool IsAligning(){ return aligning; };
 	bool IsAligned(){ return aligned; }
 	void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
-	bool UpdateAlignmentState(const PHD_Point& position);
-	bool setStar(int idx);
-	bool setparams(double newoffset);
-	bool rotateMount(double theta, int npulse);
-	void movewestby(double thetadeg); //, double exp);
+	bool RotateMount(); 
+	bool SetStar(int idx);
+	bool SetParams(double newoffset);
+	void MoveWestBy(double thetadeg); //, double exp);
+	wxBitmap CreateStarTemplate();
+
 
 	DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
A new tool for static polar alignment using PHD2
I believe this addresses issue#399 Enhancement: drift tool: option to align using polar field
It provides two modes of operation: Automatic method requires a mount that can respond to slew commands and report its position and requires two alignment points. Typically, this mode requires the mount to slew through 10 degrees of less.
Manual can be used in place of automatic and is the default when the mount cannot slew e.g. on camera. This requires the user to slew manually and record three alignment points.
