### PR TITLE
ZWO / INDI / ASCOM cameras: do not assume binned frame size

### DIFF
--- a/cam_ascom.cpp
+++ b/cam_ascom.cpp
@@ -58,6 +58,7 @@ class CameraASCOM : public GuideCamera
     wxString m_choice; // name of chosen camera
     wxRect m_roi;
     wxSize m_maxSize;
+    bool m_swapAxes;
     bool m_canAbortExposure;
     bool m_canStopExposure;
     bool m_canSetCoolerTemperature;
@@ -131,13 +132,13 @@ static bool ASCOM_SetBin(IDispatch *cam, int binning, EXCEPINFO *excep)
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_setxbin, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke setxbin", *excep);
         return true;
     }
     if (FAILED(hr = cam->Invoke(dispid_setybin, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke setybin", *excep);
         return true;
@@ -165,7 +166,7 @@ static bool ASCOM_SetROI(IDispatch *cam, const wxRect& roi, EXCEPINFO *excep)
 
     rgvarg[0].lVal = roi.GetLeft();
     if (FAILED(hr = cam->Invoke(dispid_startx, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "set startx", *excep);
         return true;
@@ -173,7 +174,7 @@ static bool ASCOM_SetROI(IDispatch *cam, const wxRect& roi, EXCEPINFO *excep)
 
     rgvarg[0].lVal = roi.GetTop();
     if (FAILED(hr = cam->Invoke(dispid_starty, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "set starty", *excep);
         return true;
@@ -181,7 +182,7 @@ static bool ASCOM_SetROI(IDispatch *cam, const wxRect& roi, EXCEPINFO *excep)
 
     rgvarg[0].lVal = roi.GetWidth();
     if (FAILED(hr = cam->Invoke(dispid_numx, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "set numx", *excep);
         return true;
@@ -189,7 +190,7 @@ static bool ASCOM_SetROI(IDispatch *cam, const wxRect& roi, EXCEPINFO *excep)
 
     rgvarg[0].lVal = roi.GetHeight();
     if (FAILED(hr = cam->Invoke(dispid_numy, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYPUT,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "set numy", *excep);
         return true;
@@ -204,15 +205,15 @@ static bool ASCOM_AbortExposure(IDispatch *cam, EXCEPINFO *excep)
 
     DISPPARAMS dispParms;
     dispParms.cArgs = 0;
-    dispParms.rgvarg = NULL;
+    dispParms.rgvarg = nullptr;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     Variant vRes;
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_abortexposure, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke abortexposure", *excep);
         return true;
@@ -227,15 +228,15 @@ static bool ASCOM_StopExposure(IDispatch *cam, EXCEPINFO *excep)
 
     DISPPARAMS dispParms;
     dispParms.cArgs = 0;
-    dispParms.rgvarg = NULL;
+    dispParms.rgvarg = nullptr;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     Variant vRes;
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_stopexposure, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke stopexposure", *excep);
         return true;
@@ -258,13 +259,13 @@ static bool ASCOM_StartExposure(IDispatch *cam, double duration, bool dark, EXCE
     dispParms.cArgs = 2;
     dispParms.rgvarg = rgvarg;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     Variant vRes;
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_startexposure, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke startexposure", *excep);
         return true;
@@ -279,15 +280,15 @@ static bool ASCOM_ImageReady(IDispatch *cam, bool *ready, EXCEPINFO *excep)
 
     DISPPARAMS dispParms;
     dispParms.cArgs = 0;
-    dispParms.rgvarg = NULL;
+    dispParms.rgvarg = nullptr;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     Variant vRes;
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_imageready, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYGET,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke imageready", *excep);
         return true;
@@ -297,21 +298,22 @@ static bool ASCOM_ImageReady(IDispatch *cam, bool *ready, EXCEPINFO *excep)
     return false;
 }
 
-static bool ASCOM_Image(IDispatch *cam, usImage& Image, bool takeSubframe, const wxRect& subframe, EXCEPINFO *excep)
+static bool ASCOM_Image(IDispatch *cam, usImage& img, bool is_subframe, const wxRect& roi,
+                        wxSize *size, const wxSize& max_size, bool *swap_axes, EXCEPINFO *excep)
 {
     // returns true on error, false if OK
 
     DISPPARAMS dispParms;
     dispParms.cArgs = 0;
-    dispParms.rgvarg = NULL;
+    dispParms.rgvarg = nullptr;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     Variant vRes;
     HRESULT hr;
 
     if (FAILED(hr = cam->Invoke(dispid_imagearray, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYGET,
-        &dispParms, &vRes, excep, NULL)))
+        &dispParms, &vRes, excep, nullptr)))
     {
         LogExcep(hr, "invoke imagearray", *excep);
         return true;
@@ -335,30 +337,63 @@ static bool ASCOM_Image(IDispatch *cam, usImage& Image, bool takeSubframe, const
 
     long xsize = ubound1 - lbound1 + 1;
     long ysize = ubound2 - lbound2 + 1;
-    if ((xsize < ysize) && (Image.Size.GetWidth() > Image.Size.GetHeight())) // array has dim #'s switched, Tom..
+
+    if (!is_subframe && !*swap_axes && xsize < ysize && max_size.x > max_size.y)
     {
-        std::swap(xsize, ysize);
+        Debug.Write(wxString::Format("ASCOM camera: array axes are flipped (%dx%d) vs (%dx%d)\n",
+            xsize, ysize, max_size.x, max_size.y));
+
+        *swap_axes = true;
     }
 
-    if (takeSubframe)
-    {
-        Image.Subframe = subframe;
+    if (*swap_axes)
+        std::swap(xsize, ysize);
 
-        // Clear out the image
-        Image.Clear();
+    if (is_subframe)
+    {
+        if (*size == UNDEFINED_FRAME_SIZE)
+        {
+            // should never happen since we arranged not to take a subframe
+            // unless full frame size is known
+            Debug.Write("internal error: taking subframe before full frame\n");
+            hr = SafeArrayUnaccessData(rawarray);
+            hr = SafeArrayDestroyData(rawarray);
+            return true;
+        }
+
+        if (img.Init(*size))
+        {
+            pFrame->Alert(_("Memory allocation error"));
+            hr = SafeArrayUnaccessData(rawarray);
+            hr = SafeArrayDestroyData(rawarray);
+            return true;
+        }
+
+        img.Clear();
+        img.Subframe = roi;
 
         int i = 0;
-        for (int y = 0; y < subframe.height; y++)
+        for (int y = 0; y < roi.height; y++)
         {
-            unsigned short *dataptr = Image.ImageData + (y + subframe.y) * Image.Size.GetWidth() + subframe.x;
-            for (int x = 0; x < subframe.width; x++, i++)
+            unsigned short *dataptr = img.ImageData + (y + roi.y) * img.Size.GetWidth() + roi.x;
+            for (int x = 0; x < roi.width; x++, i++)
                 *dataptr++ = (unsigned short) rawdata[i];
         }
     }
     else
     {
-        for (unsigned int i = 0; i < Image.NPixels; i++)
-            Image.ImageData[i] = (unsigned short) rawdata[i];
+        size->Set(xsize, ysize);
+
+        if (img.Init(*size))
+        {
+            pFrame->Alert(_("Memory allocation error"));
+            hr = SafeArrayUnaccessData(rawarray);
+            hr = SafeArrayDestroyData(rawarray);
+            return true;
+        }
+
+        for (unsigned int i = 0; i < img.NPixels; i++)
+            img.ImageData[i] = (unsigned short) rawdata[i];
     }
 
     hr = SafeArrayUnaccessData(rawarray);
@@ -371,15 +406,15 @@ static bool ASCOM_IsMoving(IDispatch *cam)
 {
     DISPPARAMS dispParms;
     dispParms.cArgs = 0;
-    dispParms.rgvarg = NULL;
+    dispParms.rgvarg = nullptr;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs = NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     HRESULT hr;
     ExcepInfo excep;
     Variant vRes;
 
-    if (FAILED(hr = cam->Invoke(dispid_ispulseguiding, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYGET, &dispParms, &vRes, &excep, NULL)))
+    if (FAILED(hr = cam->Invoke(dispid_ispulseguiding, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_PROPERTYGET, &dispParms, &vRes, &excep, nullptr)))
     {
         LogExcep(hr, "invoke ispulseguiding", excep);
         pFrame->Alert(ExcepMsg(_("ASCOM driver failed checking IsPulseGuiding. See the debug log for more information."), excep));
@@ -395,7 +430,6 @@ CameraASCOM::CameraASCOM(const wxString& choice)
 
     Connected = false;
     Name = choice;
-    FullSize = wxSize(100,100);
     m_hasGuideOutput = false;
     HasGainControl = false;
     HasSubframes = true;
@@ -593,6 +627,8 @@ bool CameraASCOM::Connect(const wxString& camId)
     }
     m_maxSize.SetHeight((int) vRes.lVal);
 
+    m_swapAxes = false;
+
     if (!driver.GetProp(&vRes, L"MaxADU"))
     {
         Debug.AddLine(ExcepMsg("MaxADU", driver.Excep()));
@@ -736,9 +772,9 @@ bool CameraASCOM::Connect(const wxString& camId)
             return CamConnectFailed(_("The ASCOM camera failed to set binning. See the debug log for more information."));
         }
     }
-    FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
-    m_roi = FullSize;
-    ASCOM_SetROI(driver.IDisp(), FullSize, &excep);
+
+    // defer defining FullSize since it is not simply derivable from max size and binning
+    // no: FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
 
     Connected = true;
 
@@ -898,7 +934,7 @@ void CameraASCOM::ShowPropertyDialog()
 {
     DispatchObj camera;
 
-    if (Create(&camera, NULL))
+    if (Create(&camera, nullptr))
     {
         Variant res;
         if (!camera.InvokeMethod(&res, L"SetupDialog"))
@@ -934,9 +970,9 @@ bool CameraASCOM::Capture(int duration, usImage& img, int options, const wxRect&
 {
     bool retval = false;
     bool takeSubframe = UseSubframes;
-    wxRect subframe(subframeArg);
+    wxRect roi(subframeArg);
 
-    if (subframe.width <= 0 || subframe.height <= 0)
+    if (roi.width <= 0 || roi.height <= 0)
     {
         takeSubframe = false;
     }
@@ -944,21 +980,38 @@ bool CameraASCOM::Capture(int duration, usImage& img, int options, const wxRect&
     bool binning_changed = false;
     if (Binning != m_curBin)
     {
-        FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
         binning_changed = true;
         takeSubframe = false; // subframe may be out of bounds now
+        if (Binning == 1)
+            FullSize.Set(m_maxSize.x, m_maxSize.y);
+        else
+            FullSize = UNDEFINED_FRAME_SIZE; // we don't know the binned size until we get a frame
+    }
+
+    if (takeSubframe && FullSize == UNDEFINED_FRAME_SIZE)
+    {
+        // if we do not know the full frame size, we cannot take a
+        // subframe until we receive a full frame and get the frame size
+        takeSubframe = false;
     }
 
     // Program the size
     if (!takeSubframe)
     {
-        subframe = wxRect(0, 0, FullSize.GetWidth(), FullSize.GetHeight());
-    }
-
-    if (img.Init(FullSize))
-    {
-        pFrame->Alert(_("Cannot allocate memory to download image from camera"));
-        return true;
+        wxSize sz;
+        if (FullSize != UNDEFINED_FRAME_SIZE)
+        {
+            // we know the actual frame size
+            sz = FullSize;
+        }
+        else
+        {
+            // the max size divided by the binning may be larger than
+            // the actual frame, but setting a larger size should
+            // request the full binned frame which we want
+            sz.Set(m_maxSize.x / Binning, m_maxSize.y / Binning);
+        }
+        roi = wxRect(sz);
     }
 
     GITObjRef cam(m_gitEntry);
@@ -975,10 +1028,10 @@ bool CameraASCOM::Capture(int duration, usImage& img, int options, const wxRect&
         m_curBin = Binning;
     }
 
-    if (subframe != m_roi)
+    if (roi != m_roi)
     {
-        ASCOM_SetROI(cam.IDisp(), subframe, &excep);
-        m_roi = subframe;
+        ASCOM_SetROI(cam.IDisp(), roi, &excep);
+        m_roi = roi;
     }
 
     bool takeDark = HasShutter && ShutterClosed;
@@ -1029,7 +1082,7 @@ bool CameraASCOM::Capture(int duration, usImage& img, int options, const wxRect&
     }
 
     // Get the image
-    if (ASCOM_Image(cam.IDisp(), img, takeSubframe, subframe, &excep))
+    if (ASCOM_Image(cam.IDisp(), img, takeSubframe, roi, &FullSize, m_maxSize, &m_swapAxes, &excep))
     {
         Debug.AddLine(ExcepMsg(_T("ASCOM_Image failed"), excep));
         pFrame->Alert(ExcepMsg(_("Error reading image"), excep));
@@ -1064,7 +1117,7 @@ bool CameraASCOM::ST4PulseGuideScope(int direction, int duration)
     dispParms.cArgs = 2;
     dispParms.rgvarg = rgvarg;
     dispParms.cNamedArgs = 0;
-    dispParms.rgdispidNamedArgs =NULL;
+    dispParms.rgdispidNamedArgs = nullptr;
 
     MountWatchdog watchdog(duration, 5000);
 
@@ -1073,7 +1126,7 @@ bool CameraASCOM::ST4PulseGuideScope(int direction, int duration)
     HRESULT hr;
 
     if (FAILED(hr = cam.IDisp()->Invoke(dispid_pulseguide, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD,
-        &dispParms,&vRes,&excep,NULL)))
+        &dispParms, &vRes, &excep, nullptr)))
     {
         LogExcep(hr, "invoke pulseguide", excep);
         return true;

--- a/cam_ascom.h
+++ b/cam_ascom.h
@@ -1,100 +1,46 @@
 /*
- *  cam_ascom.h
- *  PHD2 Guiding
- *
- *  Created by Craig Stark.
- *  Copyright (c) 2009-2010 Craig Stark.
- *  Copyright (c) 2013-2017 Andy Galasso.
- *  All rights reserved.
- *
- *  This source code is distributed under the following "BSD" license
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *    Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *    Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *    Neither the name of Craig Stark, Stark Labs, openphdguiding.org nor the names of its
- *     contributors may be used to endorse or promote products derived from
- *     this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *
- */
+*  cam_ascom.h
+*  Open PHD Guiding
+*
+*  Copyright (c) 2020 Andy Galasso.
+*  All rights reserved.
+*
+*  This source code is distributed under the following "BSD" license
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*    Redistributions of source code must retain the above copyright notice,
+*     this list of conditions and the following disclaimer.
+*    Redistributions in binary form must reproduce the above copyright notice,
+*     this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*    Neither the name of openphdguiding.org nor the names of its
+*     contributors may be used to endorse or promote products derived from
+*     this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+*  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+*  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+*  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+*  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+*  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+*  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+*  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+*  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+*/
 
 #ifndef CAM_ASCOM_INCLUDED
 #define CAM_ASCOM_INCLUDED
 
-#if defined (ASCOM_CAMERA)
+class GuideCamera;
 
-class DispatchObj;
-class DispatchClass;
-
-class CameraASCOM : public GuideCamera
+class ASCOMCameraFactory
 {
-#ifdef __WINDOWS__
-
-    GITEntry m_gitEntry;
-    int DriverVersion;
-    wxString m_choice; // name of chosen camera
-    wxRect m_roi;
-    wxSize m_maxSize;
-    bool m_canAbortExposure;
-    bool m_canStopExposure;
-    bool m_canSetCoolerTemperature;
-    bool m_canGetCoolerPower;
-    wxByte m_bitsPerPixel;
-    wxByte m_curBin;
-    double m_driverPixelSize;
-
-#endif // __WINDOWS__
-
 public:
-
-    bool Color;
-
     static wxArrayString EnumAscomCameras();
-
-    CameraASCOM(const wxString& choice);
-    ~CameraASCOM();
-
-    bool    Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
-    bool    HasNonGuiCapture() override;
-    bool    Connect(const wxString& camId) override;
-    bool    Disconnect() override;
-    void    ShowPropertyDialog() override;
-    bool    ST4PulseGuideScope(int direction, int duration) override;
-    wxByte  BitsPerPixel() override;
-    bool    GetDevicePixelSize(double* devPixelSize) override;
-    bool    SetCoolerOn(bool on) override;
-    bool    SetCoolerSetpoint(double temperature) override;
-    bool    GetCoolerStatus(bool *on, double *setpoint, double *power, double *temperature) override;
-    bool    GetSensorTemperature(double *temperature) override;
-
-private:
-
-#ifdef __WINDOWS__
-
-    bool Create(DispatchObj *obj, DispatchClass *cls);
-
-    bool AbortExposure();
-
-    bool ST4HasNonGuiMove() override;
-
-#endif
+    static GuideCamera *MakeASCOMCamera(const wxString& name);
 };
-
-#endif // defined (ASCOM_CAMERA)
 
 #endif // CAM_ASCOM_INCLUDED

--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -230,7 +230,7 @@ void CameraINDI::newSwitch(ISwitchVectorProperty *svp)
     // we go here every time a Switch state change
 
     if (INDIConfig::Verbose())
-        Debug.Write(wxString::Format("INDI Camera Receive Switch: %s = %i\n", svp->name, svp->sp->s));
+        Debug.Write(wxString::Format("INDI Camera Received Switch: %s = %i\n", svp->name, svp->sp->s));
 
     if (strcmp(svp->name, "CONNECTION") == 0)
     {
@@ -263,7 +263,7 @@ void CameraINDI::newMessage(INDI::BaseDevice *dp, int messageID)
     // we go here every time the camera driver send a message
 
     if (INDIConfig::Verbose())
-        Debug.Write(wxString::Format("INDI Camera Receive message: %s\n", dp->messageQueue(messageID)));
+        Debug.Write(wxString::Format("INDI Camera Received message: %s\n", dp->messageQueue(messageID)));
 }
 
 inline static const char *StateStr(IPState st)
@@ -290,9 +290,13 @@ void CameraINDI::newNumber(INumberVectorProperty *nvp)
                 return;
             s_lastval = nvp->np->value;
         }
-
-        Debug.Write(wxString::Format("INDI Camera Received Number: %s = %g state = %s\n",
-                                     nvp->name, nvp->np->value, StateStr(nvp->s)));
+        std::ostringstream os;
+        for (int i = 0; i < nvp->nnp; i++)
+        {
+            if (i) os << ',';
+            os << nvp->np[i].name << ':' << nvp->np[i].value;
+        }
+        Debug.Write(wxString::Format("INDI Camera Received Number: %s = %s state = %s\n", nvp->name, os.str().c_str(), StateStr(nvp->s)));
     }
 
     if (nvp == ccdinfo_prop)
@@ -344,7 +348,7 @@ void CameraINDI::newText(ITextVectorProperty *tvp)
     // we go here every time a Text value change
 
     if (INDIConfig::Verbose())
-        Debug.Write(wxString::Format("INDI Camera Receive Text: %s = %s\n", tvp->name, tvp->tp->text));
+        Debug.Write(wxString::Format("INDI Camera Received Text: %s = %s\n", tvp->name, tvp->tp->text));
 }
 
 void CameraINDI::newBLOB(IBLOB *bp)
@@ -353,7 +357,7 @@ void CameraINDI::newBLOB(IBLOB *bp)
     // this is normally the image from the camera
 
     if (INDIConfig::Verbose())
-        Debug.Write(wxString::Format("INDI Camera Got camera blob %s\n", bp->name));
+        Debug.Write(wxString::Format("INDI Camera Received BLOB %s len=%d size=%d\n", bp->name, bp->bloblen, bp->size));
 
     if (expose_prop && !INDICameraForceVideo)
     {

--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -138,7 +138,7 @@ void CameraINDI::newSwitch(ISwitchVectorProperty *svp)
 
     if (strcmp(svp->name, "CONNECTION") == 0)
     {
-        ISwitch *connectswitch = IUFindSwitch(svp,"CONNECT");
+        ISwitch *connectswitch = IUFindSwitch(svp, "CONNECT");
         if (connectswitch->s == ISS_ON)
         {
             Connected = true;
@@ -194,16 +194,18 @@ void CameraINDI::newNumber(INumberVectorProperty *nvp)
                 return;
             s_lastval = nvp->np->value;
         }
-        Debug.Write(wxString::Format("INDI Camera Receive Number: %s = %g state = %s\n", nvp->name, nvp->np->value, StateStr(nvp->s)));
+
+        Debug.Write(wxString::Format("INDI Camera Received Number: %s = %g state = %s\n",
+                                     nvp->name, nvp->np->value, StateStr(nvp->s)));
     }
 
     if (nvp == ccdinfo_prop)
     {
-        PixSize = IUFindNumber(ccdinfo_prop,"CCD_PIXEL_SIZE")->value;
-        PixSizeX = IUFindNumber(ccdinfo_prop,"CCD_PIXEL_SIZE_X")->value;
-        PixSizeY = IUFindNumber(ccdinfo_prop,"CCD_PIXEL_SIZE_Y")->value;
-        m_maxSize.x = IUFindNumber(ccdinfo_prop,"CCD_MAX_X")->value;
-        m_maxSize.y = IUFindNumber(ccdinfo_prop,"CCD_MAX_Y")->value;
+        PixSize = IUFindNumber(ccdinfo_prop, "CCD_PIXEL_SIZE")->value;
+        PixSizeX = IUFindNumber(ccdinfo_prop, "CCD_PIXEL_SIZE_X")->value;
+        PixSizeY = IUFindNumber(ccdinfo_prop, "CCD_PIXEL_SIZE_Y")->value;
+        m_maxSize.x = IUFindNumber(ccdinfo_prop, "CCD_MAX_X")->value;
+        m_maxSize.y = IUFindNumber(ccdinfo_prop, "CCD_MAX_Y")->value;
         FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
         m_bitsPerPixel = IUFindNumber(ccdinfo_prop, "CCD_BITSPERPIXEL")->value;
     }
@@ -222,7 +224,8 @@ void CameraINDI::newNumber(INumberVectorProperty *nvp)
         {
             wxMutexLocker lck(sync_lock);
             if (guide_active && nvp->s != IPS_BUSY &&
-                ((guide_active_axis == GUIDE_RA && nvp == pulseGuideEW_prop) || (guide_active_axis == GUIDE_DEC && nvp == pulseGuideNS_prop)))
+                ((guide_active_axis == GUIDE_RA && nvp == pulseGuideEW_prop) ||
+                 (guide_active_axis == GUIDE_DEC && nvp == pulseGuideNS_prop)))
             {
                 guide_active = false;
                 notify = true;
@@ -313,10 +316,10 @@ void CameraINDI::newProperty(INDI::Property *property)
             Debug.Write(wxString::Format("INDI Camera Found CCD_FRAME for %s %s\n", property->getDeviceName(), PropName));
 
         frame_prop = property->getNumber();
-        frame_x = IUFindNumber(frame_prop,"X");
-        frame_y = IUFindNumber(frame_prop,"Y");
-        frame_width = IUFindNumber(frame_prop,"WIDTH");
-        frame_height = IUFindNumber(frame_prop,"HEIGHT");
+        frame_x = IUFindNumber(frame_prop, "X");
+        frame_y = IUFindNumber(frame_prop, "Y");
+        frame_width = IUFindNumber(frame_prop, "WIDTH");
+        frame_height = IUFindNumber(frame_prop, "HEIGHT");
     }
     else if (PropName == INDICameraCCDCmd + "FRAME_TYPE" && Proptype == INDI_SWITCH)
     {
@@ -331,8 +334,8 @@ void CameraINDI::newProperty(INDI::Property *property)
             Debug.Write(wxString::Format("INDI Camera Found CCD_BINNING for %s %s\n", property->getDeviceName(), PropName));
 
         binning_prop = property->getNumber();
-        binning_x = IUFindNumber(binning_prop,"HOR_BIN");
-        binning_y = IUFindNumber(binning_prop,"VER_BIN");
+        binning_x = IUFindNumber(binning_prop, "HOR_BIN");
+        binning_y = IUFindNumber(binning_prop, "VER_BIN");
         newNumber(binning_prop);
     }
     else if (PropName == INDICameraCCDCmd + "CFA" && Proptype == INDI_TEXT)
@@ -380,7 +383,7 @@ void CameraINDI::newProperty(INDI::Property *property)
 
         // Check the value here in case the device is already connected
         connection_prop = property->getSwitch();
-        ISwitch *connectswitch = IUFindSwitch(connection_prop,"CONNECT");
+        ISwitch *connectswitch = IUFindSwitch(connection_prop, "CONNECT");
         Connected = (connectswitch->s == ISS_ON);
     }
     else if (PropName == "DRIVER_INFO" && Proptype == INDI_TEXT)
@@ -391,14 +394,14 @@ void CameraINDI::newProperty(INDI::Property *property)
     else if (PropName == "TELESCOPE_TIMED_GUIDE_NS" && Proptype == INDI_NUMBER)
     {
         pulseGuideNS_prop = property->getNumber();
-        pulseN_prop = IUFindNumber(pulseGuideNS_prop,"TIMED_GUIDE_N");
-        pulseS_prop = IUFindNumber(pulseGuideNS_prop,"TIMED_GUIDE_S");
+        pulseN_prop = IUFindNumber(pulseGuideNS_prop, "TIMED_GUIDE_N");
+        pulseS_prop = IUFindNumber(pulseGuideNS_prop, "TIMED_GUIDE_S");
     }
     else if (PropName == "TELESCOPE_TIMED_GUIDE_WE" && Proptype == INDI_NUMBER)
     {
         pulseGuideEW_prop = property->getNumber();
-        pulseW_prop = IUFindNumber(pulseGuideEW_prop,"TIMED_GUIDE_W");
-        pulseE_prop = IUFindNumber(pulseGuideEW_prop,"TIMED_GUIDE_E");
+        pulseW_prop = IUFindNumber(pulseGuideEW_prop, "TIMED_GUIDE_W");
+        pulseE_prop = IUFindNumber(pulseGuideEW_prop, "TIMED_GUIDE_E");
     }
     else if (PropName == INDICameraCCDCmd + "INFO" && Proptype == INDI_NUMBER)
     {
@@ -671,7 +674,7 @@ bool CameraINDI::ReadFITS(usImage& img, bool takeSubframe, const wxRect& subfram
     ysize = (int) fits_size[1];
     fits_get_num_hdus(fptr,&nhdus,&status);
 
-    if ((nhdus != 1) || (naxis != 2))
+    if (nhdus != 1 || naxis != 2)
     {
         pFrame->Alert(_("Unsupported type or read error loading FITS file"));
         PHD_fits_close_file(fptr);
@@ -692,7 +695,7 @@ bool CameraINDI::ReadFITS(usImage& img, bool takeSubframe, const wxRect& subfram
 
         unsigned short *rawdata = new unsigned short[xsize*ysize];
 
-        if (fits_read_pix(fptr, TUSHORT, fpixel, xsize*ysize, nullptr, rawdata, nullptr, &status))
+        if (fits_read_pix(fptr, TUSHORT, fpixel, xsize * ysize, nullptr, rawdata, nullptr, &status))
         {
             pFrame->Alert(_("Error reading data"));
             PHD_fits_close_file(fptr);
@@ -712,7 +715,7 @@ bool CameraINDI::ReadFITS(usImage& img, bool takeSubframe, const wxRect& subfram
     }
     else
     {
-        if (img.Init(xsize,ysize))
+        if (img.Init(xsize, ysize))
         {
             pFrame->Alert(_("Memory allocation error"));
             PHD_fits_close_file(fptr);
@@ -720,7 +723,7 @@ bool CameraINDI::ReadFITS(usImage& img, bool takeSubframe, const wxRect& subfram
         }
 
         // Read image
-        if (fits_read_pix(fptr, TUSHORT, fpixel, xsize*ysize, nullptr, img.ImageData, nullptr, &status))
+        if (fits_read_pix(fptr, TUSHORT, fpixel, xsize * ysize, nullptr, img.ImageData, nullptr, &status))
         {
             pFrame->Alert(_("Error reading data"));
             PHD_fits_close_file(fptr);
@@ -759,7 +762,7 @@ bool CameraINDI::ReadStream(usImage& img)
     ysize = frame_height->value;
 
     // allocate image
-    if (img.Init(xsize,ysize))
+    if (img.Init(xsize, ysize))
     {
         pFrame->Alert(_("CCD stream: memory allocation error"));
         return true;
@@ -811,7 +814,7 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
     // we can set the exposure time directly in the camera
     if (expose_prop && !INDICameraForceVideo)
     {
-        if (binning_prop && (Binning != m_curBinning))
+        if (binning_prop && Binning != m_curBinning)
         {
             FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
             binning_x->value = Binning;
@@ -832,12 +835,12 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
             subframe = wxRect(0, 0, FullSize.GetWidth(), FullSize.GetHeight());
         }
 
-        if (frame_prop && (subframe != m_roi))
+        if (frame_prop && subframe != m_roi)
         {
-            frame_x->value = subframe.x*Binning;
-            frame_y->value = subframe.y*Binning;
-            frame_width->value = subframe.width*Binning;
-            frame_height->value = subframe.height*Binning;
+            frame_x->value = subframe.x * Binning;
+            frame_y->value = subframe.y * Binning;
+            frame_width->value = subframe.width * Binning;
+            frame_height->value = subframe.height * Binning;
             sendNewNumber(frame_prop);
             m_roi = subframe;
         }
@@ -870,7 +873,7 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
             Debug.Write(wxString::Format("INDI Camera Exposing for %dms\n", duration));
 
         // set the exposure time, this immediately start the exposure
-        expose_prop->np->value = (double)duration/1000;
+        expose_prop->np->value = (double) duration / 1000;
         sendNewNumber(expose_prop);
 
         modal = true;  // will be reset when the image blob is received
@@ -892,7 +895,8 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
                     // try to use video stream instead of exposure
                     // See: http://www.indilib.org/forum/ccds-dslrs/3078-v4l2-ccd-exposure-property.html
                     // TODO : check if an updated INDI v4l2 driver offer a better solution
-                    pFrame->Alert(wxString::Format(_("Camera  %s, exposure error. Trying to use streaming instead."), INDICameraName));
+                    pFrame->Alert(wxString::Format(_("Camera  %s, exposure error. Trying to use streaming instead."),
+                                                   INDICameraName));
                     INDICameraForceVideo = true;
                     first_frame = false;
                     return Capture(duration, img,  options, subframeArg);
@@ -958,13 +962,13 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
         ISwitch *v_off;
         if (has_old_videoprop)
         {
-            v_on = IUFindSwitch(video_prop,"ON");
-            v_off = IUFindSwitch(video_prop,"OFF");
+            v_on = IUFindSwitch(video_prop, "ON");
+            v_off = IUFindSwitch(video_prop, "OFF");
         }
         else
         {
-            v_on = IUFindSwitch(video_prop,"STREAM_ON");
-            v_off = IUFindSwitch(video_prop,"STREAM_OFF");
+            v_on = IUFindSwitch(video_prop, "STREAM_ON");
+            v_off = IUFindSwitch(video_prop, "STREAM_OFF");
         }
 
         // start streaming if not already active, every video frame is received as a blob
@@ -988,7 +992,7 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
         {
             wxMilliSleep(loopwait);
             // test exposure complete
-            if ((swatch.Time() >= duration) && (StackFrames > 2))
+            if (swatch.Time() >= duration && StackFrames > 2)
                 modal = false;
             // test termination request, stop streaming before to return
             if (WorkerThread::TerminateRequested())
@@ -1015,7 +1019,8 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
 
         pFrame->StatusMsg(wxString::Format(_("%d frames"), StackFrames));
 
-        if (options & CAPTURE_SUBTRACT_DARK) SubtractDark(img);
+        if (options & CAPTURE_SUBTRACT_DARK)
+            SubtractDark(img);
 
         return false;
     }

--- a/cam_indi.h
+++ b/cam_indi.h
@@ -1,13 +1,8 @@
 /*
  *  cam_indi.h
- *  PHD Guiding
+ *  Open PHD Guiding
  *
- *  Created by Geoffrey Hausheer.
- *  Copyright (c) 2009 Geoffrey Hausheer.
- *  All rights reserved.
- *
- *  Redraw for libindi/baseclient by Patrick Chevalley
- *  Copyright (c) 2014 Patrick Chevalley
+ *  Copyright (c) 2020 Andy Galasso.
  *  All rights reserved.
  *
  *  This source code is distributed under the following "BSD" license
@@ -18,7 +13,7 @@
  *    Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *    Neither the name of Craig Stark, Stark Labs nor the names of its
+ *    Neither the name of openphdguiding.org nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
@@ -36,112 +31,15 @@
  *
  */
 
-#ifndef _CAM_INDI_H_
-#define _CAM_INDI_H_
+#ifndef CAM_INDI_INCLUDED
+#define CAM_INDI_INCLUDED
 
-#include "phdindiclient.h"
-#include <libindi/basedevice.h>
-#include <libindi/indiproperty.h>
+class GuideCamera;
 
-#include "indi_gui.h"
-
-class CameraINDI : public GuideCamera, public PhdIndiClient
+class INDICameraFactory
 {
-private:
-    ISwitchVectorProperty *connection_prop;
-    INumberVectorProperty *expose_prop;
-    INumberVectorProperty *frame_prop;
-    INumber               *frame_x;
-    INumber               *frame_y;
-    INumber               *frame_width;
-    INumber               *frame_height;
-    ISwitchVectorProperty *frame_type_prop;
-    INumberVectorProperty *ccdinfo_prop;
-    INumberVectorProperty *binning_prop;
-    INumber               *binning_x;
-    INumber               *binning_y;
-    ISwitchVectorProperty *video_prop;
-    ITextVectorProperty   *camera_port;
-    INDI::BaseDevice      *camera_device;
-    INumberVectorProperty *pulseGuideNS_prop;
-    INumber               *pulseN_prop;
-    INumber               *pulseS_prop;
-    INumberVectorProperty *pulseGuideEW_prop;
-    INumber               *pulseE_prop;
-    INumber               *pulseW_prop;
-
-    wxMutex sync_lock;
-    wxCondition sync_cond;
-    bool guide_active;
-    GuideAxis guide_active_axis;
-
-    IndiGui  *m_gui;
-    IBLOB    *cam_bp;
-    usImage  *StackImg;
-    int      StackFrames;
-    bool     stacking;
-    bool     has_blob;
-    bool     has_old_videoprop;
-    bool     first_frame;
-    bool     modal;
-    bool     ready;
-    wxByte   m_bitsPerPixel;
-    double   PixSize;
-    double   PixSizeX;
-    double   PixSizeY;
-    wxRect   m_maxSize;
-    wxByte   m_curBinning;
-    bool     HasBayer;
-    long     INDIport;
-    wxString INDIhost;
-    wxString INDICameraName;
-    long     INDICameraCCD;
-    wxString INDICameraCCDCmd;
-    wxString INDICameraBlobName;
-    bool     INDICameraForceVideo;
-    bool     INDICameraForceExposure;
-    wxRect   m_roi;
-
-    bool     ConnectToDriver(RunInBg *ctx);
-    void     SetCCDdevice();
-    void     ClearStatus();
-    void     CheckState();
-    void     CameraDialog();
-    void     CameraSetup();
-    bool     ReadFITS(usImage& img, bool takeSubframe, const wxRect& subframe);
-    bool     ReadStream(usImage& img);
-    bool     StackStream();
-
-protected:
-    void newDevice(INDI::BaseDevice *dp) override;
-#ifndef INDI_PRE_1_0_0
-    void removeDevice(INDI::BaseDevice *dp) override;
-#endif
-    void newProperty(INDI::Property *property) override;
-    void removeProperty(INDI::Property *property) override {}
-    void newBLOB(IBLOB *bp) override;
-    void newSwitch(ISwitchVectorProperty *svp) override;
-    void newNumber(INumberVectorProperty *nvp) override;
-    void newMessage(INDI::BaseDevice *dp, int messageID) override;
-    void newText(ITextVectorProperty *tvp) override;
-    void newLight(ILightVectorProperty *lvp) override {}
-    void serverConnected() override;
-    void IndiServerDisconnected(int exit_code) override;
-
 public:
-    CameraINDI();
-    ~CameraINDI();
-    bool    Connect(const wxString& camId) override;
-    bool    Disconnect() override;
-    bool    HasNonGuiCapture() override;
-    wxByte  BitsPerPixel() override;
-    bool    GetDevicePixelSize(double *pixSize) override;
-    void    ShowPropertyDialog() override;
-
-    bool    Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
-
-    bool    ST4PulseGuideScope(int direction, int duration) override;
-    bool    ST4HasNonGuiMove() override;
+    static GuideCamera *MakeINDICamera();
 };
 
-#endif
+#endif // CAM_INDI_INCLUDED

--- a/cam_zwo.cpp
+++ b/cam_zwo.cpp
@@ -707,7 +707,7 @@ bool Camera_ZWO::Capture(int duration, usImage& img, int options, const wxRect& 
 
     bool useSubframe = UseSubframes;
 
-    if (subframe.width <= 0 || subframe.height <= 0)
+    if (useSubframe && (subframe.width <= 0 || subframe.height <= 0 || binning_change))
         useSubframe = false;
 
     if (useSubframe)

--- a/camera.cpp
+++ b/camera.cpp
@@ -245,7 +245,7 @@ wxArrayString GuideCamera::GuideCameraList()
 
     CameraList.Add(_("None"));
 #if defined (ASCOM_CAMERA)
-    wxArrayString ascomCameras = CameraASCOM::EnumAscomCameras();
+    wxArrayString ascomCameras = ASCOMCameraFactory::EnumAscomCameras();
     for (unsigned int i = 0; i < ascomCameras.Count(); i++)
         CameraList.Add(ascomCameras[i]);
 #endif
@@ -392,7 +392,7 @@ GuideCamera *GuideCamera::Factory(const wxString& choice)
         // Chack ASCOM and INDI first since those choices may match match other choices below (like Simulator)
 #if defined (ASCOM_CAMERA)
         else if (choice.Contains(_T("ASCOM"))) {
-            pReturn = new CameraASCOM(choice);
+            pReturn = ASCOMCameraFactory::MakeASCOMCamera(choice);
         }
 #endif
 #if defined (INDI_CAMERA)

--- a/camera.cpp
+++ b/camera.cpp
@@ -397,7 +397,7 @@ GuideCamera *GuideCamera::Factory(const wxString& choice)
 #endif
 #if defined (INDI_CAMERA)
         else if (choice.Contains(_T("INDI"))) {
-            pReturn = new CameraINDI();
+            pReturn = INDICameraFactory::MakeINDICamera();
         }
 #endif
 #if defined (IOPTRON_CAMERA)

--- a/phd.h
+++ b/phd.h
@@ -79,7 +79,7 @@
 
 #define APPNAME _T("PHD2 Guiding")
 #define PHDVERSION _T("2.6.9")
-#define PHDSUBVER _T("dev1")
+#define PHDSUBVER _T("dev1-binframe1")
 #define FULLVER PHDVERSION PHDSUBVER
 
 #if defined (__WINDOWS__)

--- a/phd.h
+++ b/phd.h
@@ -79,7 +79,7 @@
 
 #define APPNAME _T("PHD2 Guiding")
 #define PHDVERSION _T("2.6.9")
-#define PHDSUBVER _T("dev1-binframe1")
+#define PHDSUBVER _T("dev1")
 #define FULLVER PHDVERSION PHDSUBVER
 
 #if defined (__WINDOWS__)

--- a/scope_indi.cpp
+++ b/scope_indi.cpp
@@ -631,7 +631,7 @@ Mount::MOVE_RESULT ScopeINDI::Guide(GUIDE_DIRECTION direction, int duration)
         case SOUTH:
             break;
         default:
-            Debug.Write("INDI Camera error CameraINDI::Guide NONE\n");
+            Debug.Write("INDI Mount error ScopeINDI::Guide NONE\n");
             return MOVE_ERROR;
         }
 


### PR DESCRIPTION
Some ZWO ASI cameras break the assumption that the binned frame size is directly proportional to the un-binned frame.

Update the ZWO ASI native driver and the INDI camera client code to remove the assumption and use the actual binned camera frame to determine the binned frame size.

TODO: fix ASCOM cameras too

Fixes #878
