### PR TITLE
update release scripts to check build servers up front

### DIFF
--- a/build/make_release_dev
+++ b/build/make_release_dev
@@ -55,6 +55,16 @@ for v in WWW_{HOST,DIR} MAC_{HOST,DIR}{32,64}; do
     }
 done
 
+# make sure hosts are reachable
+for h in $WWW_HOST $MAC_HOST32 $MAC_HOST64; do
+    printf "checking $h ..."
+    ssh -q -oBatchMode=yes $h exit || {
+        echo "Error: host $h is not ssh-accessible" >&2
+        exit 1
+    }
+    printf " ok\n"
+done
+
 # convert changelog path to an absolute path
 case $changelog in
     /*) ;;

--- a/build/make_release_full
+++ b/build/make_release_full
@@ -61,6 +61,16 @@ for v in WWW_{HOST,DIR} MAC_{HOST,DIR}{32,64}; do
     }
 done
 
+# make sure hosts are reachable
+for h in $WWW_HOST $MAC_HOST32 $MAC_HOST64; do
+    printf "checking $h ..."
+    ssh -q -oBatchMode=yes $h exit || {
+        echo "Error: host $h is not ssh-accessible" >&2
+        exit 1
+    }
+    printf " ok\n"
+done
+
 # convert changelog paths to absolute paths
 case $changelog_dev in
     /*) ;;


### PR DESCRIPTION
It is better to have an up-front check to detect when build machines are not available
rather than to have the scripts fail later on when they try to access the servers.