### PR TITLE
cam_indi: add an option to prevent fallback to streaming

### DIFF
--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -62,6 +62,7 @@ CameraINDI::CameraINDI()
     INDICameraCCD = pConfig->Profile.GetLong("/indi/INDIcam_ccd", 0);
     INDICameraPort = pConfig->Profile.GetString("/indi/INDIcam_port",_T(""));
     INDICameraForceVideo = pConfig->Profile.GetBoolean("/indi/INDIcam_forcevideo",false);
+    INDICameraForceExposure = pConfig->Profile.GetBoolean("/indi/INDIcam_forceexposure",false);
     Name = wxString::Format("INDI Camera [%s]", INDICameraName);
     SetCCDdevice();
     PropertyDialogType = PROPDLG_ANY;
@@ -618,6 +619,7 @@ void CameraINDI::CameraSetup()
     indiDlg.INDIDevCCD = INDICameraCCD;
     indiDlg.INDIDevPort = INDICameraPort;
     indiDlg.INDIForceVideo = INDICameraForceVideo;
+    indiDlg.INDIForceExposure = INDICameraForceExposure;
     // initialize with actual values
     indiDlg.SetSettings();
     // try to connect to server
@@ -632,11 +634,13 @@ void CameraINDI::CameraSetup()
         INDICameraCCD = indiDlg.INDIDevCCD;
         INDICameraPort = indiDlg.INDIDevPort;
         INDICameraForceVideo = indiDlg.INDIForceVideo;
+        INDICameraForceExposure = indiDlg.INDIForceExposure;
         pConfig->Profile.SetString("/indi/INDIhost", INDIhost);
         pConfig->Profile.SetLong("/indi/INDIport", INDIport);
         pConfig->Profile.SetString("/indi/INDIcam", INDICameraName);
         pConfig->Profile.SetLong("/indi/INDIcam_ccd",INDICameraCCD);
         pConfig->Profile.SetBoolean("/indi/INDIcam_forcevideo",INDICameraForceVideo);
+        pConfig->Profile.SetBoolean("/indi/INDIcam_forceexposure",INDICameraForceExposure);
         pConfig->Profile.SetString("/indi/INDIcam_port",INDICameraPort);
         Name = INDICameraName;
         SetCCDdevice();
@@ -912,7 +916,7 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
                 return true;
             if (watchdog.Expired())
             {
-                if (first_frame && video_prop)
+                if (first_frame && video_prop && !INDICameraForceExposure)
                 {
                     // exposure fail, maybe this is a webcam with only streaming
                     // try to use video stream instead of exposure
@@ -1051,6 +1055,8 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
         wxString msg;
         if (INDICameraForceVideo)
             msg = _("Camera has no VIDEO_STREAM property, please uncheck the option: Camera does not support exposure time.");
+        else if (INDICameraForceExposure)
+            msg = _("Camera has no CCD_EXPOSURE property, please uncheck the option: Camera does not support stream.");
         else
             msg = _("Camera has no CCD_EXPOSURE or VIDEO_STREAM property");
 

--- a/cam_indi.h
+++ b/cam_indi.h
@@ -100,6 +100,7 @@ private:
     wxString INDICameraBlobName;
     wxString INDICameraPort;
     bool     INDICameraForceVideo;
+    bool     INDICameraForceExposure;
     wxRect   m_roi;
 
     bool     ConnectToDriver(RunInBg *ctx);

--- a/config_indi.h
+++ b/config_indi.h
@@ -70,6 +70,7 @@ class INDIConfig : public wxDialog, public PhdIndiClient
     wxTextCtrl *devport;
     wxComboBox *ccd;
     wxCheckBox *forcevideo;
+    wxCheckBox *forceexposure;
     wxButton *guiBtn;
     wxButton *okBtn;
 
@@ -87,6 +88,7 @@ public:
     wxString INDIDevPort;
     long     INDIDevCCD;
     bool     INDIForceVideo;
+    bool     INDIForceExposure;
 
     void Connect();
     void Disconnect();
@@ -122,6 +124,7 @@ private:
     void OnIndiGui(wxCommandEvent& evt);
     void OnDevSelected(wxCommandEvent& evt);
     void OnVerboseChecked(wxCommandEvent& evt);
+    void OnForceVideoChecked(wxCommandEvent& evt);
     void UpdateControlStates();
 
     wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
INDI exposures sometime fail because camera/driver is in wrong state (ex: already exposing, user abort from indi panel, invalid conf, ...)
On such condition, the current version fallbacks to stream mode with no way to switch back to exposure. Stream mode should be regarded as a fallback since it is only 8 bits and may include alteration of the signal (gamma correction in latest git, and probably jpeg mode on some cam)

The current PR adds an option to disable fallback stream usage. It defaults to false to not change anything on existing installation.
