### PR TITLE
SVB Cameras: make ST4 Pulse guide commands synchronous

### DIFF
--- a/cam_svb.cpp
+++ b/cam_svb.cpp
@@ -840,6 +840,7 @@ bool SVBCamera::ST4PulseGuideScope(int direction, int duration)
 {
     SVB_GUIDE_DIRECTION d = GetSVBDirection(direction);
     SVBPulseGuide(m_cameraId, d, duration);
+    WorkerThread::MilliSleep(duration, WorkerThread::INT_ANY);
     return false;
 }
 


### PR DESCRIPTION
SVBPulseGuide returns immediately after being called.    It does not wait for the guide pulse to complete.    A delay is necessary to avoid starting an exposure while the mount is moving.    It is also desirable to avoid calling SVBPulseGuide while a pulse is active.

I have verified this is the designed behavior of SVBPulseGuide with SVBony technical support.     