### PR TITLE
ASCOM cameras: fix an error from some cameras about invalid frame size after disconnecting and re-connecting the camera

### DIFF
--- a/cam_ascom.cpp
+++ b/cam_ascom.cpp
@@ -775,6 +775,8 @@ bool CameraASCOM::Connect(const wxString& camId)
 
     // defer defining FullSize since it is not simply derivable from max size and binning
     // no: FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
+    FullSize = UNDEFINED_FRAME_SIZE;
+    m_roi = wxRect(); // reset ROI state in case we're reconnecting
 
     Connected = true;
 


### PR DESCRIPTION
When reconnecting an ASCOM camera, the camera object was using stale info (FullSize and m_roi) from the last time it was connected. This would result in failing to set a proper ROI before starting capture, and result in a capture error from some ASCOM drivers (including QHY).
The fix is to properly initialize FullSize and m_roi when connecting to the camera, as they are initialized the first time the camera is connected.