### PR TITLE
Touptek on Linux

### DIFF
--- a/cam_touptek.cpp
+++ b/cam_touptek.cpp
@@ -563,7 +563,7 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
     m_cam.SetOption(TOUPCAM_OPTION_DFC, 0);
     m_cam.SetOption(TOUPCAM_OPTION_SHARPENING, 0);
     m_cam.SetOption(TOUPCAM_OPTION_AGAIN, 0);
-    
+
     unsigned short speed;
     if (SUCCEEDED(hr = Toupcam_get_Speed(m_cam.m_h, &speed)))
     {

--- a/cam_touptek.cpp
+++ b/cam_touptek.cpp
@@ -851,7 +851,7 @@ bool CameraToupTek::ST4PulseGuideScope(int direction, int duration)
         long elapsed = watchdog.Time();
         unsigned long delay = elapsed < duration ? wxMin(duration - elapsed, 200) : 10;
         wxMilliSleep(delay);
-        if (Toupcam_ST4PlusGuideState(m_cam.m_h) != S_OK)
+        if (Toupcam_ST4PlusGuideState(m_cam.m_h) != 0)
             return false; // pulse completed
         if (WorkerThread::TerminateRequested())
             return true;

--- a/cam_touptek.cpp
+++ b/cam_touptek.cpp
@@ -556,8 +556,7 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
     //m_cam.SetOption(TOUPCAM_OPTION_CURVE, 0); // resetting this one fails on all the cameras I have
     m_cam.SetOption(TOUPCAM_OPTION_COLORMATIX, 0);
     m_cam.SetOption(TOUPCAM_OPTION_WBGAIN, 0);
-    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 0);  // video mode
-//    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 1);  // software trigger
+    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 1);  // software trigger
     m_cam.SetOption(TOUPCAM_OPTION_ROTATE, 0);
     m_cam.SetOption(TOUPCAM_OPTION_FFC, 0);
     m_cam.SetOption(TOUPCAM_OPTION_DFC, 0);
@@ -686,8 +685,8 @@ bool CameraToupTek::Capture(int duration, usImage& img, int options, const wxRec
     m_cam.StartCapture();
 
     //Debug.Write("TOUPTEK: capture: trigger\n");
-//    if (FAILED(hr = Toupcam_Trigger(m_cam.m_h, 1)))
-//        Debug.Write(wxString::Format("TOUPTEK: Toupcam_Trigger(1) failed with status 0x%x\n", hr));
+    if (FAILED(hr = Toupcam_Trigger(m_cam.m_h, 1)))
+        Debug.Write(wxString::Format("TOUPTEK: Toupcam_Trigger(1) failed with status 0x%x\n", hr));
 
     // "The timeout is recommended for not less than (Exposure Time * 102% + 8 Seconds)."
     CameraWatchdog watchdog(duration * 102 / 100, GetTimeoutMs());

--- a/cam_touptek.cpp
+++ b/cam_touptek.cpp
@@ -556,13 +556,14 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
     //m_cam.SetOption(TOUPCAM_OPTION_CURVE, 0); // resetting this one fails on all the cameras I have
     m_cam.SetOption(TOUPCAM_OPTION_COLORMATIX, 0);
     m_cam.SetOption(TOUPCAM_OPTION_WBGAIN, 0);
-    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 1);  // software trigger
+    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 0);  // video mode
+//    m_cam.SetOption(TOUPCAM_OPTION_TRIGGER, 1);  // software trigger
     m_cam.SetOption(TOUPCAM_OPTION_ROTATE, 0);
     m_cam.SetOption(TOUPCAM_OPTION_FFC, 0);
     m_cam.SetOption(TOUPCAM_OPTION_DFC, 0);
     m_cam.SetOption(TOUPCAM_OPTION_SHARPENING, 0);
     m_cam.SetOption(TOUPCAM_OPTION_AGAIN, 0);
-
+    
     unsigned short speed;
     if (SUCCEEDED(hr = Toupcam_get_Speed(m_cam.m_h, &speed)))
     {
@@ -685,8 +686,8 @@ bool CameraToupTek::Capture(int duration, usImage& img, int options, const wxRec
     m_cam.StartCapture();
 
     //Debug.Write("TOUPTEK: capture: trigger\n");
-    if (FAILED(hr = Toupcam_Trigger(m_cam.m_h, 1)))
-        Debug.Write(wxString::Format("TOUPTEK: Toupcam_Trigger(1) failed with status 0x%x\n", hr));
+//    if (FAILED(hr = Toupcam_Trigger(m_cam.m_h, 1)))
+//        Debug.Write(wxString::Format("TOUPTEK: Toupcam_Trigger(1) failed with status 0x%x\n", hr));
 
     // "The timeout is recommended for not less than (Exposure Time * 102% + 8 Seconds)."
     CameraWatchdog watchdog(duration * 102 / 100, GetTimeoutMs());

--- a/cameras.h
+++ b/cameras.h
@@ -113,6 +113,9 @@
 # ifdef HAVE_ZWO_CAMERA
 #  define ZWO_ASI
 # endif
+# ifdef HAVE_TOUP_CAMERA
+# define TOUPTEK_CAMERA
+# endif
 # define SXV
 # ifdef HAVE_SBIG_CAMERA
 #   define SBIG

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -1266,6 +1266,16 @@ if(UNIX AND NOT APPLE)
     add_definitions(-DHAVE_ZWO_CAMERA=1)
     set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${asiCamera2})
 
+    find_library(toupcam
+                 NAMES toupcam)
+#                 NO_DEFAULT_PATHS)
+    if(NOT toupcam)
+      message(FATAL_ERROR "Cannot find the toupcam drivers")
+    endif()
+    message(STATUS "Found toupcam lib ${toupcam}")
+    add_definitions(-DHAVE_TOUP_CAMERA=1)
+    set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${toupcam})
+
     if(IS_DIRECTORY ${PHD_PROJECT_ROOT_DIR}/cameras/qhyccdlibs/linux/${qhyarch})
       add_definitions(-DHAVE_QHY_CAMERA=1)
 


### PR DESCRIPTION
I took the easy way out and changed S_OK to 0 on line 854 to get around a compiler error. You may want to define S_OK conditionally for Linux.
I changed from trigger mode to video mode as in trigger mode on both Win and Linux a 1s exposure led to a 1.6s sampling period. In video mode a 1s exposure is very close to a 1 sampling period.
In early testing of video mode I was getting an occasional long delay between frames but I have not been able to reproduce it recently. Could have been a USB issue.

While testing with a very artificial "star" I saw fairly large (0.5 pixel), high frequency deviation on the dec axis. What was weird is that when I turned on the target plot the mean position of the deviations switched to the other side of the axis. Ans when I switched it off again the mean returned to its previous location.  I'll post details to the forum as it may be unrelated to the toupcam. 

toupcam.h was saved to phd2/cameras/toupcam.h
libtoupcam.so was saved to /usr/lib/x86_64-linux-gnu/libtoupcam,so

Tested on Ubuntu 16.04 64bit VM