### PR TITLE
Prevent resizing of rows and columns in stats window

### DIFF
--- a/statswindow.cpp
+++ b/statswindow.cpp
@@ -82,6 +82,7 @@ StatsWindow::StatsWindow(wxWindow *parent)
     m_grid1->SetCellValue(1, 1, "");
     m_grid1->SetCellValue(1, 2, "");
     m_grid1->ClearSelection();
+    m_grid1->DisableDragGridSize();
 
     m_grid2 = new wxGrid(this, wxID_ANY);
     m_grid2->CreateGrid(12, 2);
@@ -128,6 +129,7 @@ StatsWindow::StatsWindow(wxWindow *parent)
     m_grid2->SetCellValue(3, 1, wxEmptyString);
     m_grid2->SetCellValue(m_pixelScaleRow + 1, 1, wxEmptyString); // field of view row
     m_grid2->ClearSelection();
+    m_grid2->DisableDragGridSize();
 
     wxSizer *sizer1 = new wxBoxSizer(wxHORIZONTAL);
 


### PR DESCRIPTION
Prevent resizing of rows and columns in stats grids to protect against inadvertent change of cell size by the user.