### PR TITLE
Do not try to fetch the Ogma camera library whith OPENSOURCE_ONLY

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: phd2
 Section: education
 Priority: optional
 Maintainer: Patrick Chevalley <pch@ap-i.net>
-Build-Depends: debhelper (>= 9), cmake, libwxgtk3.2-dev | libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev, libcfitsio-dev, libopencv-dev, libusb-1.0-0-dev, libudev-dev, libv4l-dev, libnova-dev, libcurl4-gnutls-dev, libindi-dev (>= 2.0), libeigen3-dev, libgtest-dev libopencv-dev
+Build-Depends: debhelper (>= 9), cmake, libwxgtk3.2-dev | libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev, libcfitsio-dev, libopencv-dev, libusb-1.0-0-dev, libudev-dev, libv4l-dev, libnova-dev, libcurl4-gnutls-dev, libindi-dev (>= 2.0), libeigen3-dev, libgtest-dev
 Standards-Version: 3.9.5
 Homepage: http://openphdguiding.org/
 

--- a/debian/rules
+++ b/debian/rules
@@ -28,5 +28,5 @@ include /usr/share/dpkg/default.mk
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
-	dh_auto_configure --  -DUSE_SYSTEM_LIBINDI=1 -DUSE_SYSTEM_GTEST=1 -DUSE_SYSTEM_LIBUSB=1
+	dh_auto_configure --  -DUSE_SYSTEM_LIBINDI=1 -DUSE_SYSTEM_GTEST=1 -DUSE_SYSTEM_LIBUSB=1 -DOPENSOURCE_ONLY=1
 

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -714,17 +714,19 @@ if(WIN32)
   )
 endif()
 
-include(FetchContent)
-FetchContent_Declare(
-  OGMAcamSDK
-  GIT_REPOSITORY https://github.com/OGMAvision/OGMAcamSDK.git
-  GIT_TAG be02a7317194e28e5b4f5f0d735eae729d096752
-)
-FetchContent_MakeAvailable(OGMAcamSDK)
-include_directories(${ogmacamsdk_SOURCE_DIR}/inc)
-if (WIN32)
-  list(APPEND PHD_LINK_EXTERNAL ${ogmacamsdk_SOURCE_DIR}/win/x86/ogmacam.lib)
-  list(APPEND PHD_COPY_EXTERNAL_ALL ${ogmacamsdk_SOURCE_DIR}/win/x86/ogmacam.dll)
+if (NOT OPENSOURCE_ONLY)
+  include(FetchContent)
+  FetchContent_Declare(
+    OGMAcamSDK
+    GIT_REPOSITORY https://github.com/OGMAvision/OGMAcamSDK.git
+    GIT_TAG be02a7317194e28e5b4f5f0d735eae729d096752
+  )
+  FetchContent_MakeAvailable(OGMAcamSDK)
+  include_directories(${ogmacamsdk_SOURCE_DIR}/inc)
+  if (WIN32)
+    list(APPEND PHD_LINK_EXTERNAL ${ogmacamsdk_SOURCE_DIR}/win/x86/ogmacam.lib)
+    list(APPEND PHD_COPY_EXTERNAL_ALL ${ogmacamsdk_SOURCE_DIR}/win/x86/ogmacam.dll)
+  endif()
 endif()
 
 # Various camera libraries


### PR DESCRIPTION
With the recent addition of OGMA camera it is no more possible to build the Ubuntu PPA package.

This is because it is not possible to reach Github from the Ubuntu build server to download the library.
Even with -DOPENSOURCE_ONLY=1 it still try to fetch the library, making the build to failed.

This change just prevent the fetch when OPENSOURCE_ONLY=1.


 
