### PR TITLE
Target window: tweak positions of graphical elements to avoid overlap (part4 for planetary guiding)

### DIFF
--- a/statswindow.cpp
+++ b/statswindow.cpp
@@ -269,7 +269,7 @@ void StatsWindow::UpdateCooler()
 static wxString fov(const wxSize& sensorFormat, double sampling)
 {
     if (sampling != 1.0)
-        return wxString::Format("% 4.1f x % 4.1f  %s", sensorFormat.x * sampling / 60.0, sensorFormat.y * sampling / 60.0, _("arc-min"));
+        return wxString::Format("%4.1f x %4.1f %s", sensorFormat.x * sampling / 60.0, sensorFormat.y * sampling / 60.0, _("arc-min"));
     else
         return " ";
 }

--- a/target.cpp
+++ b/target.cpp
@@ -337,7 +337,7 @@ void TargetClient::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     // Draw labels
     int d_width, d_height;
-    dc.GetTextExtent(_("0"), &d_width, &d_height);
+    dc.GetTextExtent(_T("0"), &d_width, &d_height);
     dc.DrawText(_("RA"), leftEdge, center.y - 3 - d_height);
     dc.DrawText(_("Dec"), center.x + 5, center.y - radius_max - d_height);
 

--- a/target.cpp
+++ b/target.cpp
@@ -336,8 +336,10 @@ void TargetClient::OnPaint(wxPaintEvent& WXUNUSED(evt))
     }
 
     // Draw labels
-    dc.DrawText(_("RA"), leftEdge, center.y - 15);
-    dc.DrawText(_("Dec"), center.x - 35, topEdge - 3);
+    int d_width = 10, d_height = 10;
+    dc.GetTextExtent(_("0"), &d_width, &d_height);
+    dc.DrawText(_("RA"), leftEdge, center.y - 3 - d_height);
+    dc.DrawText(_("Dec"), center.x + 5, center.y - radius_max - d_height);
 
     // Draw impacts
     unsigned int startPoint = m_maxHistorySize - m_length;
@@ -359,15 +361,15 @@ void TargetClient::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     GuideParity raParity = pMount ? pMount->RAParity() : GUIDE_PARITY_UNKNOWN;
     if (raParity == GUIDE_PARITY_EVEN)
-        dc.DrawText(_("SkyE"), size.x - 30, center.y + 5);  // sky E = mount E
+        dc.DrawText(_("SkyE"), size.x - d_width * 5, center.y + 5);  // sky E = mount E
     else if (raParity == GUIDE_PARITY_ODD)
-        dc.DrawText(_("SkyE"), leftEdge, center.y + 5);     // sky E = mount W
+        dc.DrawText(_("SkyE"), leftEdge, center.y + 5);              // sky E = mount W
 
     GuideParity decParity = pMount ? pMount->DecParity() : GUIDE_PARITY_UNKNOWN;
     if (decParity == GUIDE_PARITY_EVEN)
-        dc.DrawText(_("SkyN"), center.x + 5, topEdge - 3);  // sky N = mount N
+        dc.DrawText(_("SkyN"), center.x + 5, center.y + 5 - radius_max);    // sky N = mount N
     else if (decParity == GUIDE_PARITY_ODD)
-        dc.DrawText(_("SkyN"), center.x + 5, size.y - 15);  // sky N = mount S
+        dc.DrawText(_("SkyN"), center.x + 5, center.y + 5 + radius_max);    // sky N = mount S
 
     dc.SetPen(wxPen(wxColour(127, 127, 255), 1, wxPENSTYLE_SOLID));
     for (unsigned int i = startPoint; i < m_maxHistorySize; i++)

--- a/target.cpp
+++ b/target.cpp
@@ -336,7 +336,7 @@ void TargetClient::OnPaint(wxPaintEvent& WXUNUSED(evt))
     }
 
     // Draw labels
-    int d_width = 10, d_height = 10;
+    int d_width, d_height;
     dc.GetTextExtent(_("0"), &d_width, &d_height);
     dc.DrawText(_("RA"), leftEdge, center.y - 3 - d_height);
     dc.DrawText(_("Dec"), center.x + 5, center.y - radius_max - d_height);


### PR DESCRIPTION
I'll add later a few screenshots to show what was fixed.