### PR TITLE
event server: fix possible problems when client sends multiple requests

### DIFF
--- a/src/event_server.h
+++ b/src/event_server.h
@@ -44,7 +44,6 @@ public:
     typedef std::set<wxSocketClient *> CliSockSet;
 
 private:
-    JsonParser m_parser;
     wxSocketServer *m_serverSocket;
     CliSockSet m_eventServerClients;
     wxTimer *m_configEventDebouncer;


### PR DESCRIPTION
event server: fix possible problems when client sends multiple requests

The `connect` command can cause the event loop to run and for the event server to process additional buffered client commands.  As the JSON parser instance is reused for all client commands, the parser's state will reflect the most recent client command and may lose the state of the unfinished connect command.

The fix is to not reuse the JsonParser instance -- instantiate a dedicated parser for each client command.

Testing:
 - manually exercised the event server by issuing commands with an event server client
 - checked the runtime overhead of instantiating the JsonParser instance per request (negligible, < 100 ns)

