### PR TITLE
event server: capture_single_frame enhancements

### DIFF
--- a/src/event_server.h
+++ b/src/event_server.h
@@ -62,6 +62,7 @@ public:
     void NotifyCalibrationDataFlipped(const Mount *mount);
     void NotifyLooping(unsigned int exposure, const Star *star, const FrameDroppedInfo *info);
     void NotifyLoopingStopped();
+    void NotifySingleFrameComplete(bool succeeded, const wxString& errorMsg, const SingleExposure& info);
     void NotifyStarSelected(const PHD_Point& pos);
     void NotifyStarLost(const FrameDroppedInfo& info);
     void NotifyGuidingStarted();

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -112,9 +112,19 @@ struct DitherSpiral
 struct SingleExposure
 {
     bool enabled;
-    int duration;
+    int duration; // exposure duration, millis
     wxRect subframe;
+    bool save;
+    wxString path;
+    wxByte prev_binning;
+    int prev_gain;
+
+    SingleExposure();
+    bool Activate(int duration, wxByte binning, int gain, const wxRect& subframe, bool save, const wxString& path);
+    void Complete(bool succeeded, const wxString& errorMsg = wxEmptyString);
 };
+
+inline SingleExposure::SingleExposure() : enabled(false), duration(0) { }
 
 class MyFrameConfigDialogCtrlSet : public ConfigDialogCtrlSet
 {
@@ -411,7 +421,7 @@ public:
 
     void StartCapturing();
     bool StopCapturing();
-    bool StartSingleExposure(int duration, const wxRect& subframe);
+    bool StartSingleExposure(int duration, wxByte binning, int gain, const wxRect& subframe, bool save, const wxString& path);
 
     bool AutoSelectStar(const wxRect& roi = wxRect());
 


### PR DESCRIPTION
event server: capture_single_frame enhancements

Updated the capture_single_frame server method to allow more flexibility.
 - allow the caller to optionally specify the exposure duration, binning, gain, and ROI
 - allow the caller to optionally request that the image be automatically saved when the
   exposure completes.  The caller can provide a path name for the output file
   (the file must not already exist); when omitted PHD2 will choose a unique
   output filename.
 - on completion of the frame, PHD2 sends a SingleFrameComplete notification event.
   The event will be sent on both success and failure.

