### PR TITLE
OpenPHD2Guiding: Add delay between RA and Dec corrections.

### DIFF
--- a/configdialog.h
+++ b/configdialog.h
@@ -86,7 +86,8 @@ enum BRAIN_CTRL_IDS
     AD_cbSlewDetection,
     AD_cbUseDecComp,
     AD_cbBeepForLostStar,
-    AD_GUIDER_TAB_BOUNDARY,        // --------------- end of guiding tab controls
+	AD_cbDelayBetweenCorrections,
+	AD_GUIDER_TAB_BOUNDARY,        // --------------- end of guiding tab controls
 
     AD_szBLCompCtrls,
     AD_szMaxRAAmt,

--- a/guider.cpp
+++ b/guider.cpp
@@ -1705,8 +1705,9 @@ void Guider::GuiderConfigDialogPane::LayoutControls(Guider *pGuider, BrainCtrlId
     pSharedSizer->Add(GetSingleCtrl(CtrlMap, AD_cbFastRecenter), wxSizerFlags(0).Border(wxLEFT, 35));
     CondAddCtrl(pSharedSizer, CtrlMap, AD_cbReverseDecOnFlip);
     CondAddCtrl(pSharedSizer, CtrlMap, AD_cbEnableGuiding, wxSizerFlags(0).Border(wxLEFT, 35));
-    CondAddCtrl(pSharedSizer, CtrlMap, AD_cbSlewDetection);
-    pShared->Add(pSharedSizer, def_flags);
+	CondAddCtrl(pSharedSizer, CtrlMap, AD_cbDelayBetweenCorrections);
+	CondAddCtrl(pSharedSizer, CtrlMap, AD_cbSlewDetection, wxSizerFlags(0).Border(wxLEFT, 35));
+	pShared->Add(pSharedSizer, def_flags);
     pShared->Layout();
 
     this->Add(pStarTrack, def_flags);

--- a/mount.cpp
+++ b/mount.cpp
@@ -1030,7 +1030,11 @@ Mount::MOVE_RESULT Mount::MoveOffset(GuiderOffset *ofs, unsigned int moveOptions
             if (m_backlashComp)
                 m_backlashComp->ApplyBacklashComp(moveOptions, yDistance, &requestedYAmount);
 
-            result = MoveAxis(yDirection, requestedYAmount, moveOptions, &yMoveResult);
+			// delay between corrections
+			if (TheScope()->IsDelayBetweenCorrectionsEnabled() == true && requestedXAmount > 0 && requestedYAmount > 0)
+				Sleep(250);
+
+			result = MoveAxis(yDirection, requestedYAmount, moveOptions, &yMoveResult);
         }
 
         // Record the info about the guide step. The info will be picked up back in the main UI thread.

--- a/scope.h
+++ b/scope.h
@@ -63,7 +63,8 @@ class ScopeConfigDialogCtrlSet : public MountConfigDialogCtrlSet
     wxSpinCtrlDouble *m_pBacklashFloor;
     wxSpinCtrlDouble *m_pBacklashCeiling;
     wxCheckBox *m_pUseDecComp;
-    int m_calibrationDistance;
+	wxCheckBox *m_pDelayBetweenCorrections;
+	int m_calibrationDistance;
     bool m_origBLCEnabled;
 
     void OnCalcCalibrationStep(wxCommandEvent& evt);
@@ -128,7 +129,8 @@ class Scope : public Mount
 
     bool m_calibrationFlipRequiresDecFlip;
     bool m_stopGuidingWhenSlewing;
-    Calibration m_prevCalibration;
+	bool m_delayBetweenCorrections;
+	Calibration m_prevCalibration;
     CalibrationDetails m_prevCalibrationDetails;
     CalibrationIssueType m_lastCalibrationIssue;
 
@@ -239,7 +241,9 @@ public:
     void SetCalibrationFlipRequiresDecFlip(bool val);
     void EnableStopGuidingWhenSlewing(bool enable);
     bool IsStopGuidingWhenSlewingEnabled() const;
-    void SetAssumeOrthogonal(bool val);
+	void EnableDelayBetweenCorrections(bool enable);
+	bool IsDelayBetweenCorrectionsEnabled() const;
+	void SetAssumeOrthogonal(bool val);
     bool IsAssumeOrthogonal() const;
     void HandleSanityCheckDialog();
     void SetCalibrationWarning(CalibrationIssueType etype, bool val);
@@ -289,6 +293,11 @@ private:
 inline bool Scope::IsStopGuidingWhenSlewingEnabled() const
 {
     return m_stopGuidingWhenSlewing;
+}
+
+inline bool Scope::IsDelayBetweenCorrectionsEnabled() const
+{
+	return m_delayBetweenCorrections;
 }
 
 inline bool Scope::IsAssumeOrthogonal() const


### PR DESCRIPTION
OpenPHD2Guiding: Add delay between RA and Dec corrections. This is for repository: https://github.com/OpenPHDGuiding/phd2

The changes add a checkbox labeled "Delay between RA and Dec correction" to the Guiding page of the Advanced Settings dialog. When selected, a 1/4 second delay will occur between RA and Dec corrections for each guiding cycle. Files changed: configdialog.h guider.cpp mount.cpp scope.cpp scope.h

This change was actually implemented a few years ago, tested numerous times, and has proven quite useful for my particular mount - an old Celestron CI-700 with an ST-4 port. I just finally got around to submitting this change to OpenPHD2Guiding.

Without the delay, the mount would sometimes act erratically by bursting into a series of oscillations that would ruin the imaging sub-frame. Through trial-and-error, I determined the cause was that if both RA and Dec corrections were applied, the mount would sometimes interpret the Dec correction period as an extension of the RA period. So, the RA period would be increased, and the Dec correction would not be applied. This would lead to overshoot, over-correction, and hence oscillation.

Question/comments welcome. Please be aware this is my first public "pull request", and I hope I did things right.