### PR TITLE
Linux: update phd2.sh to use CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmake_modules/PHD2Packaging.cmake
+++ b/cmake_modules/PHD2Packaging.cmake
@@ -68,7 +68,8 @@ endif()
 if(UNIX AND NOT APPLE)
   install(TARGETS phd2
           RUNTIME DESTINATION bin)
-  install(PROGRAMS phd2.sh
+  configure_file(phd2.sh.in phd2.sh @ONLY)
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/phd2.sh
           DESTINATION bin
           RENAME phd2)
   install(FILES ${PHD_INSTALL_LIBS}

--- a/phd2.sh
+++ b/phd2.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-export LD_LIBRARY_PATH="/usr/lib/phd2${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-exec "$0.bin" "$@"

--- a/phd2.sh.in
+++ b/phd2.sh.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+export LD_LIBRARY_PATH="@CMAKE_INSTALL_PREFIX@/lib/phd2${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$0.bin" "$@"


### PR DESCRIPTION
Allows `make install` run with a CMAKE_INSTALL_PREFIX other than the default (`/usr`) to generate a phd2.sh with the matching install prefix.