### PR TITLE
Fix crash when wdm camera does not report AvgTimePerFrame

### DIFF
--- a/thirdparty/VidCapture/Source/VidCapture/CVVidCaptureDSWin32.cpp
+++ b/thirdparty/VidCapture/Source/VidCapture/CVVidCaptureDSWin32.cpp
@@ -848,7 +848,9 @@ CVRES CVVidCaptureDSWin32::Connect( int devIndex)
          if (mt->formattype == FORMAT_VideoInfo) 
          {
             VIDEOINFOHEADER *pvi = (VIDEOINFOHEADER *)mt->pbFormat;
-            newMode.EstFrameRate = (int)(10000000 / pvi->AvgTimePerFrame);            
+            if (pvi->AvgTimePerFrame != 0) {
+                newMode.EstFrameRate = (int)(10000000 / pvi->AvgTimePerFrame);
+            }
          }
 		 else 
 		 {


### PR DESCRIPTION
I had an issue with a [TSSSI][1] astro webcam (I know, probably extremely poor for guiding, but just starting 😄).
Since I already owned this camera (looks like a 1:1 Omegon Camera CCD clone) I wanted to give it a try.
So debugged down the issue to a simple zero-division, which was easily fixable.
Also seems this value is only used in the select drop-down, so seems rather safe.
Although it will now report the video modes as "0 fps", still better than crashing 🚀 

![image](https://user-images.githubusercontent.com/282293/102732284-91e80c00-433a-11eb-8219-9d86b0d3fd3f.png)

Thanks! Looking forward to actually try my new auto-guiding mount.

[1]: https://www.teleskop-express.de/shop/product_info.php/info/p1778_TS-Optics-Astro-CCD-Kamera---Mond---Planeten---1-25--Anschluss.html