### PR TITLE
Bugfix: prevent reusing a single JsonParser object among all PHD2 clients and across reentrant PHD2 calls.

### DIFF
--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2639,7 +2639,8 @@ void EventServer::OnEventServerClientEvent(wxSocketEvent& event)
     }
     else if (event.GetSocketEvent() == wxSOCKET_INPUT)
     {
-        handle_cli_input(cli, m_parser);
+        JsonParser parser;
+        handle_cli_input(cli, parser);
     }
     else
     {

--- a/src/event_server.h
+++ b/src/event_server.h
@@ -44,7 +44,6 @@ public:
     typedef std::set<wxSocketClient *> CliSockSet;
 
 private:
-    JsonParser m_parser;
     wxSocketServer *m_serverSocket;
     CliSockSet m_eventServerClients;
     wxTimer *m_configEventDebouncer;


### PR DESCRIPTION
This fix addresses issues arising from sharing a single JsonParser instance, ensuring each client and reentrant call operates independently to avoid conflicts and potential data corruption.