### PR TITLE
Image scale change improvements

### DIFF
--- a/src/advanced_dialog.cpp
+++ b/src/advanced_dialog.cpp
@@ -592,6 +592,21 @@ double AdvancedDialog::DetermineGuideSpeed()
     }
     return sidRate;
 }
+
+// Floating point equality comparisons can be a problem due to rounding and trivial inequalities.
+// PercentChange can be used to see if a change is worth reacting to
+double AdvancedDialog::PercentChange(double oldVal, double newVal)
+{
+    double chg;
+    if (oldVal > 0)
+    {
+        chg = fabs(1.0 - newVal / oldVal);
+    }
+    else
+        chg = fabs(newVal);
+    return 100.0 * chg;
+}
+
 // Reacts to param changes in the AD that change the image scale.  Calibration step-size is recalculated, calibration is
 // cleared, MinMoves are set to defaults based on new image scale
 void AdvancedDialog::MakeImageScaleAdjustments()

--- a/src/advanced_dialog.h
+++ b/src/advanced_dialog.h
@@ -103,6 +103,7 @@ public:
 
     bool Validate() override;
     void ShowInvalid(wxWindow *ctrl, const wxString& message);
+    double PercentChange(double oldVal, double newVal);
     void FlagImageScaleChange()
     {
         m_imageScaleChanged = true;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1247,7 +1247,10 @@ void CameraConfigDialogCtrlSet::UnloadValues()
 
     double oldPxSz = m_pCamera->GetCameraPixelSize();
     double newPxSz = m_pPixelSize->GetValue();
-    if (oldPxSz != newPxSz)
+    if (oldPxSz != newPxSz &&
+        pFrame->pAdvancedDialog->PercentChange(oldPxSz, newPxSz) >
+            5.0) // Avoid rounding problems with floating point equality test; don't clear
+                 // calibration for inconsequential changes
         pFrame->pAdvancedDialog->FlagImageScaleChange();
     m_pCamera->SetCameraPixelSize(m_pPixelSize->GetValue());
 

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -3327,8 +3327,9 @@ void MyFrameConfigDialogCtrlSet::UnloadValues()
                                        m_varExpDelayLong->GetValue() * 1000);
         int oldFL = m_pFrame->GetFocalLength();
         int newFL = GetFocalLength(); // From UI control
-        if (oldFL != newFL) // Validator insures fl is generally reasonable and non-zero
-            m_pFrame->pAdvancedDialog->FlagImageScaleChange();
+        if (oldFL != newFL) // Validator insures fl is generally reasonable and non-zero; don't react to trivial changes
+            if (m_pFrame->pAdvancedDialog->PercentChange(oldFL, newFL) > 5.0)
+                m_pFrame->pAdvancedDialog->FlagImageScaleChange();
         m_pFrame->SetFocalLength(GetFocalLength());
 
         int idx = m_pLanguage->GetSelection();


### PR DESCRIPTION
Changes to pixel size, focal length, or binning currently trigger clearing of calibration.  This is unnecessary for minor changes in focal length or pixel size.  Also, the current floating point equality check always fails for reported pixel sizes on SX cameras because of approximation.