### PR TITLE
remove obsolete README pointing to google code

### DIFF
--- a/README-building-phd2-for-windows.txt
+++ b/README-building-phd2-for-windows.txt
@@ -1,3 +1,0 @@
-For Windows build instructions, please see
-
-   https://code.google.com/p/open-phd-guiding/wiki/BuildingPHD2OnWindows


### PR DESCRIPTION
This README file has been obsolete for years. It just caused confusion for somebody -- getting rd of it.