### PR TITLE
fix cmake error on Windows

### DIFF
--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -532,7 +532,7 @@ FetchContent_MakeAvailable(googletest)
 # The usage is a bit different on all the platforms. For having version >= 3.0, a version of cmake >= 3.0 should be used on Windows (on Linux/OSX it works properly this way).
 if(WIN32)
   # wxWidgets
-  set(wxWidgets_CONFIGURATION msw)
+  set(wxWidgets_CONFIGURATION msw CACHE STRING "Set wxWidgets configuration")
 
   if(NOT wxWidgets_PREFIX_DIRECTORY OR NOT EXISTS ${wxWidgets_PREFIX_DIRECTORY})
     message(FATAL_ERROR "The variable wxWidgets_PREFIX_DIRECTORY should be defined and should point to a valid wxWindows installation path. See the open-phd-guiding wiki for more information.")


### PR DESCRIPTION
The commit for #1144 bumped the cmake minimum version to 3.24 since we now use the FetchContent module.  This had a side-effect of changing policy CMP0126 https://cmake.org/cmake/help/latest/policy/CMP0126.html which caused the wxWidgets find_package call to fail as the wxWidgets_CONFIGURATION variable was being set as a normal (non-cache) valriable.