### PR TITLE
Update phd2.desktop

### DIFF
--- a/phd2.desktop
+++ b/phd2.desktop
@@ -4,6 +4,7 @@ Encoding=UTF-8
 Name=phd2
 Comment=PHD Guiding, auto-guiding of your telescope
 Exec=phd2
+StartupWMClass=phd2.bin
 Icon=phd2
 Terminal=false
 Type=Application


### PR DESCRIPTION
The StartupWMClass is needed to associate the launcher icon (for example a dot under the icon in ubuntu/gnome) to the phd2 window.