### PR TITLE
Fixes a bug where the camera binning can inadvertently change

### DIFF
--- a/src/myframe_events.cpp
+++ b/src/myframe_events.cpp
@@ -400,7 +400,8 @@ void MyFrame::OnButtonLoop(wxCommandEvent& WXUNUSED(event))
 void MyFrame::FinishStop(void)
 {
     assert(!CaptureActive);
-    m_singleExposure.Complete(true);
+    if (m_singleExposure.enabled)
+        m_singleExposure.Complete(true);
     EvtServer.NotifyLoopingStopped();
     // when looping resumes, start with at least one full frame. This enables applications
     // controlling PHD to auto-select a new star if the star is lost while looping was stopped.
@@ -540,7 +541,8 @@ void MyFrame::OnExposeComplete(usImage *pNewFrame, bool err)
                 pGuider->StopGuiding();
                 pGuider->UpdateImageDisplay();
             }
-            m_singleExposure.Complete(false, "camera error -- see debug log");
+            if (m_singleExposure.enabled)
+                m_singleExposure.Complete(false, "camera error -- see debug log");
             EvtServer.NotifyLoopingStopped();
             pGuider->Reset(false);
             CaptureActive = m_continueCapturing;


### PR DESCRIPTION
Fixes a bug introduced by 000799fa5f420567609327ce522842e0c186d248 causing the camera binning can inadvertently change

When capturing stops, the binning could get set to an invalid value.
