### PR TITLE
Remove zero byte from end of base64 encoded star image.

### DIFF
--- a/event_server.cpp
+++ b/event_server.cpp
@@ -1408,7 +1408,6 @@ struct B64Encode
                 << '=';
             break;
         }
-        os << std::ends;
         return os.str();
     }
 };


### PR DESCRIPTION
I'm working on implementing a client library for phd2 in rust, and I've come across an issue in the rpc response to `get_star_image`; the base64 encoded string in the `pixels` field is invalid because it has a null byte at the end.  You can see it here, in the result of calling `get_star_image` against phd2 in simulator mode:
```json
"{\"jsonrpc\":\"2.0\",\"result\":{\"frame\":5,\"width\":15,\"height\":15,\"star_pos\":[7.21,7.03],\"pixels\":\"siEUHcQXJCwWIu4sQiAiGjohpCrQH+YpIiA2KWguMB64Hu4rBC7sJ6YizCZAIWobmiNOJNQbdi3sHlgpsCF4JfwnVihmGYop1CQ4K7QlGBi4GyIqDC5MHmQd9B3cJeAazCv2LYofDB5CJ2oifB8uJHYl3iFgIbgcthrcJ+gZgi6QJ+IeMB30GHAtmCXoLDIcui7YIcQd+i34KFYbniQyLpghAjfXM/4pQxq4KGgkXBqgIEAh2ixsHawXkitOIvYxzd3/////ZVTzGfQgThqmIwIa2iBeLrYoihncJCg3////////Bpi+KwAZghgwJvoguiU+KVgbGBmeKeIunev/////CUTEIxwnvhxyHzQh5B56JdQs2h2MJe0jNCp5QmcoXBnEKCAl0heIK6Yf7CTEK0gr9ilkGQoptyepKEkpiiliIDYgqizgLSggtiFMI3YiCCI0LY4riiNmJXofliqaKK4bdBoqLhIioB9+KdYpVCeyGhAhBC3mIQgnnhoEH5YkiBnwJlopOCj+IOQiohkkLiYkFh+qLaouECJqJLAf9iXqJ6wcCB6SGZYY6BdOKpoYJi18HpgsGCHQGKIcfiUWIkwg\0\"},\"id\":43}\r\n"
```

Note the `\0` near the end of the string.

I believe this was added to the string in phd2 because of a simple misunderstanding of how to build strings using ostringstream because C strings are terminated with a null byte.  The line I'm removing doesn't terminate the string, or tell ostringstream that it is time to build the string result; it adds a literal zero byte into the string.  When that string is serialized out in the json response a zero byte is added before the string's terminating `"` character.

To make this a valid character in the json string, phd2 would need to append something like `\\00000` (see the parse tree for string in the [json spec](https://www.json.org/json-en.html))  instead of `\0`.  Doing this would put a zero byte in the deserialized json string, but it would then make it an invalid base64 encoding, as a zero byte is not one of the [allowed 64 characters](https://datatracker.ietf.org/doc/html/rfc4648#section-4).

That's a lot of words to describe the problem, but the fix is pretty simple; stop putting a null byte in the end of the string.

With this change in place, the rpc response to `get_star_image` against phd2 in simulator mode looks like this:
```json
"{\"jsonrpc\":\"2.0\",\"result\":{\"frame\":5,\"width\":15,\"height\":15,\"star_pos\":[6.97,7.46],\"pixels\":\"NBzKKOwrtB60I0ooQimkG34uzCSEKUQtCh0KI9QsNhl8HJoiyijSG6gYnCT8KuIY3h3KGwog1BjkHfAmli3wH7QhABluLfYjPB9WJzogaC4eJoIcLB2mGL4ieh72KwQpHCYSJL4qziS2HBYeGBlKLiggBibIIiId1CzqGC4eNiWsHigoBCu4GkYtfiAsIxwY7BtgLbAfeBwCGkQc0CRiKvsi+zE2NnAwtiuuLmgshhgcGEwe5C3EH6IjshgRJxEuZKj//zOslC9cKIId8iDEK2AbtiNmGEIlvC1tH/dU////////f0LSI7QnQBxOKHonUiskLk4ljh3YKGBH////////ZDvOH6IZGhjOIRYgOCHAK7Ao2C6HKPQw84z//wCJiiFOG2IajC3sJCAs2iUWKxwjDiDeIc0kvypoJ8IyKiHGI0wdACnOLX4ubivKKKwuIB94H3opviimG7wtoBeoIdwpnCEsHHAisiCwF5IczCUkGQojeC1iHfwiICIOJXAmwh2MLAwmvCPcJXImyhnOLcQb+B5QGFQsKiG8Hd4dWBiaJEoY6htcJ0wgDiiwJGAY3CriLJAnQCXMK2Ya2CR+IyYb\"},\"id\":43}\r\n"
```
