### PR TITLE
Update INDI device's Connect method to wait for 'Connected' property

### DIFF
--- a/scope_indi.cpp
+++ b/scope_indi.cpp
@@ -300,18 +300,6 @@ bool ScopeINDI::Connect()
 
     Debug.Write(wxString::Format("Waiting for 30s for [%s] to connect...\n", INDIMountName));
 
-    ///* Wait in foreground for driver to establish a device connection */
-    //if (connectServer())
-    //{
-    //    Debug.Write(wxString::Format("Waiting for 30s for [%s] to connect...\n", INDIMountName));
-    //    int i = 0;
-    //    while (!Connected && i++ < 300) 
-    //        wxMilliSleep(100);
-    //}
-    //
-    //// We need to return FALSE if we are successful???
-    //return !Connected;
-    
     /* Wait in background for driver to establish a device connection */
     struct ConnectInBg : public ConnectMountInBg
     {

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -634,7 +634,6 @@ else()
     else()
       find_library(LIBNOVA REQUIRED NAMES nova)
       set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${LIBNOVA} z)
-      add_definitions("-DLIBNOVA")
     endif()
     ## Define LIBNOVA when building Indi from source.
     add_definitions("-DLIBNOVA")

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -634,6 +634,7 @@ else()
     else()
       find_library(LIBNOVA REQUIRED NAMES nova)
       set(PHD_LINK_EXTERNAL ${PHD_LINK_EXTERNAL} ${LIBNOVA} z)
+      add_definitions("-DLIBNOVA")
     endif()
     ## Define LIBNOVA when building Indi from source.
     add_definitions("-DLIBNOVA")


### PR DESCRIPTION
This push attempts to fix "Problem with connection status when connecting Indi devices in v2.6.13dev1 [#1174 ]"

This new code monitors the INDI device's 'Connected' property and waits for it to be 'true' before releasing the Connect method back to the UI. I tried to move the wait loop into the RunInBG template so users are able to cancel.

It's been tested with an aarch64 bit build using the Indi scope and camera simulators. I verified that
* Camera simulator and mount simulator are connecting
* Both devices show as connected
* The Dark frame library is assigned successfully
* No alerts with respect to camera connectivity and bad-pixel maps or dark libraries 
* "Connect All" button connects both devices and then closes gear selection dialog.

Concerns or advise is welcome. I am not overly familiar with the overall device management code base so there is a good chance that this change is overlooking something or not following best practices - let me know!

A debug log for the test is attached:
[PHD2.log](https://github.com/OpenPHDGuiding/phd2/files/14271621/PHD2.log)
