### PR TITLE
Change star profile image interpolation to nearest neighbor

### DIFF
--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -301,7 +301,7 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
         wxBitmap subDBmp = dBmp.GetSubBitmap(wxRect(lkx - sz, lky - sz, sz * 2, sz * 2));
         wxImage subDImg = subDBmp.ConvertToImage();
         // scale by 2
-        wxBitmap zoomedDBmp(subDImg.Rescale(width, width, wxIMAGE_QUALITY_HIGH));
+        wxBitmap zoomedDBmp(subDImg.Rescale(width, width, wxIMAGE_QUALITY_NEAREST));
         wxMemoryDC tmpMdc;
         tmpMdc.SelectObject(zoomedDBmp);
         // blit into profile DC


### PR DESCRIPTION
The star profile image is currently bicubic scaled but I'm proposing changing to nearest neighbor which I think makes more sense. Normally you want a high quality scaling like bicubic but specifically for astrophotography we actually like nearest neighbor so we can see the pixels. Not seeing the pixels, in my opinion, is misleading because the star appears to show more detail than there really is.

Below is an example using the camera simulator.

**Bicubic (current):**
![image](https://github.com/OpenPHDGuiding/phd2/assets/174474/bf035dd7-be6f-4522-ab33-843133258221)

**Nearest Neighbor (proposed):**
![image](https://github.com/OpenPHDGuiding/phd2/assets/174474/75506307-1482-4f6c-80f4-d2737331f5cc)
