### PR TITLE
code cleanup: use angle brackets for wxwidgets includes

### DIFF
--- a/calreview_dialog.h
+++ b/calreview_dialog.h
@@ -36,7 +36,7 @@
 #ifndef _CALREVIEW_DIALOG_H_
 #define _CALREVIEW_DIALOG_H_
 
-#include "wx/notebook.h"
+#include <wx/notebook.h>
 
 class CalReviewDialog: public wxDialog
 {

--- a/calstep_dialog.cpp
+++ b/calstep_dialog.cpp
@@ -35,7 +35,7 @@
 
 #include "phd.h"
 #include "calstep_dialog.h"
-#include "wx/valnum.h"
+#include <wx/valnum.h>
 #include <cmath>
 
 #define MIN_PIXELSIZE 0.1

--- a/cam_OSPL130.cpp
+++ b/cam_OSPL130.cpp
@@ -11,7 +11,7 @@
 #include "camera.h"
 #include "time.h"
 #include "image_math.h"
-#include "wx/stopwatch.h"
+#include <wx/stopwatch.h>
 
 #if defined (OS_PL130)
 #include "cam_OSPL130.h"

--- a/cam_ascom.cpp
+++ b/cam_ascom.cpp
@@ -41,7 +41,7 @@
 #include "comdispatch.h"
 #include "time.h"
 #include "image_math.h"
-#include "wx/stopwatch.h"
+#include <wx/stopwatch.h>
 #include <wx/wfstream.h>
 #include <wx/txtstrm.h>
 #include <wx/stdpaths.h>

--- a/camcal_import_dialog.cpp
+++ b/camcal_import_dialog.cpp
@@ -38,7 +38,7 @@
 
 #include "phd.h"
 #include "camcal_import_dialog.h"
-#include "wx/file.h"
+#include <wx/file.h>
 
 // Utility function to add the <label, input> pairs to a flexgrid
 static void AddTableEntryPair(wxWindow *parent, wxFlexGridSizer *pTable, const wxString& label, wxWindow *pControl)

--- a/cameras/vcap_v4l.h
+++ b/cameras/vcap_v4l.h
@@ -16,8 +16,8 @@
     #pragma interface "vcap_v4l.h"
 #endif
 
-#include "wx/defs.h"
-#include "wx/timer.h"
+#include <wx/defs.h>
+#include <wx/timer.h>
 
 class wxTimerEvent;
 class wxScrollWinEvent;

--- a/cameras/vcap_vfw.h
+++ b/cameras/vcap_vfw.h
@@ -18,7 +18,7 @@
 #include <windows.h>    // MSW headers
 #include <windowsx.h>   // for GlobalAllocPtr to set audio parameters
 #include <vfw.h>        // Video For Windows 1.1
-#include "wx/timer.h"
+#include <wx/timer.h>
 
 #if defined(__GNUG__) && !defined(NO_GCC_PRAGMA)
     #pragma interface "vcap_vfw.h"
@@ -483,6 +483,6 @@ private:
     DECLARE_DYNAMIC_CLASS(wxVideoCaptureWindowVFW)
 };
 
-#include "wx/msw/winundef.h"
+#include <wx/msw/winundef.h>
 
 #endif //__WX_VCAP_VFW_H__

--- a/cameras/vcapwin.h
+++ b/cameras/vcapwin.h
@@ -19,10 +19,10 @@
     #pragma interface "vcapwin.h"
 #endif
 
-#include "wx/defs.h"
-#include "wx/event.h"
-#include "wx/scrolwin.h"
-#include "wx/image.h"
+#include <wx/defs.h>
+#include <wx/event.h>
+#include <wx/scrolwin.h>
+#include <wx/image.h>
 
 // These are our DLL macros (see the contrib libs like wxPlot)
 #ifdef WXMAKINGDLL_VIDCAP

--- a/darks_dialog.cpp
+++ b/darks_dialog.cpp
@@ -35,7 +35,7 @@
 
 #include "phd.h"
 #include "darks_dialog.h"
-#include "wx/valnum.h"
+#include <wx/valnum.h>
 
 #include <algorithm>
 #include <sstream>

--- a/logger.cpp
+++ b/logger.cpp
@@ -35,8 +35,8 @@
 
 #include "phd.h"
 #include "logger.h"
-#include "wx/dir.h"
-#include "wx/filefn.h"
+#include <wx/dir.h>
+#include <wx/filefn.h>
 
 Logger::Logger()
 {

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -53,7 +53,7 @@
 #include <wx/dirdlg.h>
 #include <wx/dnd.h>
 #include <wx/textwrapper.h>
-#include "wx/valnum.h"
+#include <wx/valnum.h>
 
 static const int DefaultNoiseReductionMethod = 0;
 static const double DefaultDitherScaleFactor = 1.00;


### PR DESCRIPTION
code cleanup: use angle brackets for wxwidgets includes

Use `#include <wx/...` consistently, not `#include "wx/.."

