### PR TITLE
SVB cameras: improved stability when changing ROI or binning

### DIFF
--- a/cam_svb.cpp
+++ b/cam_svb.cpp
@@ -516,7 +516,9 @@ void SVBCamera::StopCapture()
     if (m_capturing)
     {
         Debug.Write("SVB: stopcapture\n");
-        SVBStopVideoCapture(m_cameraId);
+        // we used to call SVBStopVideoCapture() at this point, but we found in testing that
+        // the call can occasionally hang, and also that it is not necessary, even when ROI
+        // or binning changes.
         m_capturing = false;
     }
 }


### PR DESCRIPTION
When changing ROI or binning, PHD2 was calling SVBStopVideoCapture which would sometimes hang. Removing the call makes capturing more stable, and ROI and binning change continues to work as expected without the call.