### PR TITLE
Add means to de-select star and restore full-frame image display

### DIFF
--- a/guider.h
+++ b/guider.h
@@ -280,8 +280,8 @@ public:
     // pure virtual functions -- these MUST be overridden by a subclass
 public:
     virtual bool IsValidLockPosition(const PHD_Point& pt) = 0;
-private:
     virtual void InvalidateCurrentPosition(bool fullReset = false) = 0;
+private:
     virtual bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo) = 0;
     virtual bool SetCurrentPosition(const usImage *pImage, const PHD_Point& position) = 0;
 

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -964,7 +964,7 @@ void MyFrame::SetupToolBar()
 
     MainToolbar->AddTool(BUTTON_GEAR, connect_bmp, connect_bmp_disabled, false, 0, _("Connect to equipment. Shift-click to reconnect the same equipment last connected."));
     MainToolbar->AddTool(BUTTON_LOOP, loop_bmp, loop_bmp_disabled, false, 0, _("Begin looping exposures for frame and focus"));
-    MainToolbar->AddTool(BUTTON_AUTOSTAR, auto_select_bmp, auto_select_disabled_bmp, false, 0, _("Auto-select Star"));
+    MainToolbar->AddTool(BUTTON_AUTOSTAR, auto_select_bmp, auto_select_disabled_bmp, false, 0, _("Auto-select Star. Shift-click to de-select star."));
     MainToolbar->AddTool(BUTTON_GUIDE, guide_bmp, guide_bmp_disabled, false, 0, _("Begin guiding (PHD). Shift-click to force calibration."));
     MainToolbar->AddTool(BUTTON_STOP, stop_bmp, stop_bmp_disabled, false, 0, _("Stop looping and guiding"));
     MainToolbar->AddSeparator();

--- a/myframe_events.cpp
+++ b/myframe_events.cpp
@@ -622,7 +622,10 @@ void MyFrame::OnButtonStop(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnButtonAutoStar(wxCommandEvent& WXUNUSED(event))
 {
-    AutoSelectStar();
+    if (!wxGetKeyState(WXK_SHIFT))
+        AutoSelectStar();
+    else
+        pGuider->InvalidateCurrentPosition(true);
 }
 
 void MyFrame::OnGammaSlider(wxScrollEvent& WXUNUSED(event))


### PR DESCRIPTION
Provide another way to de-select the guide star and restore full-frame display if sub-frames are being used.  The "place" in the UI where you selected the star is now the same place you go to de-select it, and there can be a tooltip to say how to do it.  The existing shift-click on the display area is fine but it is a hidden feature.