### PR TITLE
Code cleanup - dead code removal (ClearGuidePort)

### DIFF
--- a/src/cam_altair.cpp
+++ b/src/cam_altair.cpp
@@ -155,7 +155,6 @@ struct AltairCamera : public GuideCamera
     bool Disconnect() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
 
     void ShowPropertyDialog() override;
 
@@ -667,11 +666,6 @@ bool AltairCamera::ST4PulseGuideScope(int direction, int duration)
     m_sdk.ST4PlusGuide(m_handle, d, duration);
 
     return false;
-}
-
-void AltairCamera::ClearGuidePort()
-{
-    m_sdk.ST4PlusGuide(m_handle, 0, 0);
 }
 
 GuideCamera *AltairCameraFactory::MakeAltairCamera(AltairCamType type)

--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -62,7 +62,6 @@ public:
     bool Disconnect() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
     wxByte BitsPerPixel() override;
 
     bool Color;
@@ -266,11 +265,6 @@ bool CameraAtik16::ST4PulseGuideScope(int direction, int duration)
     // if (duration > 50) wxMilliSleep(duration - 50);  // wait until it's mostly done
     // wxMilliSleep(duration + 10);
     return false;
-}
-
-void CameraAtik16::ClearGuidePort()
-{
-    ArtemisStopGuiding(Cam_Handle);
 }
 
 bool CameraAtik16::Disconnect()

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -83,7 +83,6 @@ public:
     bool Disconnect() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
 
     void ShowPropertyDialog() override;
     bool HasNonGuiCapture() override { return true; }
@@ -987,14 +986,6 @@ bool POACamera::ST4PulseGuideScope(int direction, int duration)
     SetConfig(m_cameraId, d, POA_FALSE);
 
     return false;
-}
-
-void POACamera::ClearGuidePort()
-{
-    SetConfig(m_cameraId, POA_GUIDE_NORTH, POA_FALSE);
-    SetConfig(m_cameraId, POA_GUIDE_SOUTH, POA_FALSE);
-    SetConfig(m_cameraId, POA_GUIDE_EAST, POA_FALSE);
-    SetConfig(m_cameraId, POA_GUIDE_WEST, POA_FALSE);
 }
 
 // Functions from Player One ConvFuncs.h

--- a/src/cam_qguide.cpp
+++ b/src/cam_qguide.cpp
@@ -75,17 +75,13 @@ wxByte CameraQGuider::BitsPerPixel()
 bool CameraQGuider::Connect(const wxString& camId)
 {
     // returns true on error
-    //  CameraReset();
+
     if (!openUSB(0))
         return CamConnectFailed(_("No camera"));
 
-    //  ClearGuidePort();
-    //  GuideCommand(0x0F,10);
-    //  buffer = new unsigned char[1311744];
     SETBUFFERMODE(0);
     Connected = true;
-    //  qglogfile = new wxTextFile(Debug.GetLogDir() + PATHSEPSTR + _T("PHD_QGuide_log.txt"));
-    // qglogfile->AddLine(wxNow() + ": QGuide connected"); //qglogfile->Write();
+
     return false;
 }
 
@@ -120,11 +116,6 @@ bool CameraQGuider::ST4PulseGuideScope(int direction, int duration)
     WorkerThread::MilliSleep(duration + 10);
     // qglogfile->AddLine("Done"); //qglogfile->Write();
     return false;
-}
-
-void CameraQGuider::ClearGuidePort()
-{
-    //  SendGuideCommand(DevName,0,0);
 }
 
 void CameraQGuider::InitCapture()

--- a/src/cam_qguide.h
+++ b/src/cam_qguide.h
@@ -49,7 +49,6 @@ public:
     void InitCapture() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
     bool HasNonGuiCapture() override { return true; }
     bool ST4HasNonGuiMove() override { return true; }
     wxByte BitsPerPixel() override;

--- a/src/cam_qhy5.cpp
+++ b/src/cam_qhy5.cpp
@@ -173,12 +173,6 @@ bool CameraQHY5::ST4PulseGuideScope(int direction, int duration)
     return result < 0 ? true : false;
 }
 
-void CameraQHY5::ClearGuidePort()
-{
-    int16_t res = 0;
-    libusb_control_transfer(m_handle, 0xc2, 0x18, 0, 0, (unsigned char *) &res, sizeof(res), 5000);
-}
-
 void CameraQHY5::InitCapture() { }
 
 bool CameraQHY5::Disconnect()

--- a/src/cam_qhy5.h
+++ b/src/cam_qhy5.h
@@ -51,7 +51,6 @@ public:
     bool ST4PulseGuideScope(int direction, int duration) override;
     bool ST4HasNonGuiMove() override { return true; }
     bool HasNonGuiCapture() override { return true; }
-    void ClearGuidePort();
     wxByte BitsPerPixel() override;
 };
 

--- a/src/cam_sspiag.cpp
+++ b/src/cam_sspiag.cpp
@@ -333,11 +333,6 @@ bool CameraSSPIAG::ST4PulseGuideScope(int direction, int duration)
     return false;
 }
 
-void CameraSSPIAG::ClearGuidePort()
-{
-    Q5V_SendGuideCommand("QHY5V-0", 0, 0);
-}
-
 void CameraSSPIAG::InitCapture()
 {
     // Q5V_SetQHY5VGlobalGain(GuideCameraGain * 63 / 100);

--- a/src/cam_sspiag.h
+++ b/src/cam_sspiag.h
@@ -48,7 +48,6 @@ public:
     void InitCapture() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
 
     bool HasNonGuiCapture() override { return true; }
     bool ST4HasNonGuiMove() override { return true; }

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -84,7 +84,6 @@ public:
     bool Disconnect() override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
-    void ClearGuidePort();
 
     void ShowPropertyDialog() override;
     bool HasNonGuiCapture() override { return true; }
@@ -987,14 +986,6 @@ bool Camera_ZWO::ST4PulseGuideScope(int direction, int duration)
     ASIPulseGuideOff(m_cameraId, d);
 
     return false;
-}
-
-void Camera_ZWO::ClearGuidePort()
-{
-    ASIPulseGuideOff(m_cameraId, ASI_GUIDE_NORTH);
-    ASIPulseGuideOff(m_cameraId, ASI_GUIDE_SOUTH);
-    ASIPulseGuideOff(m_cameraId, ASI_GUIDE_EAST);
-    ASIPulseGuideOff(m_cameraId, ASI_GUIDE_WEST);
 }
 
 GuideCamera *ZWOCameraFactory::MakeZWOCamera()


### PR DESCRIPTION
A bunch of the cameras implement ClearGuidePort which is not needed and has no callers, but it keeps getting propagated when new cameras a copy-pasted from older ones.