### PR TITLE
Dev3 changes

### DIFF
--- a/camera.cpp
+++ b/camera.cpp
@@ -1464,12 +1464,16 @@ void GuideCamera::DisconnectWithAlert(CaptureFailType type)
 
     case CAPT_FAIL_TIMEOUT:
         {
-            wxString msg(wxString::Format(_("After %.1f sec the camera has not completed a %.1f sec exposure, so "
-                "it has been disconnected to prevent other problems. "
-                "If you think the hardware is working correctly, you can increase the "
-                "timeout period on the Camera tab of the Advanced Settings Dialog."),
+            wxString msg;
+            // Dark library exposure times won't match the selected exposure time in the pull-down menu of the main window
+            if (!ShutterClosed)
+                msg = (wxString::Format(_("After %.1f sec the camera has not completed a %.1f sec exposure, so "
+                "it has been disconnected to prevent other problems. Refer to Trouble-shooting section of Help."),
                 (pFrame->RequestedExposureDuration() + m_timeoutMs) / 1000.,
                 pFrame->RequestedExposureDuration() / 1000.));
+            else
+                msg = _("The camera has not completed an exposure in at least 15 seconds, so "
+                "it has been disconnected to prevent other problems. Refer to Trouble-shooting section of Help.");
 
             DisconnectWithAlert(msg, RECONNECT);
         }

--- a/guide_algorithm_gaussian_process.cpp
+++ b/guide_algorithm_gaussian_process.cpp
@@ -944,8 +944,6 @@ GUIDE_ALGORITHM GuideAlgorithmGaussianProcess::Algorithm() const
 
 double GuideAlgorithmGaussianProcess::result(double input)
 {
-    double control_signal;
-
     if (block_updates_)
         return(0);
 
@@ -954,21 +952,12 @@ double GuideAlgorithmGaussianProcess::result(double input)
         return deduceResult();
     }
 
-    try
-    {
-        // the third parameter of result() is a floating-point in seconds, while RequestedExposureDuration() returns milliseconds
-        const Star& star = pFrame->pGuider->PrimaryStar();
-        control_signal = GPG->result(input, star.SNR, (double)pFrame->RequestedExposureDuration() / 1000.0);
-        Debug.Write(wxString::Format("PPEC: input: %.2f, control: %.2f, exposure: %d\n",
-            input, control_signal, pFrame->RequestedExposureDuration()));
-    }
-    catch (const wxString& Msg)
-    {
-        POSSIBLY_UNUSED(Msg);
-        Debug.Write(wxString::Format("Exception thrown in PPEC Result: %s - model reset\n", Msg));
-        control_signal = input * DefaultControlGain;
-        reset();
-    }
+    // the third parameter of result() is a floating-point in seconds, while RequestedExposureDuration() returns milliseconds
+    const Star& star = pFrame->pGuider->PrimaryStar();
+    double control_signal = GPG->result(input, star.SNR, (double) pFrame->RequestedExposureDuration() / 1000.0);
+
+    Debug.Write(wxString::Format("PPEC: input: %.2f, control: %.2f, exposure: %d\n",
+        input, control_signal, pFrame->RequestedExposureDuration()));
 
     return control_signal;
 }

--- a/help/Supplemental_Info.htm
+++ b/help/Supplemental_Info.htm
@@ -393,7 +393,12 @@ amount of gap is generally required to avoid binding in the gear system
 and to allow room for lubricant and thermal expansion. &nbsp;When the
 mesh is too tight, the axis may exhibit stiction (static friction), a
 situation where the axis will not move smoothly and freely or is
-difficult to get moving from a stationary state. &nbsp;</p><p class="MsoNormal">The Guiding Assistant will
+difficult to get moving from a stationary state. &nbsp;Stiction on the
+Dec axis can result in a pattern of an initial reversal delay that
+looks like backlash followed by a large over-shoot once the axis
+finally starts moving. &nbsp;Other than mistakenly having backlash
+compensation enabled in the mount software, stiction is the most common
+cause of oscillations in Dec guiding. &nbsp;</p><p class="MsoNormal">The Guiding Assistant will
 measure how the Dec axis behaves when it is forced to reverse
 direction. &nbsp;It is only capable of measuring the "reversal delay",
 the amount of time it takes to change direction and get the axis
@@ -496,8 +501,15 @@ minutes or hours, you may notice the amount of drift is decreasing.
 declination reversal and you should be prepared to change the Dec guide
 mode accordingly.</li>
 <li>If you are dithering, you may want to set the dithering
-parameters to "RA-only" to avoid disrupting the Dec guiding.</li>
-</ol>
+parameters to "RA-only" to avoid disrupting the Dec guiding. &nbsp;</li>
+</ol>If dithering is being done through the PHD2 server interface,
+uni-directional Dec guiding will be temporarily switched to 'Auto' in
+order to execute dithers. &nbsp;This may result in extended settling
+times but it allows the kind of dithering that is required for cameras
+with fixed-pattern noise. Once settling is completed, the Dec guide
+mode will be restored to its original setting. &nbsp;This only works
+via the server interface,&nbsp;dithering done using the 'Manual Guide'
+tool will not suspend uni-directional guiding in this way.. &nbsp;
 <h3><a name="Variable_delay_guiding"></a>High-precision Mounts and Variable-delay Guiding</h3>
 
 <p class="xxxmsonormal">Mounts with very accurate absolute encoders and detailed


### PR DESCRIPTION
Continue to see situations where mis-behaved mounts can create unhandled exceptions in underlying PPEC libraries - these often cause crashes.  Try/catch is a start on the problem but Windows structured exceptions won't be caught.  Other changes are pretty trivial.