### PR TITLE
multistar: minor code refactor to clarify intent of star proximity checker

### DIFF
--- a/star.h
+++ b/star.h
@@ -100,14 +100,10 @@ public:
     int missCount;
     int zeroCount;
 
-    bool operator==(const GuideStar& other)
-    {
-        return (int)referencePoint.X == (int)other.X && (int)referencePoint.Y == (int)other.Y;
-    }
-
-public:
     GuideStar();
-    bool AutoFind(const usImage& image, int extraEdgeAllowance, int searchRegion, const wxRect& roi, std::vector<GuideStar>& foundStars, int maxStars);
+
+    bool AutoFind(const usImage& image, int extraEdgeAllowance, int searchRegion, const wxRect& roi,
+        std::vector<GuideStar>& foundStars, int maxStars);
 };
 
 #endif /* STAR_H_INCLUDED */


### PR DESCRIPTION
Using `operator==` for a proximity check (and not strictly a C++ object equality check) breaks the abstraction of what operator== is expected to be.

This code is functionally equivalent to what is already there, but makes the intent a bit clearer by moving the proximity checking code out of operator== and into a new function `CloseToReference()`
