### PR TITLE
Fix accidental revert of renaming GetDeclinationRadians() 

### DIFF
--- a/scope_indi.cpp
+++ b/scope_indi.cpp
@@ -139,7 +139,7 @@ class ScopeINDI : public Scope, public INDI::BaseClient
             return coord_prop ? true : false;
         }
 
-        double GetDeclination();
+        double GetDeclinationRadians() override;
         bool   GetGuideRates(double *pRAGuideRate, double *pDecGuideRate) override;
         bool   GetCoordinates(double *ra, double *dec, double *siderealTime) override;
         bool   GetSiteLatLong(double *latitude, double *longitude) override;
@@ -743,7 +743,7 @@ Mount::MOVE_RESULT ScopeINDI::Guide(GUIDE_DIRECTION direction, int duration)
     }
 }
 
-double ScopeINDI::GetDeclination()
+double ScopeINDI::GetDeclinationRadians()
 {
     if (coord_prop)
     {


### PR DESCRIPTION
#1129 accidentally reverted method rename from GetDeclination() to GetDeclinationRadians() done in #1045  causing declination to be reported as unknown. Renaming the method back to GetDeclinationRadians() fixes it. Fixes issue #1134 .