### PR TITLE
Fix build error due to invalid CMake function parameter

### DIFF
--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -489,7 +489,6 @@ else()
     indi
     GIT_REPOSITORY https://github.com/indilib/indi.git
     GIT_TAG 856ac85b965177d23cd0c819a49fd50bdaeece60  # v2.0.5
-    GIT_SHALLOW 1
     CMAKE_ARGS -Wno-dev
       -DINDI_BUILD_SERVER=OFF
       -DINDI_BUILD_DRIVERS=OFF
@@ -601,7 +600,6 @@ if (NOT OPENSOURCE_ONLY)
     OGMAcamSDK
     GIT_REPOSITORY https://github.com/OGMAvision/OGMAcamSDK.git
     GIT_TAG 5e83d81384479b1684b97e9f6936e453050da4cb
-    GIT_SHALLOW 1
   )
   FetchContent_MakeAvailable(OGMAcamSDK)
   include_directories(${ogmacamsdk_SOURCE_DIR}/inc)


### PR DESCRIPTION
`GIT_SHALLOW` is incomaptible with `GIT_TAG` being a SHA for FetchContent_Declare()

Fixes #1290