### PR TITLE
deselect star when scope starts slewing while looping exposures

### DIFF
--- a/gear_dialog.cpp
+++ b/gear_dialog.cpp
@@ -1308,6 +1308,9 @@ void GearDialog::OnChoiceScope(wxCommandEvent& event)
             throw THROW_INFO("OnChoiceScope: m_pScope == NULL");
         }
 
+        m_pScope->EnableStopGuidingWhenSlewing(pConfig->Profile.GetBoolean("/scope/StopGuidingWhenSlewing",
+            m_pScope->CanCheckSlewing()));
+
         m_ascomScopeSelected = choice.Contains("ASCOM");
     }
     catch (const wxString& Msg)
@@ -1344,6 +1347,9 @@ void GearDialog::OnChoiceAuxScope(wxCommandEvent& event)
         {
             throw THROW_INFO("OnAuxChoiceScope: m_pAuxScope == NULL");
         }
+
+        m_pAuxScope->EnableStopGuidingWhenSlewing(pConfig->Profile.GetBoolean("/scope/StopGuidingWhenSlewingAux",
+            m_pAuxScope->CanCheckSlewing()));
     }
     catch (const wxString& Msg)
     {

--- a/guider.cpp
+++ b/guider.cpp
@@ -1209,6 +1209,19 @@ void Guider::DisplayImage(usImage *img)
     UpdateImageDisplay();
 }
 
+static void LoopingCheckSlewing(Guider *guider)
+{
+    if (guider->CurrentPosition().IsValid() &&
+        pPointingSource &&
+        pPointingSource->IsConnected() &&
+        pPointingSource->CanCheckSlewing() &&
+        pPointingSource->Slewing())
+    {
+        Debug.Write(wxS("scope started slewing while looping, deselect\n"));
+        guider->InvalidateCurrentPosition(true);
+    }
+}
+
 /*************  A new image is ready ************************/
 
 void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
@@ -1243,6 +1256,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
         case STATE_SELECTING:
         case STATE_SELECTED:
             EvtServer.NotifyLooping(pImage->FrameNum);
+            LoopingCheckSlewing(this);
             break;
         case STATE_CALIBRATING_PRIMARY:
         case STATE_CALIBRATING_SECONDARY:

--- a/guider.cpp
+++ b/guider.cpp
@@ -1214,6 +1214,7 @@ static void LoopingCheckSlewing(Guider *guider)
     if (guider->CurrentPosition().IsValid() &&
         pPointingSource &&
         pPointingSource->IsConnected() &&
+        pPointingSource->IsStopGuidingWhenSlewingEnabled() &&
         pPointingSource->CanCheckSlewing() &&
         pPointingSource->Slewing())
     {

--- a/guider.h
+++ b/guider.h
@@ -274,14 +274,15 @@ public:
     // their operation
 private:
     virtual void InvalidateLockPosition();
+
 public:
     virtual void LoadProfileSettings();
 
     // pure virtual functions -- these MUST be overridden by a subclass
-public:
     virtual bool IsValidLockPosition(const PHD_Point& pt) = 0;
-private:
     virtual void InvalidateCurrentPosition(bool fullReset = false) = 0;
+
+private:
     virtual bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo) = 0;
     virtual bool SetCurrentPosition(const usImage *pImage, const PHD_Point& position) = 0;
 

--- a/scope.cpp
+++ b/scope.cpp
@@ -457,13 +457,6 @@ Scope *Scope::Factory(const wxString& choice)
         {
             throw ERROR_INFO("ScopeFactory: Unknown Scope choice");
         }
-
-        if (pReturn)
-        {
-            // virtual function call means we cannot do this in the Scope constructor
-            pReturn->EnableStopGuidingWhenSlewing(pConfig->Profile.GetBoolean("/scope/StopGuidingWhenSlewing",
-                pReturn->CanCheckSlewing()));
-        }
     }
     catch (const wxString& Msg)
     {


### PR DESCRIPTION
While looping exposures (but not guiding) poll pPointingSource to check for slewing, and deselect the guide star if slewing is detected.
The behavior is enabled only when the _Stop guiding when mount slews_ option is enabled.

Fixes #867