### PR TITLE
Report error if INDI v2 is being used

### DIFF
--- a/phdindiclient.h
+++ b/phdindiclient.h
@@ -35,7 +35,6 @@
 #define PHDINDICLIENT_H
 
 #include <libindi/baseclient.h>
-#include <libindi/basedevice.h>
 
 class PhdIndiClient : public INDI::BaseClient
 {
@@ -51,59 +50,6 @@ public:
 
     // must use this in PHD2 rather than BaseClient::disconnectServer()
     bool DisconnectIndiServer();
-
-#if INDI_VERSION_MAJOR >= 2
-public: // old deprecated interface INDI Version < 2.0.0
-    virtual void newDevice(INDI::BaseDevice *dp) = 0;
-    virtual void removeDevice(INDI::BaseDevice *dp) = 0;
-    virtual void newProperty(INDI::Property *property) = 0;
-    virtual void removeProperty(INDI::Property *property) = 0;
-
-    virtual void newMessage(INDI::BaseDevice *dp, int messageID) = 0;
-    virtual void newBLOB(IBLOB *bp) = 0;
-    virtual void newSwitch(ISwitchVectorProperty *svp) = 0;
-    virtual void newNumber(INumberVectorProperty *nvp) = 0;
-    virtual void newText(ITextVectorProperty *tvp) = 0;
-    virtual void newLight(ILightVectorProperty *lvp) = 0;
-
-public: // new interface INDI Version >= 2.0.0
-    void newDevice(INDI::BaseDevice device) override
-    {
-        return newDevice((INDI::BaseDevice *)device);
-    }
-
-    void removeDevice(INDI::BaseDevice device) override
-    {
-        return removeDevice((INDI::BaseDevice *)device);
-    }
-
-    void newProperty(INDI::Property property) override
-    {
-        return newProperty((INDI::Property *)property);
-    }
-
-    void removeProperty(INDI::Property property) override
-    {
-        return removeProperty((INDI::Property *)property);
-    }
-
-    void updateProperty(INDI::Property property) override
-    {
-        switch (property.getType())
-        {
-        case INDI_NUMBER: return newNumber((INumberVectorProperty *)property);
-        case INDI_SWITCH: return newSwitch((ISwitchVectorProperty *)property);
-        case INDI_LIGHT:  return newLight((ILightVectorProperty *)property);
-        case INDI_BLOB:   return newBLOB((IBLOB *)INDI::PropertyBlob(property)[0].cast());
-        case INDI_TEXT:   return newText((ITextVectorProperty *)property);
-        }
-    }
-
-    void newMessage(INDI::BaseDevice device, int messageID) override
-    {
-        return newMessage((INDI::BaseDevice *)device, messageID);
-    }
-#endif
 };
 
 #endif

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -658,8 +658,10 @@ else()
   # Linux or OSX
   if(USE_SYSTEM_LIBINDI)
     message(STATUS "Using system's libindi")
-    # INDI
     find_package(INDI 1.7 REQUIRED)
+    if(INDI_VERSION_MAJOR EQUAL 2)
+      message(FATAL_ERROR "PHD2 is not compatible with INDI 2.0.0 and greater.")
+    endif()
     # source files include <libindi/baseclient.h> so we need the libindi parent directory in the include directories
     get_filename_component(INDI_INCLUDE_PARENT_DIR ${INDI_INCLUDE_DIR} DIRECTORY)
     include_directories(${INDI_INCLUDE_PARENT_DIR})


### PR DESCRIPTION
With this change, an error is thrown if a user has INDI 2.0 installed and tries to compile PHD2 using `USE_SYSTEM_LIBINDI`.
When using the bundled INDI, phd2 compiles fine.

We need this check in place until we properly migrate INDI code to the v2 format.

This also partially reverse the previous PR (phdindiclient.h)