### PR TITLE
Windows build: link with VCPKG debug or release libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,12 +792,14 @@ if(APPLE AND NOT APPLE32)
 endif()
 target_include_directories(phd2 PRIVATE ${wxWidgets_INCLUDE_DIRS})
 
-if (PHD_LINK_EXTERNAL_RELEASE)
-  target_link_libraries(phd2 optimized ${PHD_LINK_EXTERNAL_RELEASE})
-endif()
-if (PHD_LINK_EXTERNAL_DEBUG)
-  target_link_libraries(phd2 debug ${PHD_LINK_EXTERNAL_DEBUG})
-endif()
+foreach(lib ${PHD_LINK_EXTERNAL_DEBUG})
+  target_link_libraries(phd2 debug ${lib})
+endforeach()
+
+foreach(lib ${PHD_LINK_EXTERNAL_RELEASE})
+  target_link_libraries(phd2 optimized ${lib})
+endforeach()
+
 target_link_libraries(phd2
                       MPIIS_GP GPGuider # GP Guider
                       ${PHD_LINK_EXTERNAL})

--- a/contributions/MPI_IS_gaussian_process/CMakeLists.txt
+++ b/contributions/MPI_IS_gaussian_process/CMakeLists.txt
@@ -31,7 +31,7 @@
 
 
 project(MPI_IS_GaussianProcess)
- 
+
 set(gaussian_process_root_dir ${CMAKE_CURRENT_SOURCE_DIR})
 
 
@@ -54,7 +54,7 @@ set(gp_SRC
     )
 add_library(MPIIS_GP STATIC ${gp_SRC})
 target_link_libraries(MPIIS_GP PUBLIC MPIIS_GP_TOOLS)
-target_include_directories(MPIIS_GP PUBLIC 
+target_include_directories(MPIIS_GP PUBLIC
                            ${EIGEN_SRC} ${gaussian_process_root_dir}/src
                            ${gaussian_process_root_dir}/tools)
 set_property(TARGET MPIIS_GP PROPERTY FOLDER "Contributions/")
@@ -66,10 +66,10 @@ set(gpg_SRC
 )
 add_library(GPGuider STATIC ${gpg_SRC})
 target_link_libraries(GPGuider PUBLIC MPIIS_GP_TOOLS MPIIS_GP)
-target_include_directories(GPGuider PUBLIC 
-                           ${EIGEN_SRC} 
+target_include_directories(GPGuider PUBLIC
+                           ${EIGEN_SRC}
                            ${gaussian_process_root_dir}/src
-                           ${gaussian_process_root_dir}/tools 
+                           ${gaussian_process_root_dir}/tools
                            ${phd_src_dir})
 set_property(TARGET GPGuider PROPERTY FOLDER "Contributions/")
 
@@ -80,42 +80,75 @@ set_property(TARGET GPGuider PROPERTY FOLDER "Contributions/")
 #
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(gtest_link GTest::GTest)
+    set(gtest_link_debug GTest::GTest)
+    set(gtest_link_optimized GTest::GTest)
+elseif(WIN32)
+    set(gtest_link_debug ${VCPKG_DEBUG_LIB}/gtest.lib)
+    set(gtest_link_optimized ${VCPKG_RELEASE_LIB}/gtest.lib)
 else()
-    set(gtest_link gtest)
+    set(gtest_link_debug gtest)
+    set(gtest_link_optimized gtest)
 endif()
 
 
 # Test for the GP
 add_executable(GaussianProcessTest ${gaussian_process_root_dir}/tests/gaussian_process/gaussian_process_test.cpp)
-target_link_libraries(GaussianProcessTest MPIIS_GP ${gtest_link})
+target_link_libraries(
+  GaussianProcessTest
+  MPIIS_GP
+  debug ${gtest_link_debug}
+  optimized ${gtest_link_optimized}
+)
 target_include_directories(GaussianProcessTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS})
 set_property(TARGET GaussianProcessTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GaussianProcessTest COMMAND GaussianProcessTest)
 
 # Test for the math tools
 add_executable(MathToolboxTest ${gaussian_process_root_dir}/tests/gaussian_process/math_tools_test.cpp)
-target_link_libraries(MathToolboxTest MPIIS_GP_TOOLS ${gtest_link})
+target_link_libraries(
+  MathToolboxTest
+  MPIIS_GP_TOOLS
+  debug ${gtest_link_debug}
+  optimized ${gtest_link_optimized}
+)
 target_include_directories(MathToolboxTest  PRIVATE ${gaussian_process_root_dir}/src ${GTEST_HEADERS} ${EIGEN_SRC})
 set_property(TARGET MathToolboxTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME MathToolboxTest COMMAND MathToolboxTest)
 
 # Test for the GP Guider
 add_executable(GPGuiderTest ${gaussian_process_root_dir}/tests/gaussian_process/gp_guider_test.cpp)
-target_link_libraries(GPGuiderTest MPIIS_GP ${gtest_link} GPGuider)
+target_link_libraries(
+  GPGuiderTest
+  MPIIS_GP
+  debug ${gtest_link_debug}
+  optimized ${gtest_link_optimized}
+  GPGuider
+)
 target_include_directories(GPGuiderTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GPGuiderTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GPGuiderTest COMMAND GPGuiderTest WORKING_DIRECTORY ${gaussian_process_root_dir}/tests/gaussian_process/)
 
 # Performance Test for the GP Guider
 add_executable(GuidePerformanceTest ${gaussian_process_root_dir}/tests/gaussian_process/guide_performance_test.cpp)
-target_link_libraries(GuidePerformanceTest MPIIS_GP ${gtest_link} GPGuider)
+target_link_libraries(
+  GuidePerformanceTest
+  MPIIS_GP
+  debug ${gtest_link_debug}
+  optimized ${gtest_link_optimized}
+  GPGuider
+)
 target_include_directories(GuidePerformanceTest  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GuidePerformanceTest PROPERTY FOLDER "Unit tests/Contribution")
 add_test(NAME GuidePerformanceTest COMMAND GuidePerformanceTest WORKING_DIRECTORY ${gaussian_process_root_dir}/tests/gaussian_process/)
 
 # Performance Evaluation for the GP Guider
 add_executable(GuidePerformanceEval ${gaussian_process_root_dir}/tests/gaussian_process/evaluate_performance.cpp)
-target_link_libraries(GuidePerformanceEval MPIIS_GP ${gtest_link} GPGuider)
+target_link_libraries(
+  GuidePerformanceEval
+  MPIIS_GP
+  debug ${gtest_link_debug}
+  optimized ${gtest_link_optimized}
+  GPGuider
+)
 target_include_directories(GuidePerformanceEval  PRIVATE ${gaussian_process_root_dir}/tools ${GTEST_HEADERS} ${phd_src_dir})
 set_property(TARGET GuidePerformanceEval PROPERTY FOLDER "Unit tests/Contribution")

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -82,10 +82,12 @@ if(WIN32)
   message(STATUS "Preparing VCPKG")
   FetchContent_MakeAvailable(vcpkg)
   set(VCPKG_PREFIX ${vcpkg_SOURCE_DIR}/installed/x86-windows)
-  set(VCPKG_BIN ${VCPKG_PREFIX}/bin)
+  set(VCPKG_DEBUG_BIN ${VCPKG_PREFIX}/debug/bin)
+  set(VCPKG_RELEASE_BIN ${VCPKG_PREFIX}/bin)
+  set(VCPKG_DEBUG_LIB ${VCPKG_PREFIX}/debug/lib)
+  set(VCPKG_RELEASE_LIB ${VCPKG_PREFIX}/lib)
   set(VCPKG_INCLUDE ${VCPKG_PREFIX}/include)
   include_directories(${VCPKG_INCLUDE})
-  link_directories(${VCPKG_PREFIX}/lib)
 endif()
 
 #
@@ -217,8 +219,22 @@ endif()
 
 if(WIN32)
   include_directories(${VCPKG_INCLUDE}/cfitsio)
-  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} cfitsio.lib zlib.lib)
-  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL} ${VCPKG_BIN}/cfitsio.dll ${VCPKG_BIN}/zlib1.dll)
+  set(PHD_LINK_EXTERNAL_DEBUG ${PHD_LINK_EXTERNAL_DEBUG}
+      ${VCPKG_DEBUG_LIB}/cfitsio.lib
+      ${VCPKG_DEBUG_LIB}/zlibd.lib
+  )
+  set(PHD_LINK_EXTERNAL_RELEASE ${PHD_LINK_EXTERNAL_RELEASE}
+      ${VCPKG_RELEASE_LIB}/cfitsio.lib
+      ${VCPKG_RELEASE_LIB}/zlib.lib
+  )
+  set(PHD_COPY_EXTERNAL_DBG ${PHD_COPY_EXTERNAL_DBG}
+      ${VCPKG_DEBUG_BIN}/cfitsio.dll
+      ${VCPKG_DEBUG_BIN}/zlibd1.dll
+  )
+  set(PHD_COPY_EXTERNAL_REL ${PHD_COPY_EXTERNAL_REL}
+      ${VCPKG_RELEASE_BIN}/cfitsio.dll
+      ${VCPKG_RELEASE_BIN}/zlib1.dll
+  )
 elseif(USE_SYSTEM_CFITSIO)
   find_package(CFITSIO REQUIRED)
   include_directories(${CFITSIO_INCLUDE_DIR})
@@ -520,9 +536,17 @@ endif() # NOT WIN32
 #############################################
 
 if(WIN32)
-  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} libcurl.lib)
-  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}
-      ${VCPKG_BIN}/libcurl.dll
+  set(PHD_LINK_EXTERNAL_DEBUG ${PHD_LINK_EXTERNAL_DEBUG}
+      ${VCPKG_DEBUG_LIB}/libcurl-d.lib
+  )
+  set(PHD_LINK_EXTERNAL_RELEASE ${PHD_LINK_EXTERNAL_RELEASE}
+      ${VCPKG_RELEASE_LIB}/libcurl.lib
+  )
+  set(PHD_COPY_EXTERNAL_DBG ${PHD_COPY_EXTERNAL_DBG}
+      ${VCPKG_DEBUG_BIN}/libcurl-d.dll
+  )
+  set(PHD_COPY_EXTERNAL_REL ${PHD_COPY_EXTERNAL_REL}
+      ${VCPKG_RELEASE_BIN}/libcurl.dll
   )
 else()
   if(APPLE)
@@ -918,19 +942,33 @@ if(WIN32)
   endif()
 
   include_directories(${VCPKG_INCLUDE}/opencv2.4)
-  set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL}
-      opencv_imgproc2.lib
-      opencv_highgui2.lib
-      opencv_core2.lib
+  set(PHD_LINK_EXTERNAL_DEBUG ${PHD_LINK_EXTERNAL_DEBUG}
+      ${VCPKG_DEBUG_LIB}/opencv_imgproc2d.lib
+      ${VCPKG_DEBUG_LIB}/opencv_highgui2d.lib
+      ${VCPKG_DEBUG_LIB}/opencv_core2d.lib
   )
-  set(PHD_COPY_EXTERNAL_ALL ${PHD_COPY_EXTERNAL_ALL}
-      ${VCPKG_BIN}/opencv_imgproc2.dll
-      ${VCPKG_BIN}/opencv_highgui2.dll
-      ${VCPKG_BIN}/opencv_core2.dll
-      ${VCPKG_BIN}/jpeg62.dll
-      ${VCPKG_BIN}/libpng16.dll
-      ${VCPKG_BIN}/tiff.dll
-      ${VCPKG_BIN}/liblzma.dll
+  set(PHD_LINK_EXTERNAL_RELEASE ${PHD_LINK_EXTERNAL_RELEASE}
+      ${VCPKG_RELEASE_LIB}/opencv_imgproc2.lib
+      ${VCPKG_RELEASE_LIB}/opencv_highgui2.lib
+      ${VCPKG_RELEASE_LIB}/opencv_core2.lib
+  )
+  set(PHD_COPY_EXTERNAL_DBG ${PHD_COPY_EXTERNAL_DBG}
+      ${VCPKG_DEBUG_BIN}/opencv_imgproc2d.dll
+      ${VCPKG_DEBUG_BIN}/opencv_highgui2d.dll
+      ${VCPKG_DEBUG_BIN}/opencv_core2d.dll
+      ${VCPKG_DEBUG_BIN}/jpeg62.dll
+      ${VCPKG_DEBUG_BIN}/libpng16d.dll
+      ${VCPKG_DEBUG_BIN}/tiffd.dll
+      ${VCPKG_DEBUG_BIN}/liblzma.dll
+  )
+  set(PHD_COPY_EXTERNAL_REL ${PHD_COPY_EXTERNAL_REL}
+      ${VCPKG_RELEASE_BIN}/opencv_imgproc2.dll
+      ${VCPKG_RELEASE_BIN}/opencv_highgui2.dll
+      ${VCPKG_RELEASE_BIN}/opencv_core2.dll
+      ${VCPKG_RELEASE_BIN}/jpeg62.dll
+      ${VCPKG_RELEASE_BIN}/libpng16.dll
+      ${VCPKG_RELEASE_BIN}/tiff.dll
+      ${VCPKG_RELEASE_BIN}/liblzma.dll
   )
 endif()
 


### PR DESCRIPTION
The Windows build was always linking against the vcpkg release libraries. Now we link against the debug libs in debug builds, and the release libs in release builds.