### PR TITLE
reinstate USE_SYSTEM_GTEST build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,14 @@
 
 # File created by Raffi Enficiaud
 
-cmake_minimum_required(VERSION 3.24)
+if(USE_SYSTEM_GTEST)
+  cmake_minimum_required(VERSION 3.16)
+else()
+  # If the system gtest is not available (especially Windows and Mac
+  # builds) gtest is incorporated using FetchContent which requires
+  # cmake 3.24
+  cmake_minimum_required(VERSION 3.24)
+endif()
 
 # this must come before any enable_language() or project()
 if(APPLE)
@@ -46,7 +53,9 @@ if(COMMAND cmake_policy)
       cmake_policy(SET CMP0043 NEW)
     endif()
 endif()
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 
 # root directory of the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,7 +768,9 @@ else()
   message(FATAL_ERROR "Unsupported platform")
 endif()
 
-add_dependencies(phd2 ${PHD_EXTERNAL_PROJECT_DEPENDENCIES})
+if(PHD_EXTERNAL_PROJECT_DEPENDENCIES)
+  add_dependencies(phd2 ${PHD_EXTERNAL_PROJECT_DEPENDENCIES})
+endif()
 
 # properties of the project common to all platforms
 target_compile_definitions(phd2 PRIVATE "${wxWidgets_DEFINITIONS}" "HAVE_TYPE_TRAITS")

--- a/contributions/MPI_IS_gaussian_process/CMakeLists.txt
+++ b/contributions/MPI_IS_gaussian_process/CMakeLists.txt
@@ -79,13 +79,8 @@ set_property(TARGET GPGuider PROPERTY FOLDER "Contributions/")
 # Unit tests
 #
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(gtest_link_debug GTest::GTest)
-    set(gtest_link_optimized GTest::GTest)
-else()
-    set(gtest_link_debug gtest)
-    set(gtest_link_optimized gtest)
-endif()
+set(gtest_link_debug GTest::gtest)
+set(gtest_link_optimized GTest::gtest)
 
 
 # Test for the GP

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -517,14 +517,19 @@ endif()
 # Google test, easily built
 # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
 
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+if(USE_SYSTEM_GTEST)
+  find_package(GTest REQUIRED)
+  message(STATUS "Using system's gtest")
+else()
+  include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+  )
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+endif()
 
 
 #############################################


### PR DESCRIPTION
Testing:
 - `cmake -DUSE_SYSTEM_GTEST=ON -DUSE_SYSTEM_LIBINDI=ON -DUSE_SYSTEM_EIGEN3=ON -DUSE_SYSTEM_LIBUSB=ON  ..`
 - `make`
 - `make -C tmp_gaussian_process test`