### PR TITLE
On Linux, install the SVBony SDK libSVBCameraSDK.so to /usr/lib/phd2

### DIFF
--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -1421,6 +1421,7 @@ if(UNIX AND NOT APPLE)
       message(STATUS "Found SVBCameraSDK lib ${SVBCameraSDK}")
       add_definitions(-DHAVE_SVB_CAMERA=1)
       set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${SVBCameraSDK})
+      set(PHD_INSTALL_LIBS ${PHD_INSTALL_LIBS} ${SVBCameraSDK})
 
       if(IS_DIRECTORY ${PHD_PROJECT_ROOT_DIR}/cameras/qhyccdlibs/linux/${qhyarch})
         add_definitions(-DHAVE_QHY_CAMERA=1)


### PR DESCRIPTION
This is required because PHD2 is statically linked with this library. 
Installing in  /usr/lib/phd2 make it work the same way as the Toupcam SDK.

$ ldd /usr/bin/phd2.bin
        ...
        libtoupcam.so => /usr/lib/phd2/libtoupcam.so (0x00007fc347a00000)
        libSVBCameraSDK.so => /usr/lib/phd2/libSVBCameraSDK.so (0x00007fc347200000)
       ...

Fix #1010