### PR TITLE
Multi star subframe

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1185,8 +1185,14 @@ void CameraConfigDialogCtrlSet::UnloadValues()
 
     if (m_pCamera->HasSubframes)
     {
-        m_pCamera->UseSubframes = m_pUseSubframes->GetValue();
-        pConfig->Profile.SetBoolean("/camera/UseSubframes", m_pCamera->UseSubframes);
+        bool oldVal = m_pCamera->UseSubframes;
+        bool newVal = m_pUseSubframes->GetValue();
+        m_pCamera->UseSubframes = newVal;
+        pConfig->Profile.SetBoolean("/camera/UseSubframes", newVal);
+        // MultiStar can't track secondary star locations during periods when subframes are used
+        if (oldVal && !newVal)
+            if (pFrame->pGuider->GetMultiStarMode())
+                pFrame->pGuider->SetMultiStarMode(true); // Will force a refresh of secondary stars
     }
 
     if (m_pCamera->HasGainControl)

--- a/src/guider_multistar.cpp
+++ b/src/guider_multistar.cpp
@@ -466,7 +466,8 @@ bool GuiderMultiStar::AutoSelect(const wxRect& roi)
             edgeAllowance = wxMax(edgeAllowance, pSecondaryMount->CalibrationTotDistance());
 
         GuideStar newStar;
-        if (!newStar.AutoFind(*image, edgeAllowance, m_searchRegion, roi, m_guideStars, MAX_LIST_SIZE))
+        if (!newStar.AutoFind(*image, edgeAllowance, m_searchRegion, roi, m_guideStars,
+                              (pCamera->UseSubframes || !m_multiStarMode) ? 1 : MAX_LIST_SIZE))
         {
             throw ERROR_INFO("Unable to AutoFind");
         }
@@ -1213,7 +1214,7 @@ void GuiderMultiStar::OnPaint(wxPaintEvent& event)
         }
 
         // show in-use secondary stars
-        if (m_multiStarMode && m_guideStars.size() > 1)
+        if (m_multiStarMode && m_guideStars.size() > 1 && !pCamera->UseSubframes)
         {
             if (m_primaryStar.WasFound())
                 dc.SetPen(wxPen(wxColour(0, 255, 0), 1, wxPENSTYLE_SOLID));

--- a/src/star.cpp
+++ b/src/star.cpp
@@ -1031,9 +1031,8 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
             // We're repeating the find, so we're vulnerable to hot pixels and creation of unwanted duplicates
             if (tmp.WasFound() && tmp.SNR >= minSNR)
             {
-                bool duplicate =
-                    std::find_if(foundStars.begin(), foundStars.end(),
-                                 [&tmp](const GuideStar& other) { return CloseToReference(tmp, other); }) != foundStars.end();
+                bool duplicate = std::find_if(foundStars.begin(), foundStars.end(), [&tmp](const GuideStar& other)
+                                              { return CloseToReference(tmp, other); }) != foundStars.end();
 
                 if (!duplicate)
                 {

--- a/src/star.cpp
+++ b/src/star.cpp
@@ -1021,22 +1021,26 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
     double minSNR = pFrame->pGuider->GetAFMinStarSNR();
     double maxHFD = pFrame->pGuider->GetMaxStarHFD();
     foundStars.clear();
-    for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
+    if (maxStars > 1)
     {
-        GuideStar tmp;
-        tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), maxHFD,
-                 pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
-        // We're repeating the find, so we're vulnerable to hot pixels and creation of unwanted duplicates
-        if (tmp.WasFound() && tmp.SNR >= minSNR)
+        for (std::set<Peak>::reverse_iterator it = stars.rbegin(); it != stars.rend(); ++it)
         {
-            bool duplicate = std::find_if(foundStars.begin(), foundStars.end(), [&tmp](const GuideStar& other)
-                                          { return CloseToReference(tmp, other); }) != foundStars.end();
-
-            if (!duplicate)
+            GuideStar tmp;
+            tmp.Find(&image, searchRegion, it->x, it->y, FIND_CENTROID, pFrame->pGuider->GetMinStarHFD(), maxHFD,
+                     pCamera->GetSaturationADU(), FIND_LOGGING_VERBOSE);
+            // We're repeating the find, so we're vulnerable to hot pixels and creation of unwanted duplicates
+            if (tmp.WasFound() && tmp.SNR >= minSNR)
             {
-                tmp.referencePoint.X = tmp.X;
-                tmp.referencePoint.Y = tmp.Y;
-                foundStars.push_back(tmp);
+                bool duplicate =
+                    std::find_if(foundStars.begin(), foundStars.end(),
+                                 [&tmp](const GuideStar& other) { return CloseToReference(tmp, other); }) != foundStars.end();
+
+                if (!duplicate)
+                {
+                    tmp.referencePoint.X = tmp.X;
+                    tmp.referencePoint.Y = tmp.Y;
+                    foundStars.push_back(tmp);
+                }
             }
         }
     }
@@ -1117,6 +1121,12 @@ bool GuideStar::AutoFind(const usImage& image, int extraEdgeAllowance, int searc
                         foundStars.push_back(tmp);
                         Debug.Write("MultiStar: primary star forcibly inserted in list\n");
                     }
+                }
+                else
+                {
+                    tmp.referencePoint.X = tmp.X;
+                    tmp.referencePoint.Y = tmp.Y;
+                    foundStars.push_back(tmp);
                 }
                 return true;
             }


### PR DESCRIPTION
A user was recently using subframes with multistar guiding enabled.  This created bogus exception messages in the debug log and a rather misleading display.  This commit should resolve those problems.  I didn't want to take the simplest route of just disabling multistar guiding when subframes were enabled because that would probably confuse users.  With this commit, users can enable/disable sub-frames while guiding is active and the behavior should be what is expected.