### PR TITLE
FreeBSD 12.1: Add compilation support

### DIFF
--- a/cam_sxv.cpp
+++ b/cam_sxv.cpp
@@ -290,7 +290,7 @@ bool CameraSXV::Connect(const wxString& camId)
 {
     // returns true on error
 
-#if defined (__APPLE__) || defined (__linux__)
+#if defined (__APPLE__) || defined (__linux__) || defined (__FreeBSD__)
     sxSetTimeoutMS(m_timeoutMs);
 #endif
 

--- a/cameras.h
+++ b/cameras.h
@@ -114,7 +114,7 @@
 # define ZWO_ASI
 #endif
 
-#elif defined (__linux__)
+#elif defined (__linux__) || defined (__FreeBSD__)
 
 # define SIMULATOR
 # define CAM_QHY5

--- a/cameras/SXMacLib.c
+++ b/cameras/SXMacLib.c
@@ -39,7 +39,7 @@
  
  \***************************************************************************/
 
-#if defined (__APPLE__) || defined (__linux__)
+#if defined (__APPLE__) || defined (__linux__) || defined (__FreeBSD__)
 
 #include "SXMacLib.h"
 
@@ -720,7 +720,7 @@ UInt32 sxOpen(void** sxHandles)
             ret = libusb_open(device[i], &handle);
             if (0 == ret) {
 
-#if defined (__linux__)
+#if defined (__linux__) || defined (__FreeBSD__)
                 if (libusb_kernel_driver_active(handle, 0) == 1) {
                     ret = libusb_detach_kernel_driver(handle, 0);
                     if (ret == 0) {

--- a/cameras/SXMacLib.h
+++ b/cameras/SXMacLib.h
@@ -31,7 +31,7 @@
  
  \***************************************************************************/
 
-#if defined (__APPLE__) || defined (__linux__)
+#if defined (__APPLE__) || defined (__linux__) || defined (__FreeBSD__)
 
 typedef unsigned short UInt16;
 typedef unsigned char Boolean;

--- a/contributions/MPI_IS_gaussian_process/CMakeLists.txt
+++ b/contributions/MPI_IS_gaussian_process/CMakeLists.txt
@@ -79,37 +79,43 @@ set_property(TARGET GPGuider PROPERTY FOLDER "Contributions/")
 # Unit tests
 #
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    set(gtest_link GTest::GTest)
+else()
+    set(gtest_link gtest)
+endif()
+
 
 # Test for the GP
 add_executable(GaussianProcessTest ${gaussian_process_root_dir}/tests/gaussian_process/gaussian_process_test.cpp)
-target_link_libraries(GaussianProcessTest MPIIS_GP gtest)
+target_link_libraries(GaussianProcessTest MPIIS_GP ${gtest_link})
 target_include_directories(GaussianProcessTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS})
 set_property(TARGET GaussianProcessTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GaussianProcessTest COMMAND GaussianProcessTest)
 
 # Test for the math tools
 add_executable(MathToolboxTest ${gaussian_process_root_dir}/tests/gaussian_process/math_tools_test.cpp)
-target_link_libraries(MathToolboxTest MPIIS_GP_TOOLS gtest)
+target_link_libraries(MathToolboxTest MPIIS_GP_TOOLS ${gtest_link})
 target_include_directories(MathToolboxTest  PRIVATE ${gaussian_process_root_dir}/src ${GTEST_HEADERS} ${EIGEN_SRC})
 set_property(TARGET MathToolboxTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME MathToolboxTest COMMAND MathToolboxTest)
 
 # Test for the GP Guider
 add_executable(GPGuiderTest ${gaussian_process_root_dir}/tests/gaussian_process/gp_guider_test.cpp)
-target_link_libraries(GPGuiderTest MPIIS_GP gtest GPGuider)
+target_link_libraries(GPGuiderTest MPIIS_GP ${gtest_link} GPGuider)
 target_include_directories(GPGuiderTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GPGuiderTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GPGuiderTest COMMAND GPGuiderTest WORKING_DIRECTORY ${gaussian_process_root_dir}/tests/gaussian_process/)
 
 # Performance Test for the GP Guider
 add_executable(GuidePerformanceTest ${gaussian_process_root_dir}/tests/gaussian_process/guide_performance_test.cpp)
-target_link_libraries(GuidePerformanceTest MPIIS_GP gtest GPGuider)
+target_link_libraries(GuidePerformanceTest MPIIS_GP ${gtest_link} GPGuider)
 target_include_directories(GuidePerformanceTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GuidePerformanceTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GuidePerformanceTest COMMAND GuidePerformanceTest WORKING_DIRECTORY ${gaussian_process_root_dir}/tests/gaussian_process/)
 
 # Performance Evaluation for the GP Guider
 add_executable(GuidePerformanceEval ${gaussian_process_root_dir}/tests/gaussian_process/evaluate_performance.cpp)
-target_link_libraries(GuidePerformanceEval MPIIS_GP gtest GPGuider)
+target_link_libraries(GuidePerformanceEval MPIIS_GP ${gtest_link} GPGuider)
 target_include_directories(GuidePerformanceEval  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GuidePerformanceEval PROPERTY FOLDER "Unit tests/Contribution")

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -2841,7 +2841,7 @@ struct FocalLengthValidator : public wxIntegerValidator<int>
     }
 };
 
-#ifdef __LINUX__
+#if defined(__LINUX__) || defined(__FreeBSD__)
 // ugly workaround for Issue 83 - link error on Linux
 //  undefined reference to wxPluralFormsCalculatorPtr::~wxPluralFormsCalculatorPtr
 wxPluralFormsCalculatorPtr::~wxPluralFormsCalculatorPtr() { }

--- a/phd.h
+++ b/phd.h
@@ -145,7 +145,7 @@ WX_DEFINE_ARRAY_DOUBLE(double, ArrayOfDbl);
 #define PHD_MESSAGES_CATALOG "messages"
 #endif
 
-#if defined (__linux__)
+#if defined (__linux__) || defined (__FreeBSD__)
 // On Linux the messages catalogs for all the applications are in the same directory
 // in /usr/share/locale, so the catalog name must be the application name.
 #define PHD_MESSAGES_CATALOG "phd2"

--- a/scopes.h
+++ b/scopes.h
@@ -56,7 +56,7 @@
     //#define GUIDE_NEB
     #define GUIDE_EQMAC
 
-#elif defined (__linux__)
+#elif defined (__linux__) || defined (__FreeBSD__)
 
     #define GUIDE_ONCAMERA
     #define GUIDE_ONSTEPGUIDER

--- a/serialport_posix.cpp
+++ b/serialport_posix.cpp
@@ -34,7 +34,7 @@
 
 #include "phd.h"
 
-#if defined (__linux__) || defined (__APPLE__)
+#if defined (__linux__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 #include <termios.h>
 #include <unistd.h>

--- a/serialport_posix.h
+++ b/serialport_posix.h
@@ -35,7 +35,7 @@
 #if !defined(SERIALPORT_POSIX_H_INCLUDED)
 #define SERIALPORT_POSIX_H_INCLUDED
 
-#if defined (__linux__) || defined (__APPLE__)
+#if defined (__linux__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 #include <termios.h>
 

--- a/stepguiders.h
+++ b/stepguiders.h
@@ -41,7 +41,7 @@
 #define STEPGUIDER_SXAO
 #endif
 
-#if defined (__linux__)
+#if defined (__linux__) || defined (__FreeBSD__)
 #define STEPGUIDER_SXAO
 #endif
 


### PR DESCRIPTION
Hello!

This PR contains changes required to make PHD2 compile on FreeBSD. The change highlights are that I've added definition checks for FreeBSD in a few places in the code, worked around a broken find_package for wxWidgets and excluded binary libraries that wouldn't link on FreeBSD.

I'm primarily interested in using Indi features together with PHD2 and I've upstreamed fixes to Indi to make it compile on FreeBSD again. At the moment, the only thing I've been able to properly test is webcam support via Indi using the V4L CCD driver that works on FreeBSD via webcamd. Attaching a webcam and getting images into PHD2 is working with the changes in this PR. Unfortunately, I am currently not able to test using my Celestron mount since it and I are geographically separate.

One question I have is whether the OpenPHD project interested in having upstreamed FreeBSD support? I'm contemplating looking into packaging Indi and PHD2 as a port and it would be smoother if build support were integrated upstream, rather than maintaining a patch set.

To compile on FreeBSD 12.1, do the following:
Make sure the following libraries are installed and available:
cfitsio
eigen3
googletest
libindi (currently not packaged for FreeBSD but should compile using latest upstream)
libusb (provided by the base system)
wx31-gtk3

Configure the project using the following line:
cmake . -DUSE_SYSTEM_CFITSIO=ON -DUSE_SYSTEM_EIGEN3=ON -DUSE_SYSTEM_GTEST=ON -DUSE_SYSTEM_LIBINDI=ON -DUSE_SYSTEM_LIBUSB=ON
make

Thank you for reading!