### PR TITLE
Build Fix - Use `override` for connectServer since 1.9.9 indi.

### DIFF
--- a/phdindiclient.h
+++ b/phdindiclient.h
@@ -46,7 +46,11 @@ public:
     ~PhdIndiClient();
 
 public:
-    bool connectServer() override;
+    bool connectServer()
+#if INDI_VERSION_MAJOR >= 2 || (INDI_VERSION_MINOR == 9 && INDI_VERSION_RELEASE == 9)
+    override // use override since 1.9.9
+#endif
+    ;
 
 protected:
     void serverConnected() final;


### PR DESCRIPTION
Fixed compilation error for INDI versions below 1.9.9. Detected bug described in the thread: https://github.com/OpenPHDGuiding/phd2/issues/1038