### PR TITLE
code cleanup: format wxWidgets event tables

### DIFF
--- a/Refine_DefMap.cpp
+++ b/Refine_DefMap.cpp
@@ -40,10 +40,12 @@ enum {
     ID_PREVIEW = 10001,
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(RefineDefMap, wxDialog)
     EVT_CHECKBOX(ID_PREVIEW, RefineDefMap::OnPreview)
     EVT_CLOSE(RefineDefMap::OnClose)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 static const double DefDMSigmaX = 75;
 

--- a/Refine_DefMap.h
+++ b/Refine_DefMap.h
@@ -111,7 +111,7 @@ private:
     void InitCameraMode();
     void RestoreCameraMode();
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // REFINEDEFMAP_H_INCLUDED

--- a/about_dialog.cpp
+++ b/about_dialog.cpp
@@ -37,9 +37,11 @@
 #include <wx/fs_mem.h>
 #include <wx/html/htmlwin.h>
 
-BEGIN_EVENT_TABLE(AboutDialog, wxDialog)
+// clang-format off
+wxBEGIN_EVENT_TABLE(AboutDialog, wxDialog)
     EVT_HTML_LINK_CLICKED(ABOUT_LINK,AboutDialog::OnLink)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 AboutDialog::AboutDialog()
     : wxDialog(pFrame, wxID_ANY, wxString::Format(_("About %s"), APPNAME),

--- a/about_dialog.h
+++ b/about_dialog.h
@@ -44,7 +44,7 @@ public:
 
 private:
     void OnLink(wxHtmlLinkEvent & event);
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // ABOUT_DIALOG_H_INCLUDED

--- a/aui_controls.cpp
+++ b/aui_controls.cpp
@@ -50,9 +50,11 @@
 #include "icons/sb_arrow_down_16.png.h"
 #endif
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(PHDStatusBar, wxStatusBar)
   EVT_SIZE(PHDStatusBar::OnSize)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 // Types of fields in the statusbar
 enum SBFieldTypes
@@ -105,12 +107,14 @@ public:
     wxDECLARE_EVENT_TABLE();
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(SBPanel, wxPanel)
   EVT_PAINT(SBPanel::OnPaint)
 #ifdef __APPLE__
   EVT_TIMER(wxID_ANY, SBPanel::OnTimer)
 #endif
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 // Classes for color-coded state indicators
 class SBStateIndicatorItem;

--- a/calreview_dialog.cpp
+++ b/calreview_dialog.cpp
@@ -38,11 +38,11 @@
 #include "scope.h"
 
 // Event handling for base class - derived classes handle their own bindings
-BEGIN_EVENT_TABLE( CalReviewDialog, wxDialog )
-
-EVT_CLOSE(CalReviewDialog::OnCloseWindow)
-
-END_EVENT_TABLE()
+// clang-format off
+wxBEGIN_EVENT_TABLE( CalReviewDialog, wxDialog )
+  EVT_CLOSE(CalReviewDialog::OnCloseWindow)
+wxEND_EVENT_TABLE();
+// clang-format on
 
 #define NA_STR _("N/A")
 #define CALREVIEW_BITMAP_SIZE 250

--- a/calreview_dialog.h
+++ b/calreview_dialog.h
@@ -40,7 +40,7 @@
 
 class CalReviewDialog: public wxDialog
 {
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 
 public:
     /// Constructors

--- a/cam_LESerialWebcam.cpp
+++ b/cam_LESerialWebcam.cpp
@@ -258,13 +258,15 @@ struct LEWebcamDialog : public wxDialog
     void OnDefaults(wxCommandEvent& evt);
     void OnVidCapClick(wxCommandEvent& evt);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
-BEGIN_EVENT_TABLE(LEWebcamDialog, wxDialog)
+// clang-format off
+wxBEGIN_EVENT_TABLE(LEWebcamDialog, wxDialog)
     EVT_BUTTON(wxID_DEFAULT, LEWebcamDialog::OnDefaults)
     EVT_BUTTON(wxID_CONVERT, LEWebcamDialog::OnVidCapClick)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 void LEWebcamDialog::OnDefaults(wxCommandEvent& evt)
 {

--- a/cameras/vcap_v4l.h
+++ b/cameras/vcap_v4l.h
@@ -226,7 +226,7 @@ protected:
     void print_video_mbuf();
 
 private:
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
     DECLARE_DYNAMIC_CLASS(wxVideoCaptureWindowV4L)
 };
 

--- a/cameras/vcap_vfw.h
+++ b/cameras/vcap_vfw.h
@@ -479,7 +479,7 @@ protected:
 
 private:
     void Init();
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
     DECLARE_DYNAMIC_CLASS(wxVideoCaptureWindowVFW)
 };
 

--- a/config_indi.cpp
+++ b/config_indi.cpp
@@ -236,6 +236,7 @@ void INDIConfig::UpdateControlStates()
 
 wxDEFINE_EVENT(THREAD_UPDATE_EVENT, wxThreadEvent);
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(INDIConfig, wxDialog)
     EVT_BUTTON(MCONNECT, INDIConfig::OnConnectButton)
     EVT_BUTTON(MINDIGUI, INDIConfig::OnIndiGui)
@@ -243,7 +244,8 @@ wxBEGIN_EVENT_TABLE(INDIConfig, wxDialog)
     EVT_CHECKBOX(VERBOSE, INDIConfig::OnVerboseChecked)
     EVT_CHECKBOX(FORCEVIDEO, INDIConfig::OnForceVideoChecked)
     EVT_THREAD(THREAD_UPDATE_EVENT, INDIConfig::OnUpdateFromThread)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 INDIConfig::~INDIConfig()
 {

--- a/drift_tool.cpp
+++ b/drift_tool.cpp
@@ -118,10 +118,11 @@ struct DriftToolWin : public wxFrame
 
     void SetStatusText(const wxString &text, int number = 0) override;
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
-BEGIN_EVENT_TABLE(DriftToolWin, wxFrame)
+// clang-format off
+wxBEGIN_EVENT_TABLE(DriftToolWin, wxFrame)
     EVT_BUTTON(ID_SLEW, DriftToolWin::OnSlew)
     EVT_BUTTON(ID_SAVE, DriftToolWin::OnSaveCoords)
     EVT_BUTTON(ID_DRIFT, DriftToolWin::OnDrift)
@@ -130,7 +131,8 @@ BEGIN_EVENT_TABLE(DriftToolWin, wxFrame)
     EVT_COMMAND(wxID_ANY, APPSTATE_NOTIFY_EVENT, DriftToolWin::OnAppStateNotify)
     EVT_CLOSE(DriftToolWin::OnClose)
     EVT_TIMER(ID_TIMER, DriftToolWin::OnTimer)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 DriftToolWin::DriftToolWin()
     : wxFrame(pFrame, wxID_ANY, _("Drift Align"), wxDefaultPosition, wxDefaultSize,

--- a/event_server.cpp
+++ b/event_server.cpp
@@ -41,10 +41,12 @@
 
 EventServer EvtServer;
 
-BEGIN_EVENT_TABLE(EventServer, wxEvtHandler)
+// clang-format off
+wxBEGIN_EVENT_TABLE(EventServer, wxEvtHandler)
     EVT_SOCKET(EVENT_SERVER_ID, EventServer::OnEventServerEvent)
     EVT_SOCKET(EVENT_SERVER_CLIENT_ID, EventServer::OnEventServerClientEvent)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 enum
 {

--- a/gear_dialog.cpp
+++ b/gear_dialog.cpp
@@ -38,7 +38,8 @@
 #include <wx/gbsizer.h>
 #include <functional>
 
-BEGIN_EVENT_TABLE(GearDialog, wxDialog)
+// clang-format off
+wxBEGIN_EVENT_TABLE(GearDialog, wxDialog)
     EVT_CHOICE(GEAR_PROFILES, GearDialog::OnProfileChoice)
     EVT_BUTTON(GEAR_PROFILE_MANAGE, GearDialog::OnButtonProfileManage)
     EVT_MENU(GEAR_PROFILE_NEW, GearDialog::OnProfileNew)
@@ -82,7 +83,8 @@ BEGIN_EVENT_TABLE(GearDialog, wxDialog)
     EVT_TOGGLEBUTTON(GEAR_BUTTON_DISCONNECT_ROTATOR, GearDialog::OnButtonDisconnectRotator)
 
     EVT_CHAR_HOOK(GearDialog::OnChar)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 /*
  * The Gear Dialog allows the user to select and connect to their hardware.

--- a/gear_dialog.h
+++ b/gear_dialog.h
@@ -172,7 +172,7 @@ private:
 
     void OnButtonWizard(wxCommandEvent& event);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 inline Scope *GearDialog::AuxScope() const

--- a/gear_simulator.cpp
+++ b/gear_simulator.cpp
@@ -1611,13 +1611,15 @@ struct SimCamDialog : public wxDialog
     void OnRbCustomPE(wxCommandEvent& evt);
     void OnOkClick(wxCommandEvent& evt);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
-BEGIN_EVENT_TABLE(SimCamDialog, wxDialog)
+// clang-format off
+wxBEGIN_EVENT_TABLE(SimCamDialog, wxDialog)
     EVT_BUTTON(wxID_RESET, SimCamDialog::OnReset)
     EVT_BUTTON(wxID_CONVERT, SimCamDialog::OnPierFlip)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 // Utility functions for adding controls with specified properties
 static wxSlider *NewSlider(wxWindow *parent, int val, int minval, int maxval, const wxString& tooltip)

--- a/graph-stepguider.cpp
+++ b/graph-stepguider.cpp
@@ -73,14 +73,16 @@ public:
     void SetLimits(unsigned int xMax, unsigned int yMax, unsigned int xBump, unsigned int yBump);
     void AppendData(const wxPoint& pos, const PHD_Point& avgPos);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
-BEGIN_EVENT_TABLE(GraphStepguiderWindow, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(GraphStepguiderWindow, wxWindow)
     EVT_BUTTON(BUTTON_GRAPH_LENGTH,GraphStepguiderWindow::OnButtonLength)
     EVT_MENU_RANGE(MENU_LENGTH_BEGIN, MENU_LENGTH_END, GraphStepguiderWindow::OnMenuLength)
     EVT_BUTTON(BUTTON_GRAPH_CLEAR,GraphStepguiderWindow::OnButtonClear)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 GraphStepguiderWindow::GraphStepguiderWindow(wxWindow *parent) :
     wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, _("AO Position"))
@@ -232,9 +234,11 @@ void GraphStepguiderWindow::ShowBump(const PHD_Point& curBump)
     }
 }
 
-BEGIN_EVENT_TABLE(GraphStepguiderClient, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(GraphStepguiderClient, wxWindow)
   EVT_PAINT(GraphStepguiderClient::OnPaint)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 GraphStepguiderClient::GraphStepguiderClient(wxWindow *parent) :
     wxWindow(parent, wxID_ANY, wxDefaultPosition, wxSize(201,201), wxFULL_REPAINT_ON_RESIZE)

--- a/graph-stepguider.h
+++ b/graph-stepguider.h
@@ -64,7 +64,7 @@ private:
 
     bool m_visible;
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // GRAPH_STEPGUIDER_H_INCLUDED

--- a/graph.cpp
+++ b/graph.cpp
@@ -42,6 +42,7 @@
 #include <wx/utils.h>
 #include <wx/colordlg.h>
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(GraphLogWindow, wxWindow)
     EVT_PAINT(GraphLogWindow::OnPaint)
     EVT_BUTTON(BUTTON_GRAPH_SETTINGS,GraphLogWindow::OnButtonSettings)
@@ -59,7 +60,8 @@ wxBEGIN_EVENT_TABLE(GraphLogWindow, wxWindow)
     EVT_BUTTON(BUTTON_GRAPH_CLEAR,GraphLogWindow::OnButtonClear)
     EVT_CHECKBOX(CHECKBOX_GRAPH_TRENDLINES,GraphLogWindow::OnCheckboxTrendlines)
     EVT_CHECKBOX(CHECKBOX_GRAPH_CORRECTIONS,GraphLogWindow::OnCheckboxCorrections)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 #ifdef __WXOSX__
 # define OSX_SMALL_FONT(lbl) do { (lbl)->SetFont(*wxSMALL_FONT); } while (0)
@@ -747,10 +749,12 @@ void GraphLogWindow::UpdateHeightButtonLabel()
     }
 }
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(GraphLogClientWindow, wxWindow)
     EVT_PAINT(GraphLogClientWindow::OnPaint)
     EVT_LEFT_DOWN(GraphLogClientWindow::OnLeftBtnDown)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 GraphLogClientWindow::GraphLogClientWindow(wxWindow *parent) :
     wxWindow(parent, wxID_ANY, wxDefaultPosition, wxSize(401,200), wxFULL_REPAINT_ON_RESIZE),

--- a/graph.h
+++ b/graph.h
@@ -175,7 +175,7 @@ private:
     void OnPaint(wxPaintEvent& evt);
     void OnLeftBtnDown(wxMouseEvent& evt);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 inline unsigned int GraphLogClientWindow::GetItemCount() const
@@ -263,7 +263,7 @@ public:
     const SummaryStats& Stats() const { return m_pClient->m_stats; }
     void ResetData();
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 class GraphControlPane : public wxWindow

--- a/guider.cpp
+++ b/guider.cpp
@@ -100,11 +100,13 @@ inline void DeflectionLogger::Log(const PHD_Point&) { }
 static const int DefaultOverlayMode  = OVERLAY_NONE;
 static const bool DefaultScaleImage  = true;
 
-BEGIN_EVENT_TABLE(Guider, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(Guider, wxWindow)
     EVT_PAINT(Guider::OnPaint)
     EVT_CLOSE(Guider::OnClose)
     EVT_ERASE_BACKGROUND(Guider::OnErase)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 static void SaveBookmarks(const std::vector<wxRealPoint>& vec)
 {

--- a/guider.h
+++ b/guider.h
@@ -323,7 +323,7 @@ public:
 
 private:
     void UpdateLockPosShiftCameraCoords();
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 inline bool Guider::IsPaused() const

--- a/guider_multistar.cpp
+++ b/guider_multistar.cpp
@@ -200,10 +200,12 @@ enum {
     MAX_LIST_SIZE = 12
 };
 
-BEGIN_EVENT_TABLE(GuiderMultiStar, Guider)
+// clang-format off
+wxBEGIN_EVENT_TABLE(GuiderMultiStar, Guider)
     EVT_PAINT(GuiderMultiStar::OnPaint)
     EVT_LEFT_DOWN(GuiderMultiStar::OnLClick)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 // Define a constructor for the guide canvas
 GuiderMultiStar::GuiderMultiStar(wxWindow *parent)

--- a/guider_multistar.h
+++ b/guider_multistar.h
@@ -152,7 +152,7 @@ private:
 
     void SaveStarFITS();
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 inline int

--- a/indi_gui.cpp
+++ b/indi_gui.cpp
@@ -123,6 +123,7 @@ wxDEFINE_EVENT(INDIGUI_THREAD_UPDATEPROPERTY_EVENT, wxThreadEvent);
 wxDEFINE_EVENT(INDIGUI_THREAD_NEWMESSAGE_EVENT, wxThreadEvent);
 wxDEFINE_EVENT(INDIGUI_THREAD_REMOVEPROPERTY_EVENT, wxThreadEvent);
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(IndiGui, wxDialog)
     EVT_CLOSE(IndiGui::OnQuit)
     EVT_THREAD(INDIGUI_THREAD_NEWDEVICE_EVENT, IndiGui::OnNewDeviceFromThread)
@@ -130,7 +131,8 @@ wxBEGIN_EVENT_TABLE(IndiGui, wxDialog)
     EVT_THREAD(INDIGUI_THREAD_UPDATEPROPERTY_EVENT, IndiGui::OnUpdatePropertyFromThread)
     EVT_THREAD(INDIGUI_THREAD_NEWMESSAGE_EVENT, IndiGui::OnNewMessageFromThread)
     EVT_THREAD(INDIGUI_THREAD_REMOVEPROPERTY_EVENT, IndiGui::OnRemovePropertyFromThread)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 //////////////////////////////////////////////////////////////////////
 // Functions running in the INDI client thread

--- a/indi_gui.h
+++ b/indi_gui.h
@@ -101,7 +101,7 @@ class IndiGui : public wxDialog, public INDI::BaseClient
         bool m_deleted;
         IndiGui **m_holder;
 
-        DECLARE_EVENT_TABLE()
+        wxDECLARE_EVENT_TABLE();
 
         IndiGui();
 

--- a/myframe.cpp
+++ b/myframe.cpp
@@ -77,6 +77,8 @@ wxDEFINE_EVENT(ALERT_FROM_THREAD_EVENT, wxThreadEvent);
 wxDEFINE_EVENT(RECONNECT_CAMERA_EVENT, wxThreadEvent);
 wxDEFINE_EVENT(UPDATER_EVENT, wxThreadEvent);
 
+// clang-format off
+// clang-format off
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU_HIGHLIGHT_ALL(MyFrame::OnMenuHighlight)
     EVT_MENU_CLOSE(MyFrame::OnAnyMenuClose)
@@ -172,7 +174,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_TIMER(STATUSBAR_TIMER_EVENT, MyFrame::OnStatusBarTimerEvent)
 
     EVT_AUI_PANE_CLOSE(MyFrame::OnPanelClose)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 struct FileDropTarget : public wxFileDropTarget
 {

--- a/myframe.h
+++ b/myframe.h
@@ -513,7 +513,7 @@ private:
     void DoTryReconnect();
 
     // and of course, an event table
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 extern MyFrame *pFrame;

--- a/nudge_lock.cpp
+++ b/nudge_lock.cpp
@@ -69,7 +69,7 @@ struct NudgeLockDialog : public wxDialog
     void UpdateSliderLabel();
     void UpdateLockPosCtrls();
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 enum
@@ -86,6 +86,7 @@ enum
     ID_RESTORE_LOCK_POS,
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(NudgeLockDialog, wxDialog)
     EVT_CHECKBOX(ID_STAY_ON_TOP, NudgeLockDialog::OnStayOnTopClicked)
     EVT_BUTTON(ID_UP_BTN, NudgeLockDialog::OnButton)
@@ -99,7 +100,8 @@ wxBEGIN_EVENT_TABLE(NudgeLockDialog, wxDialog)
     EVT_BUTTON(ID_RESTORE_LOCK_POS, NudgeLockDialog::OnRestoreLockPosClicked)
     EVT_COMMAND(wxID_ANY, APPSTATE_NOTIFY_EVENT, NudgeLockDialog::OnAppStateNotify)
     EVT_CLOSE(NudgeLockDialog::OnClose)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 static double NudgeIncrements[] = { 0.01, 0.03, 0.1, 0.3, 1, 3, 10, };
 

--- a/optionsbutton.cpp
+++ b/optionsbutton.cpp
@@ -38,13 +38,15 @@
 #include "icons/down_arrow.xpm"
 #include "icons/down_arrow_bold.xpm"
 
-BEGIN_EVENT_TABLE(OptionsButton, wxPanel)
+// clang-format off
+wxBEGIN_EVENT_TABLE(OptionsButton, wxPanel)
     EVT_ENTER_WINDOW(OptionsButton::OnMouseEnter)
     EVT_MOTION(OptionsButton::OnMouseMove)
     EVT_LEAVE_WINDOW(OptionsButton::OnMouseLeave)
     EVT_PAINT(OptionsButton::OnPaint)
     EVT_LEFT_UP(OptionsButton::OnClick)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 enum
 {

--- a/optionsbutton.h
+++ b/optionsbutton.h
@@ -61,7 +61,7 @@ private:
     void OnMouseLeave(wxMouseEvent& evt);
     void OnClick(wxMouseEvent& evt);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/polardrift_toolwin.cpp
+++ b/polardrift_toolwin.cpp
@@ -41,13 +41,15 @@
 #include <wx/textwrapper.h>
 
 //==================================
-BEGIN_EVENT_TABLE(PolarDriftToolWin, wxFrame)
-EVT_CHOICE(ID_HEMI, PolarDriftToolWin::OnHemi)
-EVT_CHECKBOX(ID_MIRROR, PolarDriftToolWin::OnMirror)
-EVT_BUTTON(ID_START, PolarDriftToolWin::OnStart)
-EVT_BUTTON(ID_CLOSE, PolarDriftToolWin::OnCloseBtn)
-EVT_CLOSE(PolarDriftToolWin::OnClose)
-END_EVENT_TABLE()
+// clang-format off
+wxBEGIN_EVENT_TABLE(PolarDriftToolWin, wxFrame)
+    EVT_CHOICE(ID_HEMI, PolarDriftToolWin::OnHemi)
+    EVT_CHECKBOX(ID_MIRROR, PolarDriftToolWin::OnMirror)
+    EVT_BUTTON(ID_START, PolarDriftToolWin::OnStart)
+    EVT_BUTTON(ID_CLOSE, PolarDriftToolWin::OnCloseBtn)
+    EVT_CLOSE(PolarDriftToolWin::OnClose)
+wxEND_EVENT_TABLE();
+// clang-format on
 
 wxWindow *PolarDriftTool::CreatePolarDriftToolWindow()
 {

--- a/polardrift_toolwin.h
+++ b/polardrift_toolwin.h
@@ -97,7 +97,7 @@ struct PolarDriftToolWin : public wxFrame
     bool WatchDrift();
     void PaintHelper(wxAutoBufferedPaintDCBase& dc, double scale);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/profile_wizard.cpp
+++ b/profile_wizard.cpp
@@ -145,17 +145,19 @@ public:
     wxDECLARE_EVENT_TABLE();
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(ProfileWizard, wxDialog)
-EVT_BUTTON(ID_NEXT, ProfileWizard::OnNext)
-EVT_BUTTON(ID_PREV, ProfileWizard::OnPrev)
-EVT_CHOICE(ID_COMBO, ProfileWizard::OnGearChoice)
-EVT_SPINCTRLDOUBLE(ID_PIXELSIZE, ProfileWizard::OnPixelSizeChange)
-EVT_SPINCTRLDOUBLE(ID_FOCALLENGTH, ProfileWizard::OnFocalLengthChange)
-EVT_TEXT(ID_FOCALLENGTH, ProfileWizard::OnFocalLengthText)
-EVT_CHOICE(ID_BINNING, ProfileWizard::OnBinningChange)
-EVT_SPINCTRLDOUBLE(ID_GUIDESPEED, ProfileWizard::OnGuideSpeedChange)
-EVT_BUTTON(ID_HELP, ProfileWizard::OnContextHelp)
-wxEND_EVENT_TABLE()
+    EVT_BUTTON(ID_NEXT, ProfileWizard::OnNext)
+    EVT_BUTTON(ID_PREV, ProfileWizard::OnPrev)
+    EVT_CHOICE(ID_COMBO, ProfileWizard::OnGearChoice)
+    EVT_SPINCTRLDOUBLE(ID_PIXELSIZE, ProfileWizard::OnPixelSizeChange)
+    EVT_SPINCTRLDOUBLE(ID_FOCALLENGTH, ProfileWizard::OnFocalLengthChange)
+    EVT_TEXT(ID_FOCALLENGTH, ProfileWizard::OnFocalLengthText)
+    EVT_CHOICE(ID_BINNING, ProfileWizard::OnBinningChange)
+    EVT_SPINCTRLDOUBLE(ID_GUIDESPEED, ProfileWizard::OnGuideSpeedChange)
+    EVT_BUTTON(ID_HELP, ProfileWizard::OnContextHelp)
+wxEND_EVENT_TABLE();
+// clang-format on
 
 static const int DialogWidth = 425;
 static const int TextWrapPoint = 400;

--- a/star_profile.cpp
+++ b/star_profile.cpp
@@ -35,10 +35,12 @@
 
 #include "phd.h"
 
-BEGIN_EVENT_TABLE(ProfileWindow, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(ProfileWindow, wxWindow)
     EVT_PAINT(ProfileWindow::OnPaint)
     EVT_LEFT_DOWN(ProfileWindow::OnLClick)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 enum
 {

--- a/star_profile.h
+++ b/star_profile.h
@@ -53,7 +53,7 @@ private:
     bool visible;
     unsigned short *data;
     int horiz_profile[21], vert_profile[21], midrow_profile[21];
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/starcross_test.cpp
+++ b/starcross_test.cpp
@@ -35,11 +35,11 @@
  #include "phd.h"
  #include "starcross_test.h"
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(StarCrossDialog, wxDialog)
-
-EVT_CLOSE(StarCrossDialog::OnCloseWindow)
-
-wxEND_EVENT_TABLE()
+    EVT_CLOSE(StarCrossDialog::OnCloseWindow)
+wxEND_EVENT_TABLE();
+// clang-format on
 
 #define SCT_DEFAULT_PULSE_SIZE 1000
 #define SCT_DEFAULT_PULSE_COUNT 25

--- a/starcross_test.h
+++ b/starcross_test.h
@@ -57,7 +57,7 @@ struct SCT_StepInfo
 
 class StarCrossDialog : public wxDialog
 {
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 
 public:
     StarCrossDialog(wxWindow *parent);

--- a/staticpa_toolwin.cpp
+++ b/staticpa_toolwin.cpp
@@ -41,27 +41,31 @@
 #include <wx/textwrapper.h>
 
 //==================================
-BEGIN_EVENT_TABLE(StaticPaToolWin, wxFrame)
-EVT_BUTTON(ID_INSTR, StaticPaToolWin::OnInstr)
-EVT_CHOICE(ID_HEMI, StaticPaToolWin::OnHemi)
-EVT_SPINCTRLDOUBLE(ID_HA, StaticPaToolWin::OnHa)
-EVT_CHECKBOX(ID_MANUAL, StaticPaToolWin::OnManual)
-EVT_CHECKBOX(ID_FLIP, StaticPaToolWin::OnFlip)
-EVT_CHECKBOX(ID_ORBIT, StaticPaToolWin::OnOrbit)
-EVT_CHOICE(ID_REFSTAR, StaticPaToolWin::OnRefStar)
-EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
-EVT_BUTTON(ID_STAR2, StaticPaToolWin::OnStar2)
-EVT_BUTTON(ID_STAR3, StaticPaToolWin::OnStar3)
-EVT_BUTTON(ID_GOTO, StaticPaToolWin::OnGoto)
-EVT_BUTTON(ID_CLEAR, StaticPaToolWin::OnClear)
-EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
-EVT_CLOSE(StaticPaToolWin::OnClose)
-END_EVENT_TABLE()
+// clang-format off
+wxBEGIN_EVENT_TABLE(StaticPaToolWin, wxFrame)
+    EVT_BUTTON(ID_INSTR, StaticPaToolWin::OnInstr)
+    EVT_CHOICE(ID_HEMI, StaticPaToolWin::OnHemi)
+    EVT_SPINCTRLDOUBLE(ID_HA, StaticPaToolWin::OnHa)
+    EVT_CHECKBOX(ID_MANUAL, StaticPaToolWin::OnManual)
+    EVT_CHECKBOX(ID_FLIP, StaticPaToolWin::OnFlip)
+    EVT_CHECKBOX(ID_ORBIT, StaticPaToolWin::OnOrbit)
+    EVT_CHOICE(ID_REFSTAR, StaticPaToolWin::OnRefStar)
+    EVT_BUTTON(ID_ROTATE, StaticPaToolWin::OnRotate)
+    EVT_BUTTON(ID_STAR2, StaticPaToolWin::OnStar2)
+    EVT_BUTTON(ID_STAR3, StaticPaToolWin::OnStar3)
+    EVT_BUTTON(ID_GOTO, StaticPaToolWin::OnGoto)
+    EVT_BUTTON(ID_CLEAR, StaticPaToolWin::OnClear)
+    EVT_BUTTON(ID_CLOSE, StaticPaToolWin::OnCloseBtn)
+    EVT_CLOSE(StaticPaToolWin::OnClose)
+wxEND_EVENT_TABLE();
+// clang-format on
 
-BEGIN_EVENT_TABLE(StaticPaToolWin::PolePanel, wxPanel)
-EVT_PAINT(StaticPaToolWin::PolePanel::OnPaint)
-EVT_LEFT_DCLICK(StaticPaToolWin::PolePanel::OnClick)
-END_EVENT_TABLE()
+// clang-format off
+wxBEGIN_EVENT_TABLE(StaticPaToolWin::PolePanel, wxPanel)
+    EVT_PAINT(StaticPaToolWin::PolePanel::OnPaint)
+    EVT_LEFT_DCLICK(StaticPaToolWin::PolePanel::OnClick)
+wxEND_EVENT_TABLE();
+// clang-format on
 
 StaticPaToolWin::PolePanel::PolePanel(StaticPaToolWin* parent):
     wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240), wxBU_AUTODRAW | wxBU_EXACTFIT),

--- a/staticpa_toolwin.h
+++ b/staticpa_toolwin.h
@@ -77,7 +77,7 @@ struct StaticPaToolWin : public wxFrame
         void OnClick(wxMouseEvent &evt);
         void OnPaint(wxPaintEvent &evt);
         void Paint();
-        DECLARE_EVENT_TABLE()
+        wxDECLARE_EVENT_TABLE();
     };
     PolePanel *m_polePanel; // Panel for drawing of pole stars
 
@@ -181,7 +181,7 @@ struct StaticPaToolWin : public wxFrame
     PHD_Point Radec2Px(const PHD_Point& radec);
     PHD_Point J2000Now(const PHD_Point& radec);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/statswindow.cpp
+++ b/statswindow.cpp
@@ -39,12 +39,14 @@ enum {
     TIMER_ID_COOLER = 101,
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(StatsWindow, wxWindow)
     EVT_BUTTON(BUTTON_GRAPH_LENGTH, StatsWindow::OnButtonLength)
     EVT_MENU_RANGE(MENU_LENGTH_BEGIN, MENU_LENGTH_END, StatsWindow::OnMenuLength)
     EVT_BUTTON(BUTTON_GRAPH_CLEAR, StatsWindow::OnButtonClear)
     EVT_TIMER(TIMER_ID_COOLER, StatsWindow::OnTimerCooler)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 StatsWindow::StatsWindow(wxWindow *parent)
     : wxWindow(parent, wxID_ANY),

--- a/statswindow.h
+++ b/statswindow.h
@@ -64,7 +64,7 @@ public:
     void ResetImageSize();
     void SetState(bool is_active);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/target.cpp
+++ b/target.cpp
@@ -37,7 +37,8 @@
 
 static double const MIN_ZOOM = 0.25;
 
-BEGIN_EVENT_TABLE(TargetWindow, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(TargetWindow, wxWindow)
     EVT_BUTTON(BUTTON_GRAPH_LENGTH,TargetWindow::OnButtonLength)
     EVT_MENU_RANGE(MENU_LENGTH_BEGIN, MENU_LENGTH_END, TargetWindow::OnMenuLength)
     EVT_BUTTON(BUTTON_GRAPH_CLEAR,TargetWindow::OnButtonClear)
@@ -45,7 +46,8 @@ BEGIN_EVENT_TABLE(TargetWindow, wxWindow)
     EVT_BUTTON(BUTTON_GRAPH_ZOOMOUT,TargetWindow::OnButtonZoomOut)
     EVT_CHECKBOX(TARGET_ENABLE_REF_CIRCLE, TargetWindow::OnCheckBoxRefCircle)
     EVT_SPINCTRLDOUBLE(TARGET_REF_CIRCLE_RADIUS, TargetWindow::OnRefCircleRadius)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 TargetWindow::TargetWindow(wxWindow *parent) :
     wxWindow(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize, 0,_("Target"))
@@ -225,9 +227,11 @@ void TargetWindow::OnRefCircleRadius(wxSpinDoubleEvent& event)
     }
 }
 
-BEGIN_EVENT_TABLE(TargetClient, wxWindow)
+// clang-format off
+wxBEGIN_EVENT_TABLE(TargetClient, wxWindow)
     EVT_PAINT(TargetClient::OnPaint)
-END_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 TargetClient::TargetClient(wxWindow *parent) :
     wxWindow(parent, wxID_ANY, wxDefaultPosition, wxSize(201,201), wxFULL_REPAINT_ON_RESIZE )

--- a/target.h
+++ b/target.h
@@ -65,7 +65,7 @@ class TargetClient : public wxWindow
 
     friend class TargetWindow;
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 class TargetWindow : public wxWindow
@@ -93,7 +93,7 @@ private:
     void OnCheckBoxRefCircle(wxCommandEvent& event);
     void OnRefCircleRadius(wxSpinDoubleEvent& event);
 
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // TARGET_H_INCLUDED

--- a/testguide.cpp
+++ b/testguide.cpp
@@ -53,7 +53,7 @@ public:
     void OnDither(wxCommandEvent& evt);
     void OnClose(wxCloseEvent& evt);
     void OnAppStateNotify(wxCommandEvent& evt);
-    DECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 
 enum
@@ -66,6 +66,7 @@ enum
     ID_DITHER,
 };
 
+// clang-format off
 wxBEGIN_EVENT_TABLE(TestGuideDialog, wxDialog)
     EVT_BUTTON(MGUIDE1_UP,TestGuideDialog::OnButton)
     EVT_BUTTON(MGUIDE1_DOWN,TestGuideDialog::OnButton)
@@ -81,7 +82,8 @@ wxBEGIN_EVENT_TABLE(TestGuideDialog, wxDialog)
     EVT_SPINCTRLDOUBLE(ID_DITHERSCALE, TestGuideDialog::OnDitherScaleChange)
     EVT_CHECKBOX(ID_RAONLY, TestGuideDialog::OnRAOnlyChecked)
     EVT_BUTTON(ID_DITHER, TestGuideDialog::OnDither)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
+// clang-format on
 
 wxSizer *TestGuideDialog::InitMountControls()
 {

--- a/wxled.cpp
+++ b/wxled.cpp
@@ -11,9 +11,11 @@
 
 #include <string.h>
 
-BEGIN_EVENT_TABLE (wxLed, wxWindow)
-    EVT_PAINT (wxLed::OnPaint)
-END_EVENT_TABLE ()
+// clang-format off
+wxBEGIN_EVENT_TABLE(wxLed, wxWindow)
+    EVT_PAINT(wxLed::OnPaint)
+wxEND_EVENT_TABLE();
+// clang-format on ()
 
 wxLed::wxLed (wxWindow * parent, wxWindowID id, const char * disabledColor, const wxPoint & pos, const wxSize & size)
 :

--- a/wxled.h
+++ b/wxled.h
@@ -38,7 +38,7 @@ class WXDLLEXPORT wxLed : public wxWindow
 
 	private :
 
-		DECLARE_EVENT_TABLE ()
+		wxDECLARE_EVENT_TABLE();
 } ;
 
 #endif // _WX_LED_H_


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1217

## Full chain of PRs as of 2024-07-04

* PR #1218:
  `andy/code-cleanup-event-tables` ➔ `andy/wx-includes`
* PR #1217:
  `andy/wx-includes` ➔ `master`

<!-- end git-machete generated -->

code cleanup: format wxWidgets event tables

 - use the macros with the wx prefix consistently: `DECLARE_EVENT_TABLE` => `wxDECLARE_EVENT_TABLE`
 - indent event definitions in the table
 - disable clang-format around event tables -- clang-format gets confused by the lack of trailing semi-colons

