### PR TITLE
Better error message for RGB FITS file from INDI

### DIFF
--- a/cam_indi.cpp
+++ b/cam_indi.cpp
@@ -864,9 +864,15 @@ bool CameraINDI::ReadFITS(CapturedFrame *frame, usImage& img, bool takeSubframe,
     int nhdus = 0;
     fits_get_num_hdus(fptr, &nhdus, &status);
 
+    if (naxis == 3)
+    {
+        pFrame->Alert(_("RGB images are not supported, please switch the INDI driver to Mono"));
+        PHD_fits_close_file(fptr);
+        return true;
+    }
     if (nhdus != 1 || naxis != 2)
     {
-        pFrame->Alert(_("Unsupported type or read error loading FITS file"));
+        pFrame->Alert(_("Unsupported FITS file"));
         PHD_fits_close_file(fptr);
         return true;
     }


### PR DESCRIPTION
Change the error message when receiving a FITS file from INDI with NAXIS=3
Please comment if the new message is not clear enough.

Fix #1157 