### PR TITLE
build system tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ if(APPLE)
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 endif()
 
+if(WINDOWS)
+ set(CMAKE_GENERATOR "Visual Studio 17" CACHE STRING INTERNAL "" FORCE)
+endif()
+
 enable_language(C CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -56,7 +60,6 @@ endif()
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
-
 
 # root directory of the project
 set(PHD_PROJECT_ROOT_DIR ${CMAKE_SOURCE_DIR})

--- a/build/build-win
+++ b/build/build-win
@@ -86,7 +86,7 @@ mkdir -p tmp
 cd tmp
 
 cat >run_cmake.bat <<EOF
-"$CMAKE_W" -Wno-dev -G "Visual Studio 17" -A Win32 ${vcpkg_args[@]} "-DwxWidgets_PREFIX_DIRECTORY=%WXWIN%" ..
+"$CMAKE_W" -Wno-dev -A Win32 "${vcpkg_args[@]}" ..
 EOF
 "$CMD" /c run_cmake.bat
 

--- a/run_cmake-osx
+++ b/run_cmake-osx
@@ -35,7 +35,6 @@ mkdir -p "$tmp"
 cd "$tmp"
 
 cmake -G "Unix Makefiles" \
-    -DwxWidgets_PREFIX_DIRECTORY="$WXWIN" \
     -DCMAKE_OSX_ARCHITECTURES="$APPLE_ARCH" \
     -DCMAKE_BUILD_TYPE="$buildtype" \
     "${cmake_extra_args[@]}" \

--- a/run_cmake.bat
+++ b/run_cmake.bat
@@ -1,4 +1,4 @@
 @mkdir tmp
 @cd tmp
-cmake -Wno-dev -G "Visual Studio 17" -A Win32 "-DwxWidgets_PREFIX_DIRECTORY=%WXWIN%" ..
+cmake -Wno-dev -A Win32 ..
 @cd ..

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -528,6 +528,8 @@ endif()
 #  version >= 3.0, a version of cmake >= 3.0 should be used on Windows
 #  on Linux/OSX it works properly this way).
 
+set(wxWidgets_PREFIX_DIRECTORY $ENV{WXWIN} CACHE PATH "wxWidgets directory")
+
 if(WIN32)
   # wxWidgets
   set(wxWidgets_CONFIGURATION msw CACHE STRING "Set wxWidgets configuration")
@@ -644,7 +646,10 @@ else()
     ## Define LIBNOVA when building Indi from source.
     add_definitions("-DLIBNOVA")
   endif()
-  list(APPEND PHD_EXTERNAL_PROJECT_DEPENDENCIES indi)
+  # adding indi as a dependency allows a developer to build phd2 in
+  # the IDE without explicitly building anything else first, but this
+  # slows down incremental development
+  # list(APPEND PHD_EXTERNAL_PROJECT_DEPENDENCIES indi)
 endif()
 
 


### PR DESCRIPTION
 - use WXWIN environment variable directly so callers do not need to set wxWdgets_PREFIX_DIRECTORY when invoking cmake
 - Windows: use the Visual Studio 17 generator by default (so callers do not need to specify it)
 - Remove INDI as an explicit dependency of the phd2 executable CMake target. This will speed up the incremental edit-compile-test cycle a little bit, but developers will have to build INDI once before building the phd2 target specifically. In Visual Studio this means building the whole solution once before building the phd2 project.