### PR TITLE
Allow client to specify starting window size in Guider

### DIFF
--- a/src/guider.cpp
+++ b/src/guider.cpp
@@ -161,7 +161,7 @@ static const wxStringCharType *StateStr(GUIDER_STATE st)
 }
 
 Guider::Guider(wxWindow *parent, int xSize, int ySize)
-    : wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxFULL_REPAINT_ON_RESIZE)
+    : wxWindow(parent, wxID_ANY, wxDefaultPosition, wxSize(xSize, ySize), wxFULL_REPAINT_ON_RESIZE)
 {
     m_state = STATE_UNINITIALIZED;
     Debug.Write(wxString::Format("guider state => %s\n", StateStr(m_state)));


### PR DESCRIPTION
This fixes a latent problem with initialization of the guider window size.  Two of the passed parameters in the constructor - xsize and ysize - are ignored in the original code.