### PR TITLE
Star profile layout tweaks

### DIFF
--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -239,55 +239,13 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
         dc.DrawLines(FULLW, Prof);
     }
 
+    // Prioritize rendering star image before rendering text
     dc.SetTextForeground(wxColour(255,0,0));
-
-    const Star& star = pFrame->pGuider->PrimaryStar();
-    if (star.IsValid())
-    {
-        dc.DrawText(_("Peak"), 3, 3);
-        dc.DrawText(wxString::Format("%u", star.PeakVal), 3, 3 + smallFontHeight);
-    }
-
-    float hfd = star.HFD;
-    imageLeftMargin = (xsize - 15) / 2;
-    if (hfd != 0.f)
-    {
-        float hfdArcSec = hfd * pFrame->GetCameraPixelScale();
-        if (inFocusingMode)
-        {
-            wxString fwhmLine = wxString::Format(_("%s FWHM: %.2f"), profileLabel, fwhm);
-            int fwhmLineWidth = dc.GetTextExtent(fwhmLine).GetWidth();
-            dc.DrawText(fwhmLine, 5, ysize - labelTextHeight + 5);
-            // Show X/Y of centroid if there's room
-            if (imageLeftMargin > fwhmLineWidth + 20)
-                dc.DrawText(wxString::Format("X: %0.2f, Y: %0.2f", pFrame->pGuider->CurrentPosition().X, pFrame->pGuider->CurrentPosition().Y), imageLeftMargin, ysize - labelTextHeight + 5);
-            int x = 5;
-            wxString s(_("HFD: "));
-            dc.DrawText(s, x, ysize - largeFontHeight / 2 - smallFontHeight / 2);
-            x += dc.GetTextExtent(s).GetWidth();
-
-            dc.SetFont(largeFont);
-            s = wxString::Format(_T("%.2f"), hfd);
-            dc.DrawText(s, x, ysize - largeFontHeight);
-            x += dc.GetTextExtent(s).GetWidth();
-
-            dc.SetFont(smallFont);
-            s = wxString::Format(_T("  %.2f\""), hfdArcSec);
-            dc.DrawText(s, x, ysize - largeFontHeight / 2 - smallFontHeight / 2);
-        }
-        else
-        {
-            dc.DrawText(wxString::Format(_("%s FWHM: %.2f, HFD: %.2f (%.2f\")"), profileLabel, fwhm, hfd, hfdArcSec), 5, ysize - smallFontHeight - 5);
-        }
-    }
-    else
-    {
-        dc.DrawText(wxString::Format(_("%s FWHM: %.2f"), profileLabel, fwhm), 5, ysize - smallFontHeight - 5);
-    }
 
     // JBW: draw zoomed guidestar subframe (todo: make constants symbolic)
     wxImage* img = pFrame->pGuider->DisplayedImage();
     double scaleFactor = pFrame->pGuider->ScaleFactor();
+    imageLeftMargin = (xsize - 15) / 2;
     if (img)
     {
         int width = xsize - imageLeftMargin - 5;
@@ -352,5 +310,49 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
             }
         }
     }
+
+    const Star& star = pFrame->pGuider->PrimaryStar();
+    if (star.IsValid())
+    {
+        dc.DrawText(_("Peak"), 3, 3);
+        dc.DrawText(wxString::Format("%u", star.PeakVal), 3, 3 + smallFontHeight);
+    }
+
+    float hfd = star.HFD;
+    if (hfd != 0.f)
+    {
+        float hfdArcSec = hfd * pFrame->GetCameraPixelScale();
+        if (inFocusingMode)
+        {
+            wxString fwhmLine = wxString::Format(_("%s FWHM: %.2f"), profileLabel, fwhm);
+            int fwhmLineWidth = dc.GetTextExtent(fwhmLine).GetWidth();
+            dc.DrawText(fwhmLine, 5, ysize - labelTextHeight + 5);
+            // Show X/Y of centroid if there's room
+            if (imageLeftMargin > fwhmLineWidth + 20)
+                dc.DrawText(wxString::Format("X: %0.2f, Y: %0.2f", pFrame->pGuider->CurrentPosition().X, pFrame->pGuider->CurrentPosition().Y), imageLeftMargin, ysize - labelTextHeight + 5);
+            int x = 5;
+            wxString s(_("HFD: "));
+            dc.DrawText(s, x, ysize - largeFontHeight / 2 - smallFontHeight / 2);
+            x += dc.GetTextExtent(s).GetWidth();
+
+            dc.SetFont(largeFont);
+            s = wxString::Format(_T("%.2f"), hfd);
+            dc.DrawText(s, x, ysize - largeFontHeight);
+            x += dc.GetTextExtent(s).GetWidth();
+
+            dc.SetFont(smallFont);
+            s = wxString::Format(_T("  %.2f\""), hfdArcSec);
+            dc.DrawText(s, x, ysize - largeFontHeight / 2 - smallFontHeight / 2);
+        }
+        else
+        {
+            dc.DrawText(wxString::Format(_("%s FWHM: %.2f, HFD: %.2f (%.2f\")"), profileLabel, fwhm, hfd, hfdArcSec), 5, ysize - smallFontHeight - 5);
+        }
+    }
+    else
+    {
+        dc.DrawText(wxString::Format(_("%s FWHM: %.2f"), profileLabel, fwhm), 5, ysize - smallFontHeight - 5);
+    }
+
 }
 

--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -56,6 +56,12 @@ ProfileWindow::ProfileWindow(wxWindow *parent) :
     rawMode = pConfig->Global.GetBoolean("/ProfileRawMode", false);
     this->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
     this->data = new unsigned short[FULLW * FULLW];  // 21x21 subframe
+
+    memset(midrow_profile, 0, sizeof(midrow_profile));
+    memset(vert_profile, 0, sizeof(vert_profile));
+    memset(horiz_profile, 0, sizeof(horiz_profile));
+    imageLeftMargin = 0;
+    imageBottom = 0;
 }
 
 ProfileWindow::~ProfileWindow()

--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -346,7 +346,7 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
             int fwhmLineWidth = dc.GetTextExtent(fwhmLine).GetWidth();
             dc.DrawText(fwhmLine, 5, ysize - labelTextHeight + 5);
             // Show X/Y of centroid if there's room
-            if (imageLeftMargin > fwhmLineWidth + 20)
+            if ((imageLeftMargin > fwhmLineWidth + 20) && (ysize - labelTextHeight + 5 > imageBottom))
                 dc.DrawText(wxString::Format("X: %0.2f, Y: %0.2f", pFrame->pGuider->CurrentPosition().X, pFrame->pGuider->CurrentPosition().Y), imageLeftMargin, ysize - labelTextHeight + 5);
             int x = 5;
             wxString s(_("HFD: "));

--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -343,12 +343,12 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
         if (sz > 0)
         {
             // and a small cross at the centroid
-            double starX = imageLeftMargin + midwidth - dStarX * (width / (sz * 2)) + 1, starY = midwidth - dStarY * (width / (sz * 2)) + 1 + imgTop;
+            double starX = imageLeftMargin + midwidth - dStarX * (width / (sz * 2.0)) + 1, starY = midwidth - dStarY * (width / (sz * 2.0)) + 1 + imgTop;
             if (starX >= imageLeftMargin)
             {
                 dc.SetPen(RedPen);
-                dc.DrawLine(starX - 3, starY, starX + 3, starY);
-                dc.DrawLine(starX, starY - 3, starX, starY + 3);
+                dc.DrawLine(starX - 5, starY, starX + 5, starY);
+                dc.DrawLine(starX, starY - 5, starX, starY + 5);
             }
         }
     }

--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -258,13 +258,14 @@ void ProfileWindow::OnPaint(wxPaintEvent& WXUNUSED(evt))
         double dStarY = LockY - pFrame->pGuider->CurrentPosition().Y * scaleFactor;
         // grab the subframe
         wxBitmap dBmp(*img);
+        int scaledSize = 15 * scaleFactor;
         int lkx = ROUND(LockX);
-        int l = std::max(0, lkx - 15);
-        int r = std::min(dBmp.GetWidth() - 1, lkx + 15);
+        int l = std::max(0, lkx - scaledSize);
+        int r = std::min(dBmp.GetWidth() - 1, lkx + scaledSize);
         int w = std::min(lkx - l, r - lkx);
         int lky = ROUND(LockY);
-        int t = std::max(0, lky - 15);
-        int b = std::min(dBmp.GetHeight() - 1, lky + 15);
+        int t = std::max(0, lky - scaledSize);
+        int b = std::min(dBmp.GetHeight() - 1, lky + scaledSize);
         int h = std::min(lky - t, b - lky);
         int sz = std::min(w, h);
         // scale by 2


### PR DESCRIPTION
A set of commits fixing few scaling factors used to prevent HFD metrics clipping at the window edges or by other window elements, enhancing accuracy of displayed star centroid, clearing previously uninitialized state variables - all resulting in a cleaner UI and predictable behavior.