### PR TITLE
Fix cmake debian dependencies.

### DIFF
--- a/cmake_modules/PHD2Packaging.cmake
+++ b/cmake_modules/PHD2Packaging.cmake
@@ -103,7 +103,7 @@ if(UNIX AND NOT APPLE)
   # set version and arch compatible file name
   set(CPACK_PACKAGE_FILE_NAME "phd2_${CPACK_DEBIAN_PACKAGE_VERSION}_${debarch}")
   # Ubuntu 14.04 compatible minimal dependency
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.17), libgcc1 (>= 1:4.1.1), libnova-0.14-0 | libnova-0.16-0, libstdc++6 (>= 4.2.1), libusb-1.0-0 (>= 2:1.0.8), libwxbase3.0-0 | libwxbase3.0-0v5 (>= 3.0.0), libwxgtk3.0-0 | libwxgtk3.0-0v5 (>=3.0.0), libx11-6, zlib1g (>= 1:1.1.4)")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.17), libgcc1 (>= 1:4.1.1), libnova-0.14-0 | libnova-0.16-0, libstdc++6 (>= 4.2.1), libusb-1.0-0 (>= 2:1.0.8), libwxbase3.0-0 | libwxbase3.0-0v5 (>= 3.0.0), libwxgtk3.0-0 | libwxgtk3.0-0v5 | libwxgtk3.0-gtk3-0v5 (>=3.0.0), libx11-6, zlib1g (>= 1:1.1.4)")
   set(CPACK_DEBIAN_PACKAGE_SUGGESTS "indi-bin (>= 0.9.7)")
   set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "PHD2 auto-guiding software")
   # same section as many astronomy packages


### PR DESCRIPTION
Additional fix to #975 to allow cmake to generate a debian package for Ubuntu 20.04.