### PR TITLE
Fix serverConnected call too early for INDI Core 1.9.9/2.0.0

### DIFF
--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -170,7 +170,7 @@ protected:
     void newMessage(INDI::BaseDevice *dp, int messageID) override;
     void newText(ITextVectorProperty *tvp) override;
     void newLight(ILightVectorProperty *lvp) override {}
-    void serverConnected() override;
+    void IndiServerConnected() override;
     void IndiServerDisconnected(int exit_code) override;
 
 public:
@@ -697,7 +697,7 @@ bool CameraINDI::ConnectToDriver(RunInBg *r)
     return ready;
 }
 
-void CameraINDI::serverConnected()
+void CameraINDI::IndiServerConnected()
 {
     // After connection to the server
 

--- a/config_indi.cpp
+++ b/config_indi.cpp
@@ -320,7 +320,7 @@ void INDIConfig::Disconnect()
     DisconnectIndiServer();
 }
 
-void INDIConfig::serverConnected()
+void INDIConfig::IndiServerConnected()
 {
     if (wxThread::IsMain())
     {

--- a/config_indi.h
+++ b/config_indi.h
@@ -109,7 +109,7 @@ protected:
     void newMessage(INDI::BaseDevice *dp, int messageID) override {}
     void newText(ITextVectorProperty *tvp) override {}
     void newLight(ILightVectorProperty *lvp) override {}
-    void serverConnected() override;
+    void IndiServerConnected() override;
     void IndiServerDisconnected(int exit_code) override;
 
 private:

--- a/indi_gui.cpp
+++ b/indi_gui.cpp
@@ -198,7 +198,7 @@ void IndiGui::ConnectServer(const wxString& INDIhost, long INDIport)
     connectServer();
 }
 
-void IndiGui::serverConnected()
+void IndiGui::IndiServerConnected()
 {
     setBLOBMode(B_NEVER, "", nullptr);
     m_lastUpdate = wxGetUTCTimeMillis();

--- a/indi_gui.h
+++ b/indi_gui.h
@@ -121,7 +121,7 @@ protected:
     void newMessage(INDI::BaseDevice *dp, int messageID) override;
     void newText(ITextVectorProperty *tvp) override;
     void newLight(ILightVectorProperty *lvp) override {}
-    void serverConnected() override;
+    void IndiServerConnected() override;
     void IndiServerDisconnected(int exit_code) override;
 
 public:

--- a/phdindiclient.cpp
+++ b/phdindiclient.cpp
@@ -51,6 +51,33 @@ void PhdIndiClient::serverDisconnected(int exit_code)
     m_disconnecting = false;
 }
 
+void PhdIndiClient::serverConnected()
+{
+    // nothing to do yet
+    // for INDI Core 1.9.9, 2.0.0, the function is called before requesting to retrieve device information.
+    // If the function implementation waits for information, a deadlock occurs.
+    //
+    // see PhdIndiClient::connectServer override function below
+}
+
+bool PhdIndiClient::connectServer()
+{
+    // Call the original function.
+    bool ok = INDI::BaseClient::connectServer();
+
+    // After the original function was completed,
+    // the device information request was made in the INDI Core library.
+
+    // If connected, inform via the IndiServerConnected function,
+    // which replaces the serverConnected function.
+    if (ok)
+    {
+        IndiServerConnected();
+    }
+
+    return ok;
+}
+
 bool PhdIndiClient::DisconnectIndiServer()
 {
     // suppress any attempt to call disconnectServer from the

--- a/phdindiclient.h
+++ b/phdindiclient.h
@@ -45,15 +45,21 @@ public:
     PhdIndiClient();
     ~PhdIndiClient();
 
+public:
+    bool connectServer() override;
+
+protected:
+    void serverConnected() final;
     void serverDisconnected(int exit_code) final;
 
+    virtual void IndiServerConnected() = 0;
     virtual void IndiServerDisconnected(int exit_code) = 0;
 
     // must use this in PHD2 rather than BaseClient::disconnectServer()
     bool DisconnectIndiServer();
 
 #if INDI_VERSION_MAJOR >= 2
-public: // old deprecated interface INDI Version < 2.0.0
+protected: // old deprecated interface INDI Version < 2.0.0
     virtual void newDevice(INDI::BaseDevice *dp) = 0;
     virtual void removeDevice(INDI::BaseDevice *dp) = 0;
     virtual void newProperty(INDI::Property *property) = 0;
@@ -66,7 +72,7 @@ public: // old deprecated interface INDI Version < 2.0.0
     virtual void newText(ITextVectorProperty *tvp) = 0;
     virtual void newLight(ILightVectorProperty *lvp) = 0;
 
-public: // new interface INDI Version >= 2.0.0
+protected: // new interface INDI Version >= 2.0.0
     void newDevice(INDI::BaseDevice device) override
     {
         return newDevice((INDI::BaseDevice *)device);

--- a/scope_indi.cpp
+++ b/scope_indi.cpp
@@ -110,7 +110,7 @@ protected:
     void newMessage(INDI::BaseDevice *dp, int messageID) override;
     void newText(ITextVectorProperty *tvp) override;
     void newLight(ILightVectorProperty *lvp) override {}
-    void serverConnected() override;
+    void IndiServerConnected() override;
     void IndiServerDisconnected(int exit_code) override;
 
 public:
@@ -370,7 +370,7 @@ bool ScopeINDI::ConnectToDriver(RunInBg *r)
     return m_ready;
 }
 
-void ScopeINDI::serverConnected()
+void ScopeINDI::IndiServerConnected()
 {
     // After connection to the server
 

--- a/stepguider_sbigao_indi.cpp
+++ b/stepguider_sbigao_indi.cpp
@@ -110,7 +110,7 @@ class StepGuiderSbigAoINDI : public StepGuider, public PhdIndiClient
         void newMessage(INDI::BaseDevice *dp, int messageID) override;
         void newText(ITextVectorProperty *tvp) override {};
         void newLight(ILightVectorProperty *lvp) override {};
-        void serverConnected() override;
+        void IndiServerConnected() override;
         void IndiServerDisconnected(int exit_code) override;
 
     public:
@@ -352,7 +352,7 @@ void StepGuiderSbigAoINDI::ShowPropertyDialog()
     SetupDialog();
 }
 
-void StepGuiderSbigAoINDI::serverConnected()
+void StepGuiderSbigAoINDI::IndiServerConnected()
 {
     modal = true;
     wxLongLong msec;

--- a/stepguider_sxao_indi.cpp
+++ b/stepguider_sxao_indi.cpp
@@ -118,7 +118,7 @@ protected:
     void newMessage(INDI::BaseDevice *dp, int messageID) override;
     void newText(ITextVectorProperty *tvp) override {};
     void newLight(ILightVectorProperty *lvp) override {};
-    void serverConnected() override;
+    void IndiServerConnected() override;
     void IndiServerDisconnected(int exit_code) override;
 
 public:
@@ -371,7 +371,7 @@ void StepGuiderSxAoINDI::ShowPropertyDialog()
     SetupDialog();
 }
 
-void StepGuiderSxAoINDI::serverConnected()
+void StepGuiderSxAoINDI::IndiServerConnected()
 {
     // wait for the DEVICE_PORT property
     modal = true;


### PR DESCRIPTION
For [INDI Core](https://github.com/indilib/indi) 1.9.9 and 2.0.0, the `serverConnected` virtual function executes too early.
Implementing this function to wait for device information loses its purpose as it blocks requests for device information from being sent.

The detected problem is described in [Mount connection times out with INDI 2.0 #1036](https://github.com/OpenPHDGuiding/phd2/issues/1036), and all other related topics.

**This pull request should be compatible with previous and future versions of INDI Core.**

I'm adding your great PHD2 project to my list of tests and support for heavy upgrades to the INDI Core library.
If you allow me, I will propose implementation simplifications as pull requests as far as possible to reduce the amount of code and simplify the use of the INDI Core library.

Thank you.