### PR TITLE
Correct appdata file location

### DIFF
--- a/cmake_modules/PHD2Packaging.cmake
+++ b/cmake_modules/PHD2Packaging.cmake
@@ -74,7 +74,7 @@ if(UNIX AND NOT APPLE)
   install(FILES ${phd_src_dir}/phd2.desktop      
           DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications/ )
   install(FILES ${phd_src_dir}/phd2.appdata.xml      
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata/ )
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo/ )
 
   # Make Debian package
   set(CPACK_GENERATOR "DEB")


### PR DESCRIPTION
Appdata standard has changed file location to /usr/share/metainfo.
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps