### PR TITLE
Add cooler control API method

### DIFF
--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2119,7 +2119,7 @@ static void set_cooler_state(JObj& response, const json_value *params)
     if (enable)
     {
         double setpt = pConfig->Profile.GetDouble("/camera/CoolerSetpt", 10.0);
-        if (pCamera->SetCoolerSetpoint(setpt));
+        if (pCamera->SetCoolerSetpoint(setpt))
         {
             response << jrpc_error(1, "failed to set cooler setpoint");
             return;

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2089,7 +2089,6 @@ static void get_calibration_data(JObj& response, const json_value *params)
 
 static void set_cooler_state(JObj& response, const json_value *params)
 {
-    bool ret;
     Params p("enabled", params);
     const json_value *val = p.param("enabled");
     bool enable;
@@ -2111,21 +2110,22 @@ static void set_cooler_state(JObj& response, const json_value *params)
         return;
     }
 
+    if (!pCamera->SetCoolerOn(enable))
+    {
+        response << jrpc_error(1, "failed to set cooler state");
+    }
+
     if (enable)
     {
         double setpt = pConfig->Profile.GetDouble("/camera/CoolerSetpt", 10.0);
-        ret = pCamera->SetCoolerSetpoint(setpt);
-        if (!ret)
+        if (!pCamera->SetCoolerSetpoint(setpt));
         {
             response << jrpc_error(1, "failed to set cooler setpoint");
             return;
         }
     }
 
-    if (pCamera->SetCoolerOn(enable))
-        response << jrpc_result(0);
-    else
-        response << jrpc_error(1, "failed to set cooler state");
+    response << jrpc_result(0);
 }
 
 static void get_cooler_status(JObj& response, const json_value *params)

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2113,6 +2113,7 @@ static void set_cooler_state(JObj& response, const json_value *params)
     if (pCamera->SetCoolerOn(enable))
     {
         response << jrpc_error(1, "failed to set cooler state");
+        return;
     }
 
     if (enable)

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2087,6 +2087,47 @@ static void get_calibration_data(JObj& response, const json_value *params)
     response << jrpc_result(rslt);
 }
 
+static void set_cooler_state(JObj& response, const json_value *params)
+{
+    bool ret;
+    Params p("enabled", params);
+    const json_value *val = p.param("enabled");
+    bool enable;
+    if (!val || !bool_param(val, &enable))
+    {
+        response << jrpc_error(JSONRPC_INVALID_PARAMS, "expected enabled boolean param");
+        return;
+    }
+
+    if (!pCamera || !pCamera->Connected)
+    {
+        response << jrpc_error(1, "camera not connected");
+        return;
+    }
+
+    if (!pCamera->HasCooler)
+    {
+        response << jrpc_error(1, "camera lacks a cooler");
+        return;
+    }
+
+    if (enable)
+    {
+        double setpt = pConfig->Profile.GetDouble("/camera/CoolerSetpt", 10.0);
+        ret = pCamera->SetCoolerSetpoint(setpt);
+        if (!ret)
+        {
+            response << jrpc_error(1, "failed to set cooler setpoint");
+            return;
+        }
+    }
+
+    if (pCamera->SetCoolerOn(enable))
+        response << jrpc_result(0);
+    else
+        response << jrpc_error(1, "failed to set cooler state");
+}
+
 static void get_cooler_status(JObj& response, const json_value *params)
 {
     if (!pCamera || !pCamera->Connected)
@@ -2402,6 +2443,10 @@ static bool handle_request(JRpcCall& call)
                     {
                         "get_cooler_status",
                         &get_cooler_status,
+                    },
+                    {
+                        "set_cooler_state",
+                        &set_cooler_state,
                     },
                     {
                         "get_ccd_temperature",

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2110,7 +2110,7 @@ static void set_cooler_state(JObj& response, const json_value *params)
         return;
     }
 
-    if (!pCamera->SetCoolerOn(enable))
+    if (pCamera->SetCoolerOn(enable))
     {
         response << jrpc_error(1, "failed to set cooler state");
     }
@@ -2118,7 +2118,7 @@ static void set_cooler_state(JObj& response, const json_value *params)
     if (enable)
     {
         double setpt = pConfig->Profile.GetDouble("/camera/CoolerSetpt", 10.0);
-        if (!pCamera->SetCoolerSetpoint(setpt));
+        if (pCamera->SetCoolerSetpoint(setpt));
         {
             response << jrpc_error(1, "failed to set cooler setpoint");
             return;


### PR DESCRIPTION
This adds a new JSON-RPC API method, `set_cooler_state`, which takes a single boolean argument to turn the cooler on or off if the connected camera is equipped with one.

Turning the cooler on:
```json
{"method":"set_cooler_state", "params": [ true ], "id":1}
```

Turning it off:
```json
{"method":"set_cooler_state", "params": [ false ], "id":1}
```

This will permit full automated setup of the camera from an API client. Currently, the cooler must be manually turned on via the Advanced Settings > Camera window. This complements the existing `get_cooler_status` method.