### PR TITLE
Ignore the BIN value read from INDI driver on startup. Fix #910

### DIFF
--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -314,10 +314,9 @@ void CameraINDI::newNumber(INumberVectorProperty *nvp)
     else if (nvp == binning_prop)
     {
         MaxBinning = wxMin(binning_x->max, binning_y->max);
-        Binning = wxMin(binning_x->value, binning_y->value);
+        m_curBinning = wxMin(binning_x->value, binning_y->value);
         if (Binning > MaxBinning)
             Binning = MaxBinning;
-        m_curBinning = Binning;
         // defer defining FullSize since it is not simply derivable from max size and binning
         // no: FullSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
     }


### PR DESCRIPTION
The BIN value would otherwise reset to 1, dropping the dark library of the profile

Fix issue #910
