### PR TITLE
Fix build with Ubuntu 24.10

### DIFF
--- a/contributions/MPI_IS_gaussian_process/tests/gaussian_process/gp_guider_test.cpp
+++ b/contributions/MPI_IS_gaussian_process/tests/gaussian_process/gp_guider_test.cpp
@@ -115,6 +115,7 @@ const bool GPGTest::DefaultComputePeriod = true;
 #include <sstream>
 #include <vector>
 #include <string>
+#include <iomanip>
 
 #include "guide_performance_tools.h"
 


### PR DESCRIPTION
While it work fine with previous version of Ubuntu,  the last version 24.10 fail to build with this error:

```
/<<PKGBUILDDIR>>/contributions/MPI_IS_gaussian_process/tests/gaussian_process/gp_guider_test.cpp:555:25: error: ‘setw’ is not a member of ‘std’
  555 |         outfile << std::setw(8) << GPG->GetGPHyperparameters()[PKPeriodLength] << "\n";
      |                         ^~~~
/<<PKGBUILDDIR>>/contributions/MPI_IS_gaussian_process/tests/gaussian_process/gp_guider_test.cpp:120:1: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
  119 | #include "guide_performance_tools.h"
  +++ |+#include <iomanip>
```

Applying the suggest change work, the package for 24.10 is now in the PPA and I tested it work without problem.
Probably "iomanip" was previously included from another header but no more now.

I not test with Windows and Mac, it may be good to do it before to merge. 
