### PR TITLE
Workaround for GPDebug::Log not working with format %s

### DIFF
--- a/contributions/MPI_IS_gaussian_process/src/gaussian_process_guider.cpp
+++ b/contributions/MPI_IS_gaussian_process/src/gaussian_process_guider.cpp
@@ -824,6 +824,7 @@ void GaussianProcessGuider::SetLearningRate(double learning_rate)
 class NullDebugLog : public GPDebug
 {
     void Log(const char *fmt, ...) { }
+    void Write(const char *what) { }
 };
 
 class GPDebug *GPDebug = new NullDebugLog();

--- a/contributions/MPI_IS_gaussian_process/src/gaussian_process_guider.h
+++ b/contributions/MPI_IS_gaussian_process/src/gaussian_process_guider.h
@@ -333,6 +333,7 @@ public:
     static void SetGPDebug(GPDebug *logger);
     virtual ~GPDebug();
     virtual void Log(const char *format, ...) = 0;
+    virtual void Write(const char *what) = 0;
 };
 
 extern class GPDebug *GPDebug;

--- a/src/mount.cpp
+++ b/src/mount.cpp
@@ -699,6 +699,7 @@ static GuideAlgorithm *MakeGaussianProcessGuideAlgo(Mount *mount, GuideAxis axis
                 Debug.Write(wxString::FormatV(format + wxString("\n"), ap));
                 va_end(ap);
             }
+            void Write(const char *what) { Debug.Write(wxString(what) + _T("\n")); }
         };
         GPDebug::SetGPDebug(new PHD2DebugLogger());
         s_gp_debug_inited = true;


### PR DESCRIPTION
Add a Write method to GPDebug::Log for logging an already formatted C-style string. This is a workaround for GPDebug::Log not being able to handle a format string with %s.