### PR TITLE
Fix crash due to nullptr access of pPointingsource in simulator

### DIFF
--- a/gear_simulator.cpp
+++ b/gear_simulator.cpp
@@ -1006,10 +1006,10 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
     last_exposure_time = cur_time;
 
     // simulate worm phase changing with RA slew
-    double ra, dec, st;
-    bool err = pPointingSource->GetCoordinates(&ra, &dec, &st);
-    if (err)
-        ra = 0.;
+    double dec, st, ra = 0.;
+    if (pPointingSource)
+        pPointingSource->GetCoordinates(&ra, &dec, &st);
+
     static double s_prev_ra;
     double dra = norm(ra - s_prev_ra, -12.0, 12.0);
     s_prev_ra = ra;


### PR DESCRIPTION
Creating a new profile with just simulator
(Mount: none, Aux mount: none) causes a crash due to:

(gdb) bt
    at /home/tstibor/dev/astronomy/phd2/gear_simulator.cpp:1010
    at /home/tstibor/dev/astronomy/phd2/gear_simulator.cpp:1372
    (camera=0x555556861400, duration=1000, img=..., captureOptions=3, subframe=...) at /home/tstibor/dev/astronomy/phd2/camera.cpp:1475
(gdb) p img
$4 = (usImage &) @0x555556620d70: {ImageData = 0x7fffec003510, Size = {x = 752, y = 580}, Subframe = {x = 0, y = 0, width = 0, height = 0}, NPixels = 436160, Min = 0,
  Max = 0, FiltMin = 0, FiltMax = 0, ImgStartTime = {static ms_country = wxDateTime::Country_Unknown, static TIME_T_FACTOR = 1000, m_time = {m_ll = 1558298246075}},
  ImgExpDur = 1000, ImgStackCnt = 1, BitsPerPixel = 16 '\020', Pedestal = 0, FrameNum = 0}
(gdb) p pPointingSource
$5 = (Scope *) 0x0