### PR TITLE
Fix ToupTek/OGMA sensor temperature

### DIFF
--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -875,7 +875,9 @@ bool CameraOgma::GetCoolerStatus(bool *on, double *setpoint, double *power, doub
 
     if (m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
+    {
         *power = vcur * 100.0 / vmax;
+    }
     else
         err = true;
 

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -869,13 +869,13 @@ bool CameraOgma::GetCoolerStatus(bool *on, double *setpoint, double *power, doub
         err = true;
 
     if (m_cam.GetOption(OGMACAM_OPTION_TECTARGET, &targ))
-        *setpoint = static_cast<double>(targ / 10.0);
+        *setpoint = targ / 10.0;
     else
         err = true;
 
     if (m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
-        *power = static_cast<double>(vcur * 100.0 / vmax);
+        *power = vcur * 100.0 / vmax;
     else
         err = true;
 
@@ -896,7 +896,7 @@ bool CameraOgma::GetSensorTemperature(double *temperature)
         return true;
     }
 
-    *temperature = static_cast<double>(val / 10.0);
+    *temperature = val / 10.0;
     return false;
 }
 

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -869,16 +869,17 @@ bool CameraOgma::GetCoolerStatus(bool *on, double *setpoint, double *power, doub
         err = true;
 
     if (m_cam.GetOption(OGMACAM_OPTION_TECTARGET, &targ))
-        *setpoint = targ / 10.0;
+        *setpoint = static_cast<double>(targ / 10.0);
     else
         err = true;
 
     if (m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(OGMACAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
-    {
-        *power = vcur * 100.0 / vmax;
-    }
+        *power = static_cast<double>(vcur * 100.0 / vmax);
     else
+        err = true;
+
+    if (GetSensorTemperature(temperature))
         err = true;
 
     return err;
@@ -895,7 +896,7 @@ bool CameraOgma::GetSensorTemperature(double *temperature)
         return true;
     }
 
-    *temperature = val / 10.0;
+    *temperature = static_cast<double>(val / 10.0);
     return false;
 }
 

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -870,13 +870,13 @@ bool CameraToupTek::GetCoolerStatus(bool *on, double *setpoint, double *power, d
         err = true;
 
     if (m_cam.GetOption(TOUPCAM_OPTION_TECTARGET, &targ))
-        *setpoint = static_cast<double>(targ / 10.0);
+        *setpoint = targ / 10.0;
     else
         err = true;
 
     if (m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
-        *power = static_cast<double>(vcur * 100.0 / vmax);
+        *power = vcur * 100.0 / vmax;
     else
         err = true;
 
@@ -897,7 +897,7 @@ bool CameraToupTek::GetSensorTemperature(double *temperature)
         return true;
     }
 
-    *temperature = static_cast<double>(val / 10.0);
+    *temperature = val / 10.0;
     return false;
 }
 

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -870,16 +870,17 @@ bool CameraToupTek::GetCoolerStatus(bool *on, double *setpoint, double *power, d
         err = true;
 
     if (m_cam.GetOption(TOUPCAM_OPTION_TECTARGET, &targ))
-        *setpoint = targ / 10.0;
+        *setpoint = static_cast<double>(targ / 10.0);
     else
         err = true;
 
     if (m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
-    {
-        *power = vcur * 100.0 / vmax;
-    }
+        *power = static_cast<double>(vcur * 100.0 / vmax);
     else
+        err = true;
+
+    if (GetSensorTemperature(temperature))
         err = true;
 
     return err;
@@ -896,7 +897,7 @@ bool CameraToupTek::GetSensorTemperature(double *temperature)
         return true;
     }
 
-    *temperature = val / 10.0;
+    *temperature = static_cast<double>(val / 10.0);
     return false;
 }
 

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -876,7 +876,9 @@ bool CameraToupTek::GetCoolerStatus(bool *on, double *setpoint, double *power, d
 
     if (m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE, &vcur) && m_cam.GetOption(TOUPCAM_OPTION_TEC_VOLTAGE_MAX, &vmax) &&
         vmax > 0)
+    {
         *power = vcur * 100.0 / vmax;
+    }
     else
         err = true;
 


### PR DESCRIPTION
The `GetCoolerStatus()` function for ToupTek and OGMA cameras did not set the `temperature` pointer with the cooler temperature readout, causing PHD2 to display garbage of an uninitialized variable. This PR fixes that so that the temperature is fetched and thus properly displayed. Although also ToupTek-based, the Malincam and Altair drivers leave these functions unimplemented and I felt that adding them would be outside the scope of this PR, plus I don't have any such devices to test with to ensure proper function. I tested this fix with a ToupTek ATR585M.

Before:
![image](https://github.com/user-attachments/assets/c7c9c3c6-0d75-415b-938f-921d2b33186a)

After:
![image](https://github.com/user-attachments/assets/b454b030-4453-430f-80a8-15c5caa02428)
