### PR TITLE
Touptek scaling

### DIFF
--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -142,7 +142,7 @@ struct ToupCam
             sz->x = width;
             sz->y = height;
 
-            if (m_bpp == 16 && false)
+            if (m_bpp == 16)
             {
                 // There are 12-bit Touptek cameras (like the GPM462M) that return values in the range [0-4094] when in 16-bit mode. 
                 // We scale the 12-bit input range [0-4094] to the 16-bit output range [0-65535].  


### PR DESCRIPTION
After extensive conversation with ToupTek tech support it has been determined that when in raw 16-bit mode different camera's return different ranges of ADU values.

The raw bit depth is returned by 

Toupcam_get_RawFormat(m_cam.m_h, &fourcc, &bpp)

For example my GPM462M returns ADU counts in the range [0 - **4094**  ] ; which is (2^12 - 2) and bpp = 12

My G3M678M return ADU counts in the range [0 - **65520**] which is [0 - **4095**  ] << 4; or (2^12-1) << 4 and bpp = 16

Touptek has confirmed that their 14-bit cameras (like the ATR533M) return values in the range [0 - **16382**]; which is (2^14 - 2) and bpp = 14

This PR simply scales these output ranges to the full [0 - 65535] expected by the reset of PhD2 code base.

