### PR TITLE
check reentrancy of handle_cli_input

### DIFF
--- a/event_server.cpp
+++ b/event_server.cpp
@@ -2243,17 +2243,23 @@ static void handle_cli_input(wxSocketClient *cli, JsonParser& parser)
         char *end;
         while ((end = static_cast<char *>(memchr(rdbuf->buf(), '\n', rdbuf->len()))) != nullptr)
         {
-            *end = 0;
-            handle_cli_input_complete(cli, rdbuf->buf(), parser);
+            // Copy to temporary buffer to avoir rentrancy pb
+            size_t off = end - rdbuf->buf();
+            char line[off + 1];
+            memcpy(line, rdbuf->buf(), off);
+            line[off] = 0;
+
             char *next = end + 1;
             size_t len = rdbuf->dest - next;
             if (len == 0)
             {
                 rdbuf->reset();
-                break;
+            } else {
+                memmove(rdbuf->buf(), next, len);
+                rdbuf->dest = rdbuf->buf() + len;
             }
-            memmove(rdbuf->buf(), next, len);
-            rdbuf->dest = rdbuf->buf() + len;
+
+            handle_cli_input_complete(cli, line, parser);
         }
     }
 }


### PR DESCRIPTION
Advertise overlap support of the RPC api in the version message, so that clients can detect support (otherwise, clients using overlapped will break when used on older version of phd)

+ "just in case" ensure handle_cli_input is fully reentrant, without blocking anything