### PR TITLE
Revise dark-subtraction algorithm to fix problem with star auto-selection due to invalid pedestal value

### DIFF
--- a/darks_dialog.cpp
+++ b/darks_dialog.cpp
@@ -511,8 +511,11 @@ bool DarksDialog::CreateMasterDarkFrame(usImage& darkFrame, int expTime, int fra
         wxYield();
 
         darkFrame.CalcStats();
-        Debug.Write(wxString::Format("dark frame stats: bpp %u min %u max %u filtmin %u filtmax %u\n",
-            darkFrame.BitsPerPixel, darkFrame.MinADU, darkFrame.MaxADU, darkFrame.FiltMin, darkFrame.FiltMax));
+
+        Debug.Write(wxString::Format("dark frame stats: bpp %u min %u max %u med %u filtmin %u filtmax %u\n",
+                                     darkFrame.BitsPerPixel, darkFrame.MinADU, darkFrame.MaxADU,
+                                     darkFrame.MedianADU, darkFrame.FiltMin, darkFrame.FiltMax));
+
         Histogram h(darkFrame);
         h.Dump();
         wxYield();

--- a/darks_dialog.cpp
+++ b/darks_dialog.cpp
@@ -512,7 +512,7 @@ bool DarksDialog::CreateMasterDarkFrame(usImage& darkFrame, int expTime, int fra
 
         darkFrame.CalcStats();
         Debug.Write(wxString::Format("dark frame stats: bpp %u min %u max %u filtmin %u filtmax %u\n",
-            darkFrame.BitsPerPixel, darkFrame.Min, darkFrame.Max, darkFrame.FiltMin, darkFrame.FiltMax));
+            darkFrame.BitsPerPixel, darkFrame.MinADU, darkFrame.MaxADU, darkFrame.FiltMin, darkFrame.FiltMax));
         Histogram h(darkFrame);
         h.Dump();
         wxYield();

--- a/guider.cpp
+++ b/guider.cpp
@@ -718,8 +718,9 @@ void Guider::UpdateImageDisplay(usImage *pImage)
         pImage = m_pCurrentImage;
     }
 
-    Debug.Write(wxString::Format("UpdateImageDisplay: Size=(%d,%d) min=%d, max=%d, FiltMin=%d, FiltMax=%d, Gamma=%.3f\n",
-        pImage->Size.x, pImage->Size.y, pImage->MinADU, pImage->MaxADU, pImage->FiltMin, pImage->FiltMax, pFrame->Stretch_gamma));
+    Debug.Write(wxString::Format("UpdateImageDisplay: Size=(%d,%d) min=%u, max=%u, med=%u, FiltMin=%u, FiltMax=%u, Gamma=%.3f\n",
+                                 pImage->Size.x, pImage->Size.y, pImage->MinADU, pImage->MaxADU, pImage->MedianADU,
+                                 pImage->FiltMin, pImage->FiltMax, pFrame->Stretch_gamma));
 
     Refresh();
     Update();

--- a/guider.cpp
+++ b/guider.cpp
@@ -719,7 +719,7 @@ void Guider::UpdateImageDisplay(usImage *pImage)
     }
 
     Debug.Write(wxString::Format("UpdateImageDisplay: Size=(%d,%d) min=%d, max=%d, FiltMin=%d, FiltMax=%d, Gamma=%.3f\n",
-        pImage->Size.x, pImage->Size.y, pImage->Min, pImage->Max, pImage->FiltMin, pImage->FiltMax, pFrame->Stretch_gamma));
+        pImage->Size.x, pImage->Size.y, pImage->MinADU, pImage->MaxADU, pImage->FiltMin, pImage->FiltMax, pFrame->Stretch_gamma));
 
     Refresh();
     Update();

--- a/image_math.h
+++ b/image_math.h
@@ -80,8 +80,6 @@ struct ImageStats
     double stdev;
     unsigned short median;
     unsigned short mad;
-    unsigned short max;
-    unsigned short min;
 };
 
 class DefectMapBuilder

--- a/image_math.h
+++ b/image_math.h
@@ -80,6 +80,8 @@ struct ImageStats
     double stdev;
     unsigned short median;
     unsigned short mad;
+    unsigned short max;
+    unsigned short min;
 };
 
 class DefectMapBuilder

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -2405,6 +2405,8 @@ static bool load_multi_darks(GuideCamera *camera, const wxString& fname)
                 }
                 img->ImgExpDur = ROUNDF(exposure * 1000.0);
 
+                img->CalcStats();
+
                 Debug.Write(wxString::Format("loaded dark frame exposure = %d\n", img->ImgExpDur));
                 camera->AddDark(img.release());
 

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -2407,7 +2407,9 @@ static bool load_multi_darks(GuideCamera *camera, const wxString& fname)
 
                 img->CalcStats();
 
-                Debug.Write(wxString::Format("loaded dark frame exposure = %d\n", img->ImgExpDur));
+                Debug.Write(wxString::Format("loaded dark frame exposure = %d, med = %u\n",
+                                             img->ImgExpDur, img->MedianADU));
+
                 camera->AddDark(img.release());
 
                 // if this is the last hdu, we are done

--- a/usImage.cpp
+++ b/usImage.cpp
@@ -35,6 +35,8 @@
 #include "phd.h"
 #include "image_math.h"
 
+#include <algorithm>
+
 bool usImage::Init(const wxSize& size)
 {
     // Allocates space for image and sets params up
@@ -73,7 +75,6 @@ void usImage::SwapImageData(usImage& other)
     other.ImageData = t;
 }
 
-#include <algorithm>
 void usImage::CalcStats()
 {
     if (!ImageData || !NPixels)

--- a/usImage.h
+++ b/usImage.h
@@ -42,12 +42,13 @@ public:
     wxSize              Size;           // Dimensions of image
     wxRect              Subframe;       // were the valid data is
     unsigned int        NPixels;
-    int                 Min;
-    int                 Max;
-    int                 FiltMin;
-    int                 FiltMax;
+    unsigned short      MinADU;
+    unsigned short      MaxADU;
+    unsigned short      MedianADU;
+    unsigned short      FiltMin;
+    unsigned short      FiltMax;
     wxDateTime          ImgStartTime;
-    int                 ImgExpDur;
+    int                 ImgExpDur;      // milli-seconds
     int                 ImgStackCnt;
     wxByte              BitsPerPixel;
     unsigned short      Pedestal;
@@ -55,10 +56,11 @@ public:
 
     usImage()
         :
-        ImageData(0),
+        ImageData(nullptr),
         NPixels(0),
-        Min(0),
-        Max(0),
+        MinADU(0),
+        MaxADU(0),
+        MedianADU(0),
         FiltMin(0),
         FiltMax(0),
         ImgExpDur(0),


### PR DESCRIPTION
The current dark subtraction algorithm works adequately when the light frames are are lighter than the dark frames, which is typically the case.  But when dark frames are lighter then the lights, the existing Pedestal calculation does not behave well since it is based on a the minimum per-pixel difference.  Bruce did some testing with user data frames and found that basing the pedestal value on the difference between the overall median ADU works much better.
In order to support this, we now calculate the median ADU value for each light frame, and for dark frames when they are loaded. When subframes are in use, the median is computed over the subframe ROI for both the dark and light frames.