### PR TITLE
run xgettext in the src directory

### DIFF
--- a/cmake_modules/PHD2BuildDoc.cmake
+++ b/cmake_modules/PHD2BuildDoc.cmake
@@ -318,8 +318,8 @@ function(generate_single_doc_targets)
       # the generation of the main messages.mo (default language) is dependant on all the source files
       # edit: this step is now manual
       #file(GLOB all_sources
-      #     "${PHD_PROJECT_ROOT_DIR}/*.cpp"
-      #     "${PHD_PROJECT_ROOT_DIR}/*.h")
+      #     "${PHD_PROJECT_ROOT_DIR}/src/*.cpp"
+      #     "${PHD_PROJECT_ROOT_DIR}/src/*.h")
 
       # extracts the messages from the sources and merges those messages with the locale/messages.pot
       # into the build folder. This is a manual step
@@ -353,7 +353,7 @@ function(generate_single_doc_targets)
               -E remove 
               "${current_translation_output_folder}/messages.po"
           WORKING_DIRECTORY 
-            "${PHD_PROJECT_ROOT_DIR}"
+            "${PHD_PROJECT_ROOT_DIR}/src"
       )
       list(APPEND translation_target_files
            "${current_translation_output_folder}/messages.pot")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1230

## Full chain of PRs as of 2024-07-30

* PR #1231:
  `andy/build-locales-src-directory` ➔ `andy/remove-unused-file`
* PR #1230:
  `andy/remove-unused-file` ➔ `master`

<!-- end git-machete generated -->

run xgettext in the src directory

update the xgettext command to find the source files since we moved them to src/

Fixes #1229