### PR TITLE
OpenSSag should be used only if not OPENSOURCE_ONLY

### DIFF
--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -1295,23 +1295,23 @@ if(UNIX AND NOT APPLE)
     # temporarily disable qhy camera pending fix for link error on Ubuntu Trusty
     remove_definitions(-DHAVE_QHY_CAMERA=1)
 
-  endif()  # OPENSOURCE_ONLY
+    set(LIBOPENSSAG openssag)
+    set(libopenssag_dir ${thirdparty_dir}/${LIBOPENSSAG}/src)
+    include_directories(${libopenssag_dir})
+    set(libOPENSSAG_SRC
+      ${libopenssag_dir}/firmware.h
+      ${libopenssag_dir}/loader.cpp
+      ${libopenssag_dir}/openssag_priv.h
+      ${libopenssag_dir}/openssag.cpp
+      ${libopenssag_dir}/openssag.h
+      )
+    add_library(OpenSSAG ${libOPENSSAG_SRC})
+    target_link_libraries(OpenSSAG openphd_libusb)
+    target_include_directories(OpenSSAG PRIVATE ${thirdparty_dir}/${LIBOPENSSAG}/src)
+    set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} OpenSSAG)
+    set_property(TARGET OpenSSAG PROPERTY FOLDER "Thirdparty/")
 
-  set(LIBOPENSSAG openssag)
-  set(libopenssag_dir ${thirdparty_dir}/${LIBOPENSSAG}/src)
-  include_directories(${libopenssag_dir})
-  set(libOPENSSAG_SRC
-    ${libopenssag_dir}/firmware.h
-    ${libopenssag_dir}/loader.cpp
-    ${libopenssag_dir}/openssag_priv.h
-    ${libopenssag_dir}/openssag.cpp
-    ${libopenssag_dir}/openssag.h
-    )
-  add_library(OpenSSAG ${libOPENSSAG_SRC})
-  target_link_libraries(OpenSSAG openphd_libusb)
-  target_include_directories(OpenSSAG PRIVATE ${thirdparty_dir}/${LIBOPENSSAG}/src)
-  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} OpenSSAG)
-  set_property(TARGET OpenSSAG PROPERTY FOLDER "Thirdparty/")
+  endif()  # OPENSOURCE_ONLY
 
   # math library is needed, and should be one of the last things to link to here
   find_library(mathlib NAMES m)


### PR DESCRIPTION
OpenSSag is not really "open" (its license file shows it's copyrighted), so it should not be linked if OPENSSOURCE_ONLY is set.