### PR TITLE
use uniform captialization for HFD

### DIFF
--- a/guider.cpp
+++ b/guider.cpp
@@ -209,12 +209,14 @@ void Guider::LoadProfileSettings()
     bool scaleImage = pConfig->Profile.GetBoolean("/guider/ScaleImage", DefaultScaleImage);
     SetScaleImage(scaleImage);
 
-    double minHFD = pConfig->Profile.GetDouble("/guider/StarMinHFD", GetMinStarHfdDefault());
-    // Handle upgrades from earlier releases that allowed zero MinHFD values.  Values below floor (1.0) are considered to be bogus and usually zero.  Set those to 
-    // the default value (1.5).  Values between floor and default may be valid and would have come from specific user configuration - so leave them alone.  Any 
-    // values >= default are also acceptable and will be left alone
-    if (minHFD < GetMinStarHfdFloor())
-        minHFD = GetMinStarHfdDefault();
+    double minHFD = pConfig->Profile.GetDouble("/guider/StarMinHFD", GetMinStarHFDDefault());
+    // Handle upgrades from earlier releases that allowed zero MinHFD values.  Values below floor
+    // (1.0) are considered to be bogus and usually zero.  Set those to the default value (1.5).
+    // Values between floor and default may be valid and would have come from specific user
+    // configuration - so leave them alone.  Any values >= default are also acceptable and will be
+    // left alone
+    if (minHFD < GetMinStarHFDFloor())
+        minHFD = GetMinStarHFDDefault();
     SetMinStarHFD(minHFD);
 
     double minSNR = pConfig->Profile.GetDouble("/guider/StarMinSNR", 6.0);

--- a/guider.h
+++ b/guider.h
@@ -267,8 +267,8 @@ public:
     void EnableMeasurementMode(bool enabled);
     void SetMinStarHFD(double val);
     double GetMinStarHFD() const;
-    double GetMinStarHfdFloor() const;
-    double GetMinStarHfdDefault() const;
+    double GetMinStarHFDFloor() const;
+    double GetMinStarHFDDefault() const;
     void SetMinStarSNR(double val);
     double getMinStarSNR() const;
     void SetAutoSelDownsample(unsigned int val);
@@ -410,11 +410,12 @@ inline double Guider::GetMinStarHFD() const
     return m_minStarHFD;
 }
 
-inline double Guider::GetMinStarHfdFloor() const
+inline double Guider::GetMinStarHFDFloor() const
 {
     return 1.0;
 }
-inline double Guider::GetMinStarHfdDefault() const
+
+inline double Guider::GetMinStarHFDDefault() const
 {
     return 1.5;
 }

--- a/guider_multistar.cpp
+++ b/guider_multistar.cpp
@@ -1386,9 +1386,9 @@ GuiderMultiStarConfigDialogCtrlSet::GuiderMultiStarConfigDialogCtrlSet(wxWindow 
 
     width = StringWidth(_("65535"));
 
-    double minHfd = pGuider->GetMinStarHfdFloor();
+    double minHFD = pGuider->GetMinStarHFDFloor();
     m_MinHFD = pFrame->MakeSpinCtrlDouble(pParent, wxID_ANY, wxEmptyString, wxDefaultPosition,
-        wxSize(width, -1), wxSP_ARROW_KEYS, pGuider->GetMinStarHfdFloor(), 10.0, pGuider->GetMinStarHfdDefault(), 0.5);
+        wxSize(width, -1), wxSP_ARROW_KEYS, minHFD, 10.0, pGuider->GetMinStarHFDDefault(), 0.5);
     m_MinHFD->SetDigits(1);
     wxSizer *pHFD = MakeLabeledControl(AD_szStarTracking, _("Minimum star HFD (pixels)"), m_MinHFD,
         _("The minimum star HFD (size) that will be used for identifying a guide star. "


### PR DESCRIPTION
existing code uses HFD, newly added code uses Hfd; change new code to use the
prior convention. Also,
  - wrap long lines
  - fix an unused local variable