### PR TITLE
make bottom manual guide buttons visible

### DIFF
--- a/testguide.cpp
+++ b/testguide.cpp
@@ -214,6 +214,7 @@ TestGuideDialog::TestGuideDialog() :
         pOuterSizer->Add(pWrapperSizer,wxSizerFlags().Border(wxALL,3).Center().Expand());
     }
 
+    pOuterSizer->AddSpacer(30);
     pOuterSizer->SetSizeHints(this);
     SetSizerAndFit(pOuterSizer);
 }


### PR DESCRIPTION
This hack makes the bottom button row visible on Linux.