### PR TITLE
minor cleanup - cameras max size can be a wxSize, not wxRect

### DIFF
--- a/src/cam_indi.cpp
+++ b/src/cam_indi.cpp
@@ -131,7 +131,7 @@ private:
     double PixSize;
     double PixSizeX;
     double PixSizeY;
-    wxRect m_maxSize;
+    wxSize m_maxSize;
     wxByte m_curBinning;
     bool HasBayer;
     long INDIport;

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -57,7 +57,7 @@ enum CaptureMode
 
 class PlayerOneCamera : public GuideCamera
 {
-    wxRect m_maxSize;
+    wxSize m_maxSize;
     wxRect m_frame;
     unsigned short m_prevBinning;
     void *m_buffer;

--- a/src/cam_skyraider.cpp
+++ b/src/cam_skyraider.cpp
@@ -53,7 +53,6 @@ struct SkyraiderCamera : public GuideCamera
     int m_defaultGainPct;
     volatile bool m_frameReady;
     int m_cameraId;
-    wxRect m_maxSize;
     MallincamGuider m_Guider;
 
     SkyraiderCamera();

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -50,7 +50,7 @@ enum CaptureMode
 
 class SVBCamera : public GuideCamera
 {
-    wxRect m_maxSize;
+    wxSize m_maxSize;
     wxRect m_frame;
     unsigned short m_prevBinning;
     void *m_buffer;

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -58,7 +58,7 @@ enum CaptureMode
 
 class Camera_ZWO : public GuideCamera
 {
-    wxRect m_maxSize;
+    wxSize m_maxSize;
     wxRect m_frame;
     unsigned short m_prevBinning;
     void *m_buffer;


### PR DESCRIPTION
minor cleanup - cameras max size can be a wxSize, not wxRect

