### PR TITLE
build scripts: tag release sooner

### DIFF
--- a/build/make_release_dev
+++ b/build/make_release_dev
@@ -192,6 +192,16 @@ if [[ $do_build ]]; then
 fi
 
 #
+# tag the release
+#
+if [[ $need_tag ]]; then
+    echo "tagging the release"
+    PAUSE
+    git tag -a -m "v${REV}" "v${REV}"
+    git push --tags
+fi
+
+#
 # web site dev release page
 #
 if [[ $do_changelog ]]; then
@@ -202,16 +212,6 @@ if [[ $do_changelog ]]; then
     scp "$changelog" "${WWW_HOST}:/tmp/phd2changelog"
     ssh $WWW_HOST "./bin/phd2_add_release_page -r $REV $changelog_test /tmp/phd2changelog"
     need_static_update=1
-fi
-
-#
-# tag the release
-#
-if [[ $need_tag ]]; then
-    echo "tagging the release"
-    PAUSE
-    git tag -a -m "v${REV}" "v${REV}"
-    git push --tags
 fi
 
 #

--- a/build/make_release_full
+++ b/build/make_release_full
@@ -187,6 +187,16 @@ if [[ $do_build ]]; then
 fi
 
 #
+# tag the release
+#
+if [[ $need_tag ]]; then
+    echo "tagging the release"
+    PAUSE
+    git tag -a -m "v${REV}" "v${REV}"
+    git push --tags
+fi
+
+#
 # web site dev release page
 #
 if [[ $do_changelog_dev ]]; then
@@ -210,16 +220,6 @@ if [[ $do_changelog_full ]]; then
     scp "$changelog_full" "${WWW_HOST}:/tmp/phd2changelog-full"
     ssh $WWW_HOST "./bin/phd2_add_release_page -r $REV -R $changelog_test /tmp/phd2changelog-full"
     need_static_update=1
-fi
-
-#
-# tag the release
-#
-if [[ $need_tag ]]; then
-    echo "tagging the release"
-    PAUSE
-    git tag -a -m "v${REV}" "v${REV}"
-    git push --tags
 fi
 
 #


### PR DESCRIPTION
Tag the release as soon as the builds succeed, prior to publishing the ChangeLogs to Wordpress. This makes it slightly easier to resume processing if publishing the ChangeLog to Wordpress fails.