### PR TITLE
multistar: minor fix to secondary circle render location

### DIFF
--- a/guider_multistar.cpp
+++ b/guider_multistar.cpp
@@ -1220,11 +1220,13 @@ void GuiderMultiStar::OnPaint(wxPaintEvent& event)
                 limit = m_lastStarsUsed;
             }
             else
+            {
                 limit = m_starsUsed;
+            }
             for (std::vector<GuideStar>::const_iterator it = m_guideStars.begin() + 1;
                  it != m_guideStars.end(); ++it)
             {
-                wxPoint pt((int)it->referencePoint.X * m_scaleFactor, (int)it->referencePoint.Y * m_scaleFactor);
+                wxPoint pt((int)(it->referencePoint.X * m_scaleFactor), (int)(it->referencePoint.Y * m_scaleFactor));
                 dc.DrawCircle(pt, 6);
                 starsPlotted++;
                 if (starsPlotted == limit)


### PR DESCRIPTION
slight improvement to location of rendered secondary star circle position - multiply by scale factor _before_ truncation to int

this is consistent with how scale factor is used to render other objects