### PR TITLE
Compute LST in PHD2 if INDI driver does not provide it and libnova is not available

### DIFF
--- a/image_math.h
+++ b/image_math.h
@@ -128,4 +128,27 @@ inline static double radians(double degrees)
     return degrees * M_PI / 180.;
 }
 
+inline static double norm24(double t)
+{
+    return norm(t, 0.0, 24.0);
+}
+
+inline static double GST(time_t t)
+{
+    double d = (double) t / 86400.0 - 10957.5;
+    return 18.697374558 + 24.06570982441908 * d;
+}
+
+// Note: this is only intended for use a fallback if the scope (INDI/ASCOM)
+// cannot provide LST
+inline static double LST(time_t t, double longitude)
+{
+    return norm24(GST(t) + longitude / 15.0);
+}
+
+inline static double LST(double longitude)
+{
+    return LST(time(0), longitude);
+}
+
 #endif

--- a/scope_manual_pointing.cpp
+++ b/scope_manual_pointing.cpp
@@ -209,27 +209,6 @@ Mount::MOVE_RESULT ScopeManualPointing::Guide(GUIDE_DIRECTION, int)
     return MOVE_ERROR;
 }
 
-inline static double norm24(double t)
-{
-    return norm(t, 0.0, 24.0);
-}
-
-inline static double GST(time_t t)
-{
-    double d = (double) t / 86400.0 - 10957.5;
-    return 18.697374558 + 24.06570982441908 * d;
-}
-
-inline static double LST(time_t t, double longitude)
-{
-    return norm24(GST(t) + longitude / 15.0);
-}
-
-inline static double LST(double longitude)
-{
-    return LST(time(0), longitude);
-}
-
 bool ScopeManualPointing::Connect()
 {
     m_latitude = pConfig->Profile.GetDouble("/scope/manual_pointing/latitude", 41.661612);


### PR DESCRIPTION
This is an alternative to #1095 but provides a computed LST value rather than just returning an error.

The LST computation was already present in scope_manual_pointing.cpp, but has been moved to make it accessible to scope_indi.cpp as well.