### PR TITLE
Histogram builder: fix incorrect delete operator

### DIFF
--- a/usImage.cpp
+++ b/usImage.cpp
@@ -51,7 +51,7 @@ class HistogramBuilder {
         }
 
         ~HistogramBuilder() {
-            delete histo;
+            delete[] histo;
         }
 
         unsigned short median() const
@@ -66,7 +66,6 @@ class HistogramBuilder {
             }
             return MaxADU;
         }
-
 
         void scan(const unsigned short *t, int len)
         {


### PR DESCRIPTION
Using delete instead of delete[] for memory allocated with new[] is a common mistake that can lead to undefined behavior. The consequences of this mismatch between allocation and deallocation mechanisms can vary depending on the compiler, the runtime environment, and the specifics of the program.