### PR TITLE
New class for camera selector button & use in Profile Wizard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,8 @@ set(phd2_SRC
   ${phd_src_dir}/calstep_dialog.h
   ${phd_src_dir}/camcal_import_dialog.cpp
   ${phd_src_dir}/camcal_import_dialog.h
+  ${phd_src_dir}/camera_selector_button.cpp
+  ${phd_src_dir}/camera_selector_button.h
   ${phd_src_dir}/circbuf.h
 
   ${phd_src_dir}/comet_tool.cpp

--- a/src/camera_selector_button.cpp
+++ b/src/camera_selector_button.cpp
@@ -40,7 +40,7 @@ wxDEFINE_EVENT(SELECT_CAMERA_EVENT, wxCommandEvent);
 wxBEGIN_EVENT_TABLE(CameraSelectorButton, wxBitmapButton)
 	EVT_BUTTON(GEAR_BUTTON_SELECT_CAMERA, CameraSelectorButton::OnButtonSelectCamera)
     EVT_MENU_RANGE(MENU_SELECT_CAMERA_BEGIN, MENU_SELECT_CAMERA_END, CameraSelectorButton::OnMenuSelectCamera)
-wxEND_EVENT_TABLE()
+wxEND_EVENT_TABLE();
 // clang-format on
 
 CameraSelectorButton::CameraSelectorButton(wxWindow *pParent, wxWindowID id)

--- a/src/camera_selector_button.cpp
+++ b/src/camera_selector_button.cpp
@@ -1,0 +1,140 @@
+/*
+ *  camera_selector_button.cpp
+ *  PHD Guiding
+ *
+ *  Copyright (c) 2025 PHD2 Developers
+ *  All rights reserved.
+ *
+ *  This source code is distributed under the following "BSD" license
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *    Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *    Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *    Neither the name of Bret McKee, Dad Dog Development, Ltd. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "camera_selector_button.h"
+#include "icons/select.png.h"
+
+wxDEFINE_EVENT(SELECT_CAMERA_EVENT, wxCommandEvent);
+
+// clang-format off
+wxBEGIN_EVENT_TABLE(CameraSelectorButton, wxBitmapButton)
+	EVT_BUTTON(GEAR_BUTTON_SELECT_CAMERA, CameraSelectorButton::OnButtonSelectCamera)
+    EVT_MENU_RANGE(MENU_SELECT_CAMERA_BEGIN, MENU_SELECT_CAMERA_END, CameraSelectorButton::OnMenuSelectCamera)
+wxEND_EVENT_TABLE()
+// clang-format on
+
+CameraSelectorButton::CameraSelectorButton(wxWindow *pParent, wxWindowID id)
+    : wxBitmapButton(pParent, id, wxBitmap(wxBITMAP_PNG_FROM_DATA(select)))
+{
+    SetToolTip(_("Select which camera to connect to when there are multiple cameras of the same type."));
+
+    m_pCamera = nullptr;
+}
+
+CameraSelectorButton::~CameraSelectorButton()
+{
+    delete m_pCamera;
+    m_pCamera = nullptr;
+}
+
+void CameraSelectorButton::SetCamera(wxString cam)
+{
+    delete m_pCamera;
+    m_pCamera = nullptr;
+
+    m_pCamera = GuideCamera::Factory(cam);
+    m_lastCamera = cam;
+}
+
+void CameraSelectorButton::OnButtonSelectCamera(wxCommandEvent& event)
+{
+    if (!m_pCamera || !m_pCamera->CanSelectCamera())
+        return;
+
+    if (m_pCamera->HandleSelectCameraButtonClick(event))
+        return;
+
+    wxArrayString names;
+    m_cameraIds.clear(); // otherwise camera selection only works randomly as EnumCameras tends to append to the camera Ids
+    bool error = m_pCamera->EnumCameras(names, m_cameraIds);
+    if (error || names.size() == 0)
+    {
+        names.clear();
+        names.Add(_("No cameras found"));
+        m_cameraIds.clear();
+    }
+
+    wxString selectedId = SelectedCameraId(m_lastCamera);
+
+    wxMenu *menu = new wxMenu();
+    int id = MENU_SELECT_CAMERA_BEGIN;
+    for (unsigned int idx = 0; idx < names.size(); idx++)
+    {
+        wxMenuItem *item = menu->AppendRadioItem(id, names.Item(idx));
+        if (idx < m_cameraIds.size())
+        {
+            const wxString& camId = m_cameraIds[idx];
+            if (camId == selectedId || (idx == 0 && selectedId == GuideCamera::DEFAULT_CAMERA_ID))
+                item->Check(true);
+        }
+        if (++id > MENU_SELECT_CAMERA_END)
+        {
+            Debug.AddLine("Truncating camera list!");
+            break;
+        }
+    }
+
+    PopupMenu(menu, 0, this->GetSize().GetHeight());
+
+    delete menu;
+}
+
+void CameraSelectorButton::OnMenuSelectCamera(wxCommandEvent& event)
+{
+    unsigned int idx = event.GetId() - MENU_SELECT_CAMERA_BEGIN;
+    if (idx < m_cameraIds.size())
+    {
+        wxString key = CameraSelectionKey(m_lastCamera);
+        const wxString& id = m_cameraIds[idx];
+        if (pConfig->Profile.GetString(key, wxEmptyString) != id)
+        {
+            pConfig->Profile.SetString(key, id);
+
+            wxCommandEvent event(SELECT_CAMERA_EVENT, idx + MENU_SELECT_CAMERA_BEGIN);
+            wxPostEvent(GetParent(), event);
+        }
+    }
+}
+
+wxString CameraSelectorButton::CameraSelectionKey(const wxString& camName)
+{
+    std::hash<std::string> hash_fn;
+    std::string name(camName.c_str());
+    return wxString::Format("/cam_hash/%lx/whichCamera", (unsigned long) hash_fn(name));
+}
+
+wxString CameraSelectorButton::SelectedCameraId(const wxString& camName)
+{
+    wxString key = CameraSelectionKey(camName);
+    return pConfig->Profile.GetString(key, GuideCamera::DEFAULT_CAMERA_ID);
+}

--- a/src/camera_selector_button.h
+++ b/src/camera_selector_button.h
@@ -1,0 +1,60 @@
+/*
+ *  camera_selector_button.h
+ *  PHD Guiding
+ *
+ *  Copyright (c) 2025 PHD2 Developers
+ *  All rights reserved.
+ *
+ *  This source code is distributed under the following "BSD" license
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *    Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *    Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *    Neither the name of Bret McKee, Dad Dog Development, Ltd. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef CAMERA_SELECTOR_BUTTON_H_INCLUDED
+#define CAMERA_SELECTOR_BUTTON_H_INCLUDED
+
+#include "phd.h"
+
+wxDECLARE_EVENT(SELECT_CAMERA_EVENT, wxCommandEvent);
+
+class CameraSelectorButton : public wxBitmapButton
+{
+public:
+    CameraSelectorButton(wxWindow *pParent, wxWindowID id);
+    ~CameraSelectorButton();
+    void SetCamera(wxString cam);
+
+    static wxString CameraSelectionKey(const wxString& camName);
+    static wxString SelectedCameraId(const wxString& camName);
+
+private:
+    GuideCamera *m_pCamera;
+    wxString m_lastCamera;
+    wxArrayString m_cameraIds;
+    void OnButtonSelectCamera(wxCommandEvent& event);
+    void OnMenuSelectCamera(wxCommandEvent& event);
+    wxDECLARE_EVENT_TABLE();
+};
+
+#endif // CAMERA_SELECTOR_BUTTON_H_INCLUDED

--- a/src/gear_dialog.h
+++ b/src/gear_dialog.h
@@ -35,6 +35,8 @@
 #ifndef GEAR_DIALOG_H_INCLUDED
 #define GEAR_DIALOG_H_INCLUDED
 
+#include "camera_selector_button.h"
+
 class wxGridBagSizer;
 
 class GearDialog : public wxDialog
@@ -64,7 +66,7 @@ class GearDialog : public wxDialog
     wxMenu *m_menuProfileManage;
 
     wxChoice *m_pCameras;
-    wxButton *m_selectCameraButton;
+    CameraSelectorButton *m_selectCameraButton;
     wxButton *m_pSetupCameraButton;
     wxToggleButton *m_pConnectCameraButton;
 
@@ -139,8 +141,7 @@ private:
     void OnChar(wxKeyEvent& event);
 
     void OnChoiceCamera(wxCommandEvent& event);
-    void OnButtonSelectCamera(wxCommandEvent& event);
-    void OnMenuSelectCamera(wxCommandEvent& evt);
+    void OnCommandSelectCamera(wxCommandEvent& event);
 
     void OnButtonSetupCamera(wxCommandEvent& event);
     bool DoConnectCamera(bool autoReconnecting);

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -1182,7 +1182,7 @@ void ProfileWizard::InitCameraProps(bool tryConnect)
 
         m_pSelectCameraButton->SetCamera(m_SelectedCamera);
         if (cam)
-            m_pSelectCameraButton->Enable(cam->CanSelectCamera()); 
+            m_pSelectCameraButton->Enable(cam->CanSelectCamera());
     }
     else
     {


### PR DESCRIPTION
Moves much of the code for the camera selector button out of the gear dialog into a new class. Does not change anything from the user's perspective, but would like to use this new class to add the button to Profile Wizard so we no longer have to hope the right camera is selected if multiple using the same driver are attached to the PC. Most of the work is done there too, but I plan to finish and submit after this pull request is finalized and merged.

Tested on Windows 11 with one ZWO and two Player One cameras.