### PR TITLE
Rework of image-scale change handling

### DIFF
--- a/advanced_dialog.cpp
+++ b/advanced_dialog.cpp
@@ -551,12 +551,16 @@ void AdvancedDialog::SetPixelSize(double val)
         m_pCameraCtrlSet->SetPixelSize(val);
 }
 
+inline static double SiderealRateFromGuideSpeed(double guideSpeed)
+{
+    double const siderealSecsPerSec = 0.9973;
+    return guideSpeed * 3600.0 / (15.0 * siderealSecsPerSec);
+}
+
 // Get the best estimate for the current mount guide speeds
 double AdvancedDialog::DetermineGuideSpeed()
 {
-    double const siderealSecsPerSec = 0.9973;
     double sidRate = 0.5;
-    #define RateX(spd)  (spd * 3600.0 / (15.0 * siderealSecsPerSec))
 
     if (pPointingSource && pPointingSource->IsConnected())
     {
@@ -572,7 +576,7 @@ double AdvancedDialog::DetermineGuideSpeed()
                     minSpd = wxMin(raSpd, decSpd);
                 else
                     minSpd = raSpd;
-                sidRate = RateX(minSpd);
+                sidRate = SiderealRateFromGuideSpeed(minSpd);
 
             }
         }
@@ -584,7 +588,7 @@ double AdvancedDialog::DetermineGuideSpeed()
             {
                 if (TheScope()->ValidGuideRates(calDetails.raGuideSpeed, calDetails.decGuideSpeed))
                 {
-                    sidRate = RateX(wxMin(calDetails.raGuideSpeed, calDetails.decGuideSpeed));
+                    sidRate = SiderealRateFromGuideSpeed(wxMin(calDetails.raGuideSpeed, calDetails.decGuideSpeed));
                 }
             }
         }

--- a/advanced_dialog.cpp
+++ b/advanced_dialog.cpp
@@ -41,7 +41,7 @@
 # include <wx/choicebk.h>
 #endif
 
-const double AdvancedDialog::MIN_FOCAL_LENGTH = 50.0;
+const double AdvancedDialog::MIN_FOCAL_LENGTH = 100.0;
 const double AdvancedDialog::MAX_FOCAL_LENGTH = 10000.0;
 
 // a place to save id of selected panel so we can select the same panel next time the dialog is opened
@@ -454,6 +454,7 @@ void AdvancedDialog::LoadValues()
         RebuildPanels();
 
     // Load all the current params
+    m_imageScaleChanged = false;
     m_pGlobalCtrlSet->LoadValues();
     if (m_pCameraCtrlSet)
         m_pCameraCtrlSet->LoadValues();
@@ -500,6 +501,11 @@ void AdvancedDialog::UnloadValues()
         m_pScopeCtrlSet->UnloadValues();
         m_pMountPane->UnloadValues();
     }
+    if (m_imageScaleChanged)
+    {
+        MakeImageScaleAdjustments();
+        m_imageScaleChanged = false;
+    }
 }
 
 // Any un-do ops need to be handled at the ConfigDialogPane level
@@ -514,6 +520,7 @@ void AdvancedDialog::Undo()
         if (pane)
             pane->Undo();
     }
+    m_imageScaleChanged = false;
 }
 
 void AdvancedDialog::EndModal(int retCode)
@@ -544,49 +551,77 @@ void AdvancedDialog::SetPixelSize(double val)
         m_pCameraCtrlSet->SetPixelSize(val);
 }
 
-// Needed to handle reset if the image scale changes on the fly
-void AdvancedDialog::ResetGuidingParams()
+// Get the best estimate for the current mount guide speeds
+double AdvancedDialog::DetermineGuideSpeed()
 {
-    LoadValues();           // Insure that control values reflect actual device properties and any changes made outside the AD
-    m_pMountPane->ResetRAGuidingParams();
-    m_pMountPane->ResetDecGuidingParams();
-    UnloadValues();
-}
+    double const siderealSecsPerSec = 0.9973;
+    double sidRate = 0.5;
+    #define RateX(spd)  (spd * 3600.0 / (15.0 * siderealSecsPerSec))
 
-// This function only affects UI elements in the various AD panes and is intended for use only by the various ConfigCtrl classes
-void AdvancedDialog::MakeImageScaleAdjustments()
-{
-    double origImageScale = pFrame->GetPixelScale(pCamera->GetCameraPixelSize(), pFrame->GetFocalLength(), pCamera->Binning);       // Profile values
-    double newImageScale = pFrame->GetPixelScale(GetPixelSize(), GetFocalLength(), GetBinning());                                   // Current UI ctrl values
-    if (fabs((origImageScale - newImageScale) / newImageScale) >= 0.01)
+    if (pPointingSource && pPointingSource->IsConnected())
     {
-        // Scale the UI cal step size based on image scale ratio - may get refined at start of calibration if actual guiding rates are known
-        Debug.Write("Image scale has changed via AD UI - step-size and algo adjustments made\n");
-        Debug.Write(wxString::Format("  fl %d => %d, px %.3fu => %.3fu, bin %d => %d\n",
-                                     pFrame->GetFocalLength(), GetFocalLength(),
-                                     pCamera->GetCameraPixelSize(), GetPixelSize(),
-                                     pCamera->Binning, GetBinning()));
+        double raSpd;
+        double decSpd;
 
-        ScopeConfigDialogCtrlSet *cfgset = static_cast<ScopeConfigDialogCtrlSet *>(m_pScopeCtrlSet);
-        int oldStepSize = cfgset->GetCalStepSizeCtrlValue();
-        int newCalStep = (int)((double)oldStepSize * (newImageScale / origImageScale));
-        cfgset->SetCalStepSizeCtrlValue(newCalStep);
-
-        // but let the current guide algos make their own adjustments for stuff like min-moves
-        if (m_pMountPane->IsValid())
+        if (!pPointingSource->GetGuideRates(&raSpd, &decSpd))
         {
-            m_pMountPane->OnImageScaleChange();
+            if (pPointingSource->ValidGuideRates(raSpd, decSpd))
+            {
+                double minSpd;
+                if (decSpd != -1)
+                    minSpd = wxMin(raSpd, decSpd);
+                else
+                    minSpd = raSpd;
+                sidRate = RateX(minSpd);
+
+            }
         }
-        if (pMount)
+        else
         {
-            pMount->ClearCalibration();
-            if (pMount->IsStepGuider() && pSecondaryMount)
-                pSecondaryMount->ClearCalibration();
-            Debug.Write("Calibrations cleared because of image scale change\n");
+            CalibrationDetails calDetails;
+            TheScope()->LoadCalibrationDetails(&calDetails);
+            if (calDetails.IsValid())
+            {
+                if (TheScope()->ValidGuideRates(calDetails.raGuideSpeed, calDetails.decGuideSpeed))
+                {
+                    sidRate = RateX(wxMin(calDetails.raGuideSpeed, calDetails.decGuideSpeed));
+                }
+            }
         }
     }
+    return sidRate;
+}
+// Reacts to param changes in the AD that change the image scale.  Calibration step-size is recalculated, calibration is cleared, MinMoves are set to defaults based on new image scale
+void AdvancedDialog::MakeImageScaleAdjustments()
+{
+    double guideSpeedX;
+    Debug.Write("Image scale has changed via AD UI - step-size and algo adjustments will be made\n");
+    Debug.Write(wxString::Format("New image scale properties:  fl= %d, px= %.3fu, bin= %d\n",
+                                    pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(),
+                                    pCamera->Binning));
 
+    // Determine a calibration step-size based on recommended distance and best estimator of mount guide speeds
+    guideSpeedX = DetermineGuideSpeed();
+    int calibrationStep;
+    int recDistance = CalstepDialog::GetCalibrationDistance(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning);
+    int oldStepSize = TheScope()->GetCalibrationDuration();
+    CalstepDialog::GetCalibrationStepSize(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning, guideSpeedX,
+        CalstepDialog::DEFAULT_STEPS, 0, recDistance, nullptr, &calibrationStep);
+    TheScope()->SetCalibrationDuration(calibrationStep);
+    Debug.Write(wxString::Format("Cal step-size changed from %d ms to %d ms\n", oldStepSize, calibrationStep));
+    // Clear the calibration to force a new one and reset the min-move values
+    if (pMount)
+    {
+        pMount->ClearCalibration();
+        if (pMount->IsStepGuider() && pSecondaryMount)
+            pSecondaryMount->ClearCalibration();
+        Debug.Write("Calibrations cleared because of image scale change\n");
 
+        double defMinMove = GuideAlgorithm::SmartDefaultMinMove(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning);
+        Debug.Write(wxString::Format("Guide algo min moves reset to %.3fu\n", defMinMove));
+        pMount->GetXGuideAlgorithm()->SetMinMove(defMinMove);
+        pMount->GetYGuideAlgorithm()->SetMinMove(defMinMove);
+    }
 }
 
 int AdvancedDialog::GetBinning()

--- a/advanced_dialog.h
+++ b/advanced_dialog.h
@@ -79,6 +79,7 @@ class AdvancedDialog : public wxDialog
     wxPanel *m_pDevicesSettingsPanel;
     wxTipWindow *m_tip;
     wxTimer *m_tipTimer;
+    bool m_imageScaleChanged;
 
 public:
 
@@ -102,7 +103,7 @@ public:
 
     bool Validate() override;
     void ShowInvalid(wxWindow *ctrl, const wxString& message);
-
+    void FlagImageScaleChange() { m_imageScaleChanged = true; }     // Allows image scale adjustment to be made only once when AD is closed
     int GetFocalLength();
     void SetFocalLength(int val);
     double GetPixelSize();
@@ -110,7 +111,6 @@ public:
     int GetBinning();
     void SetBinning(int binning);
     void MakeImageScaleAdjustments();
-    void ResetGuidingParams();
     Mount::MountConfigDialogPane* GetCurrentMountPane() { return m_pMountPane; }
 
     wxWindow *GetTabLocation(BRAIN_CTRL_IDS id);
@@ -125,6 +125,7 @@ private:
     void BuildCtrlSets();
     void CleanupCtrlSets();
     void ConfirmLayouts();
+    double DetermineGuideSpeed();
 };
 
 #endif // ADVANCED_DIALOG_H_INCLUDED

--- a/camera.cpp
+++ b/camera.cpp
@@ -1191,7 +1191,7 @@ void CameraConfigDialogCtrlSet::UnloadValues()
         int oldBin = m_pCamera->Binning;
         int newBin = m_binning->GetSelection() + 1;
         if (oldBin != newBin)
-            pFrame->pAdvancedDialog->MakeImageScaleAdjustments();           // Do this now to preserve old (device value) and new (UI value) for scale adjustment
+            pFrame->pAdvancedDialog->FlagImageScaleChange();
         m_pCamera->SetBinning(m_binning->GetSelection() + 1);
     }
 
@@ -1234,7 +1234,7 @@ void CameraConfigDialogCtrlSet::UnloadValues()
     double oldPxSz = m_pCamera->GetCameraPixelSize();
     double newPxSz = m_pPixelSize->GetValue();
     if (oldPxSz != newPxSz)
-        pFrame->pAdvancedDialog->MakeImageScaleAdjustments();       // Preserve old (device value) and new (UI value) for scale adjustment
+        pFrame->pAdvancedDialog->FlagImageScaleChange();
     m_pCamera->SetCameraPixelSize(m_pPixelSize->GetValue());
 
     bool saturationByADU = m_SaturationByADU->GetValue();

--- a/gear_dialog.cpp
+++ b/gear_dialog.cpp
@@ -580,7 +580,7 @@ void GearDialog::EndModal(int retCode)
     if (fabs(m_imageScaleRatio - 1.0) >= 0.01)
     {
         Debug.Write("GearDialog::EndModal: imageScaleRatio changed\n");
-        pFrame->HandleImageScaleChange(m_imageScaleRatio);                  // Must be done after preceding updates to AD pane
+        pFrame->HandleImageScaleChange();
     }
 
     if (m_showDarksDialog)

--- a/mount.cpp
+++ b/mount.cpp
@@ -1311,11 +1311,7 @@ void Mount::AdjustCalibrationForScopePointing()
     if (fabs(scaleAdjustment - 1.0) >= 0.01)
     {
         Debug.Write("Mount::AdjustCalibrationForScopePointing: imageScaleRatio changed\n");
-
-        // Device-specified pixel size and binning will be reflected in AD when LoadValues() occurs
-        pFrame->HandleImageScaleChange(scaleAdjustment);          // Revert the guide params, get the various UIs sorted out
-        // Force a fresh calibration when guiding is started next
-        ClearCalibration();
+        pFrame->HandleImageScaleChange();          // Clear calibration, get the various UIs sorted out
     }
 
     if (IsOppositeSide(newPierSide, m_cal.pierSide))

--- a/myframe.h
+++ b/myframe.h
@@ -453,7 +453,7 @@ public:
     void SetDitherMode(DitherMode mode);
     DitherMode GetDitherMode() const;
 
-    void HandleImageScaleChange(double NewToOldRatio);
+    void HandleImageScaleChange();
 
     void NotifyGuidingParam(const wxString& name, double val);
     void NotifyGuidingParam(const wxString& name, int val);


### PR DESCRIPTION
This revises earlier code that reacted to image scale changes in an existing profile.  This revision takes a more straightforward approach that mimics the code in the new-profile-wiz to create from-scratch settings for calibration step-size and MinMoves.  It forces a fresh calibration after the changes are made but doesn't do the broad-brush guide algorithm resets that were done in the original code.  The original code was too vulnerable to situations where user-controlled settings were already out-of-whack.