### PR TITLE
Add OpenCV camera with Linux, the new code for OpenCV4 work fine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,7 +768,10 @@ elseif(UNIX)
    ${guiding_SRC}
    ${phd2_SRC}
    )
-  target_link_libraries(phd2 X11)
+
+  find_package( OpenCV REQUIRED )
+
+  target_link_libraries(phd2 X11 ${OpenCV_LIBS})
 
   set_target_properties(
     phd2

--- a/cameras.h
+++ b/cameras.h
@@ -109,6 +109,7 @@
 #elif defined (__linux__) || defined (__FreeBSD__)
 
 # define SIMULATOR
+# define OPENCV_CAMERA
 # define CAM_QHY5
 # ifdef HAVE_QHY_CAMERA
 #  define QHY_CAMERA

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: phd2
 Section: education
 Priority: optional
 Maintainer: Patrick Chevalley <pch@ap-i.net>
-Build-Depends: debhelper (>= 9), cmake, libwxgtk3.2-dev | libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev, libcfitsio-dev, libopencv-dev, libusb-1.0-0-dev, libudev-dev, libv4l-dev, libnova-dev, libcurl4-gnutls-dev, libindi-dev (>= 2.0), libeigen3-dev, libgtest-dev
+Build-Depends: debhelper (>= 9), cmake, libwxgtk3.2-dev | libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev, libcfitsio-dev, libopencv-dev, libusb-1.0-0-dev, libudev-dev, libv4l-dev, libnova-dev, libcurl4-gnutls-dev, libindi-dev (>= 2.0), libeigen3-dev, libgtest-dev libopencv-dev
 Standards-Version: 3.9.5
 Homepage: http://openphdguiding.org/
 


### PR DESCRIPTION
With the change for OpenCV4 the OpenCV camera now work fine on Linux.
Tested with a laptop webcam.

This is interesting to add because this can support other devices than the V4L2 INDI driver. 

The change is trivial, but please let me know if there is another/better location for "find_package".
I not added conditional switch because OpenCV will anyway be required by the new planetary module. 
