### PR TITLE
Do not rely on the bundled VC runtime files being present on the system.

### DIFF
--- a/phd2.iss.in
+++ b/phd2.iss.in
@@ -52,10 +52,10 @@ Source: ..\build\dark_mover.vbs; DestDir: {tmp}; Flags: replacesameversion
 ; Missing: TIS_DShowLib09.dll
 ; Missing: TIS_UDSHL09_vc10.dll
 ; Missing: TIS_UDSHL09_vc9.dll
-Source: ..\WinLibs\msvcr120.dll; DestDir: {app}; Flags: replacesameversion
-Source: ..\WinLibs\msvcp120.dll; DestDir: {app}; Flags: replacesameversion
-Source: ..\WinLibs\vcomp140.dll; DestDir: {app}; Flags: replacesameversion
-Source: ..\WinLibs\vcruntime140.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\msvcr120.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\msvcp120.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\vcomp140.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\vcruntime140.dll; DestDir: {app}; Flags: replacesameversion
 
 [Icons]
 Name: {group}\PHD Guiding 2; FileName: {app}\phd2.exe

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -1009,6 +1009,10 @@ if(WIN32)
   include_directories(${PHD_PROJECT_ROOT_DIR}/cameras/moravian/include)
 
   set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}  ${libcurl_dir}/lib/LIBCURL.DLL)
+  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}  ${PHD_PROJECT_ROOT_DIR}/WinLibs/msvcr120.dll)
+  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}  ${PHD_PROJECT_ROOT_DIR}/WinLibs/msvcp120.dll)
+  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}  ${PHD_PROJECT_ROOT_DIR}/WinLibs/vcomp140.dll)
+  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}  ${PHD_PROJECT_ROOT_DIR}/WinLibs/vcruntime140.dll)
 
   # ASCOM
   # disabled since not used in the SLN


### PR DESCRIPTION
Copy the files to the build directoy so the dll's that need them find them there.