### PR TITLE
Group Min/Max HFD controls in UI; clean-up for Max-HFD implementation

### DIFF
--- a/guider.cpp
+++ b/guider.cpp
@@ -218,9 +218,11 @@ void Guider::LoadProfileSettings()
     if (minHFD < GetMinStarHFDFloor())
         minHFD = GetMinStarHFDFloor();
     SetMinStarHFD(minHFD);
+    double maxHFD = pConfig->Profile.GetDouble("/guider/StarMaxHFD", 20.0);
+    SetMaxStarHFD(maxHFD);
 
     double minSNR = pConfig->Profile.GetDouble("/guider/StarMinSNR", 6.0);
-    SetMinStarSNR(minSNR);
+    SetAFMinStarSNR(minSNR);
 
     unsigned int autoSelDownsample = wxMax(0, pConfig->Profile.GetInt("/guider/AutoSelDownsample", 0));
     SetAutoSelDownsample(autoSelDownsample);
@@ -1803,21 +1805,27 @@ EXPOSED_STATE Guider::GetExposedState()
 
     return rval;
 }
-
 void Guider::SetMinStarHFD(double val)
 {
     Debug.Write(wxString::Format("Setting StarMinHFD = %.2f\n", val));
     pConfig->Profile.SetDouble("/guider/StarMinHFD", val);
     m_minStarHFD = val;
 }
-
-void Guider::SetMinStarSNR(double val)
+// Minimum star SNR for auto-find; minimum SNR for normal star tracking is hard-wired to 3
+void Guider::SetAFMinStarSNR(double val)
 {
     Debug.Write(wxString::Format("Setting StarMinSNR = %0.1f\n", val));
     pConfig->Profile.SetDouble("/guider/StarMinSNR", val);
-    m_minStarSNR = val;
+    m_minAFStarSNR = val;
 }
 
+// Maximum star HFD
+void Guider::SetMaxStarHFD(double val)
+{
+    Debug.Write(wxString::Format("Setting MaxHFD = %0.1f\n", val));
+    pConfig->Profile.SetDouble("/guider/StarMaxHFD", val);
+    m_maxAFStarHFD = val;
+}
 void Guider::SetAutoSelDownsample(unsigned int val)
 {
     Debug.Write(wxString::Format("Setting AutoSelDownsample = %u\n", val));

--- a/guider.cpp
+++ b/guider.cpp
@@ -1826,7 +1826,7 @@ void Guider::SetMaxStarHFD(double val)
 {
     Debug.Write(wxString::Format("Setting MaxHFD = %0.1f\n", val));
     pConfig->Profile.SetDouble("/guider/StarMaxHFD", val);
-    m_maxAFStarHFD = val;
+    m_maxStarHFD = val;
 }
 
 void Guider::SetAutoSelDownsample(unsigned int val)

--- a/guider.cpp
+++ b/guider.cpp
@@ -1805,12 +1805,14 @@ EXPOSED_STATE Guider::GetExposedState()
 
     return rval;
 }
+
 void Guider::SetMinStarHFD(double val)
 {
     Debug.Write(wxString::Format("Setting StarMinHFD = %.2f\n", val));
     pConfig->Profile.SetDouble("/guider/StarMinHFD", val);
     m_minStarHFD = val;
 }
+
 // Minimum star SNR for auto-find; minimum SNR for normal star tracking is hard-wired to 3
 void Guider::SetAFMinStarSNR(double val)
 {
@@ -1826,6 +1828,7 @@ void Guider::SetMaxStarHFD(double val)
     pConfig->Profile.SetDouble("/guider/StarMaxHFD", val);
     m_maxAFStarHFD = val;
 }
+
 void Guider::SetAutoSelDownsample(unsigned int val)
 {
     Debug.Write(wxString::Format("Setting AutoSelDownsample = %u\n", val));

--- a/guider.h
+++ b/guider.h
@@ -165,7 +165,8 @@ class Guider : public wxWindow
     LockPosShiftParams m_lockPosShift;
     bool m_measurementMode;
     double m_minStarHFD;
-    double m_minStarSNR;
+    double m_minAFStarSNR;
+    double m_maxAFStarHFD;
     unsigned int m_autoSelDownsample;  // downsample factor for star auto-selection, 0=Auto
 
 protected:
@@ -266,12 +267,15 @@ public:
 
     void Reset(bool fullReset);
     void EnableMeasurementMode(bool enabled);
-    void SetMinStarHFD(double val);
     double GetMinStarHFD() const;
     double GetMinStarHFDFloor() const;
     double GetMinStarHFDDefault() const;
-    void SetMinStarSNR(double val);
-    double getMinStarSNR() const;
+    void SetMinStarHFD(double val);
+    double GetMaxStarHFD() const;
+    void SetMaxStarHFD(double val);
+    void SetAFMinStarSNR(double val);
+    double GetAFMinStarSNR() const;
+
     void SetAutoSelDownsample(unsigned int val);
     unsigned int GetAutoSelDownsample() const;
 
@@ -422,11 +426,15 @@ inline double Guider::GetMinStarHFDDefault() const
     return 1.5;
 }
 
-inline double Guider::getMinStarSNR() const
+inline double Guider::GetAFMinStarSNR() const
 {
-    return m_minStarSNR;
+    return m_minAFStarSNR;
 }
 
+inline double Guider::GetMaxStarHFD() const
+{
+    return m_maxAFStarHFD;
+}
 inline unsigned int Guider::GetAutoSelDownsample() const
 {
     return m_autoSelDownsample;

--- a/guider.h
+++ b/guider.h
@@ -435,6 +435,7 @@ inline double Guider::GetMaxStarHFD() const
 {
     return m_maxAFStarHFD;
 }
+
 inline unsigned int Guider::GetAutoSelDownsample() const
 {
     return m_autoSelDownsample;

--- a/guider.h
+++ b/guider.h
@@ -166,7 +166,7 @@ class Guider : public wxWindow
     bool m_measurementMode;
     double m_minStarHFD;
     double m_minAFStarSNR;
-    double m_maxAFStarHFD;
+    double m_maxStarHFD;
     unsigned int m_autoSelDownsample;  // downsample factor for star auto-selection, 0=Auto
 
 protected:
@@ -273,6 +273,7 @@ public:
     void SetMinStarHFD(double val);
     double GetMaxStarHFD() const;
     void SetMaxStarHFD(double val);
+    // 'AF' methods deal with SNR threshold used only during Auto-Find - lets user specify a higher than default SNR floor for populating a multi-star list. Normal 'find' methods do not use this property
     void SetAFMinStarSNR(double val);
     double GetAFMinStarSNR() const;
 
@@ -433,7 +434,7 @@ inline double Guider::GetAFMinStarSNR() const
 
 inline double Guider::GetMaxStarHFD() const
 {
-    return m_maxAFStarHFD;
+    return m_maxStarHFD;
 }
 
 inline unsigned int Guider::GetAutoSelDownsample() const

--- a/guider_multistar.cpp
+++ b/guider_multistar.cpp
@@ -931,7 +931,7 @@ bool GuiderMultiStar::UpdateCurrentPosition(const usImage *pImage, GuiderOffset 
         Star newStar(m_primaryStar);
 
         if (!newStar.Find(pImage, m_searchRegion, pFrame->GetStarFindMode(), GetMinStarHFD(),
-            pCamera->GetSaturationADU(), Star::FIND_LOGGING_VERBOSE))
+            GetMaxStarHFD(), pCamera->GetSaturationADU(), Star::FIND_LOGGING_VERBOSE))
         {
             errorInfo->starError = newStar.GetError();
             errorInfo->starMass = 0.0;

--- a/guider_multistar.h
+++ b/guider_multistar.h
@@ -63,6 +63,7 @@ public:
     wxCheckBox *m_pBeepForLostStarCtrl;
     wxCheckBox *m_pUseMultiStars;
     wxSpinCtrlDouble *m_MinSNR;
+    wxSpinCtrlDouble *m_MaxHFD;
 
     virtual void LoadValues();
     virtual void UnloadValues();

--- a/star.cpp
+++ b/star.cpp
@@ -477,9 +477,9 @@ done:
     return wasFound;
 }
 
-bool Star::Find(const usImage *pImg, int searchRegion, FindMode mode, double minHFD, unsigned short saturation, StarFindLogType loggingControl)
+bool Star::Find(const usImage *pImg, int searchRegion, FindMode mode, double minHFD, double maxHFD, unsigned short saturation, StarFindLogType loggingControl)
 {
-    return Find(pImg, searchRegion, X, Y, mode, minHFD, pFrame->pGuider->GetMaxStarHFD(), saturation, loggingControl);
+    return Find(pImg, searchRegion, X, Y, mode, minHFD, maxHFD, saturation, loggingControl);
 }
 
 struct FloatImg
@@ -1004,9 +1004,9 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
     for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
     {
         GuideStar tmp;
-        tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pFrame->pGuider->GetMaxStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+        tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), maxHFD, pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
         // We're repeating the find, so we're vulnerable to hot pixels and creation of unwanted duplicates
-        if (tmp.WasFound() && tmp.SNR >= minSNR && tmp.HFD <= maxHFD)
+        if (tmp.WasFound() && tmp.SNR >= minSNR)
         {
             bool duplicate = std::find_if(foundStars.begin(), foundStars.end(),
                 [&tmp](const GuideStar& other) { return CloseToReference(tmp, other); }) != foundStars.end();
@@ -1033,7 +1033,7 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
         for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
         {
             GuideStar tmp;
-            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pFrame->pGuider->GetMaxStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), maxHFD, pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
             if (tmp.WasFound())
             {
                 if (pass == 1)

--- a/star.cpp
+++ b/star.cpp
@@ -123,7 +123,7 @@ static double hfr(std::vector<R2M>& vec, double cx, double cy, double mass)
     return hfr;
 }
 
-bool Star::Find(const usImage *pImg, int searchRegion, int base_x, int base_y, FindMode mode, double minHFD, unsigned short maxADU, StarFindLogType loggingControl)
+bool Star::Find(const usImage *pImg, int searchRegion, int base_x, int base_y, FindMode mode, double minHFD, double maxHFD, unsigned short maxADU, StarFindLogType loggingControl)
 {
     FindResult Result = STAR_OK;
     double newX = base_x;
@@ -132,8 +132,8 @@ bool Star::Find(const usImage *pImg, int searchRegion, int base_x, int base_y, F
     try
     {
         if (loggingControl == FIND_LOGGING_VERBOSE)
-            Debug.Write(wxString::Format("Star::Find(%d, %d, %d, %d, (%d,%d,%d,%d), %.1f, %hu) frame %u\n", searchRegion, base_x, base_y, mode,
-            pImg->Subframe.x, pImg->Subframe.y, pImg->Subframe.width, pImg->Subframe.height, minHFD, maxADU, pImg->FrameNum));
+            Debug.Write(wxString::Format("Star::Find(%d, %d, %d, %d, (%d,%d,%d,%d), %.1f, %0.1f, %hu) frame %u\n", searchRegion, base_x, base_y, mode,
+            pImg->Subframe.x, pImg->Subframe.y, pImg->Subframe.width, pImg->Subframe.height, minHFD, maxHFD, maxADU, pImg->FrameNum));
 
         int minx, miny, maxx, maxy;
 
@@ -395,11 +395,19 @@ bool Star::Find(const usImage *pImg, int searchRegion, int base_x, int base_y, F
         newY = peak_y + cy / mass;
 
         HFD = 2.0 * hfr(hfrvec, newX, newY, mass);
-
-        if (HFD < minHFD && mode != FIND_PEAK)
+        // Check for constraints on HFD value
+        if (mode != FIND_PEAK)
         {
-            Result = STAR_LOWHFD;
-            goto done;
+            if (HFD < minHFD)
+            {
+                Result = STAR_LOWHFD;
+                goto done;
+            }
+            if (HFD > maxHFD)
+            {
+                Result = STAR_HIHFD;
+                goto done;
+            }
         }
 
         // check for saturation
@@ -471,7 +479,7 @@ done:
 
 bool Star::Find(const usImage *pImg, int searchRegion, FindMode mode, double minHFD, unsigned short saturation, StarFindLogType loggingControl)
 {
-    return Find(pImg, searchRegion, X, Y, mode, minHFD, saturation, loggingControl);
+    return Find(pImg, searchRegion, X, Y, mode, minHFD, pFrame->pGuider->GetMaxStarHFD(), saturation, loggingControl);
 }
 
 struct FloatImg
@@ -946,7 +954,7 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
         for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
         {
             Star tmp;
-            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pFrame->pGuider->GetMaxStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
             if (tmp.WasFound() && tmp.GetError() == STAR_SATURATED)
             {
                 if ((maxVal - tmp.PeakVal) * 255U > maxVal)
@@ -990,14 +998,15 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
         image.BitsPerPixel, sat_level, image.Pedestal, sat_thresh));
 
     // Before sifting for the best star, collect all the viable candidates
-    double minSNR = pFrame->pGuider->getMinStarSNR();
+    double minSNR = pFrame->pGuider->GetAFMinStarSNR();
+    double maxHFD = pFrame->pGuider->GetMaxStarHFD();
     foundStars.clear();
     for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
     {
         GuideStar tmp;
-        tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+        tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pFrame->pGuider->GetMaxStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
         // We're repeating the find, so we're vulnerable to hot pixels and creation of unwanted duplicates
-        if (tmp.WasFound() && tmp.SNR >= minSNR)
+        if (tmp.WasFound() && tmp.SNR >= minSNR && tmp.HFD <= maxHFD)
         {
             bool duplicate = std::find_if(foundStars.begin(), foundStars.end(),
                 [&tmp](const GuideStar& other) { return CloseToReference(tmp, other); }) != foundStars.end();
@@ -1024,7 +1033,7 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
         for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
         {
             GuideStar tmp;
-            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), pFrame->pGuider->GetMaxStarHFD(), pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
             if (tmp.WasFound())
             {
                 if (pass == 1)

--- a/star.h
+++ b/star.h
@@ -80,7 +80,7 @@ public:
      *       a boolean indicating success instead of a boolean indicating an
      *       error
      */
-    bool Find(const usImage *pImg, int searchRegion, FindMode mode, double min_hfd, unsigned short saturation, StarFindLogType loggingControl);
+    bool Find(const usImage *pImg, int searchRegion, FindMode mode, double min_hfd, double max_hfd, unsigned short saturation, StarFindLogType loggingControl);
     bool Find(const usImage *pImg, int searchRegion, int X, int Y, FindMode mode, double min_hfd, double max_hfd, unsigned short saturation, StarFindLogType loggingControl);
 
     static bool WasFound(FindResult result);

--- a/star.h
+++ b/star.h
@@ -56,6 +56,7 @@ public:
         STAR_LOWSNR,
         STAR_LOWMASS,
         STAR_LOWHFD,
+        STAR_HIHFD,
         STAR_TOO_NEAR_EDGE,
         STAR_MASSCHANGE,
         STAR_ERROR,
@@ -80,7 +81,7 @@ public:
      *       error
      */
     bool Find(const usImage *pImg, int searchRegion, FindMode mode, double min_hfd, unsigned short saturation, StarFindLogType loggingControl);
-    bool Find(const usImage *pImg, int searchRegion, int X, int Y, FindMode mode, double min_hfd, unsigned short saturation, StarFindLogType loggingControl);
+    bool Find(const usImage *pImg, int searchRegion, int X, int Y, FindMode mode, double min_hfd, double max_hfd, unsigned short saturation, StarFindLogType loggingControl);
 
     static bool WasFound(FindResult result);
     bool WasFound() const;


### PR DESCRIPTION
Implementation of Max-HFD to handle clumps of sensor noise, internal reflections, unwanted comet heads and other sources of false star detection. Default value will not change historical behavior of star selection.