### PR TITLE
log a message in the debug log when saving an image fails

### DIFF
--- a/src/usImage.cpp
+++ b/src/usImage.cpp
@@ -405,6 +405,13 @@ bool usImage::Save(const wxString& fname, const wxString& hdrNote) const
 
         PHD_fits_close_file(fptr);
 
+        if (status)
+        {
+            char buf[128]; // fits_get_errstatus requires a 30 character buffer
+            fits_get_errstatus(status, buf);
+            Debug.Write(wxString::Format("CFITSIO error (%d) saving image: %s\n", status, buf));
+        }
+
         bError = status ? true : false;
     }
     catch (const wxString& Msg)


### PR DESCRIPTION
log a message in the debug log when saving an image fails

