### PR TITLE
Minor refactor - add a camera Connect wrapper method

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -655,6 +655,9 @@ GuideCamera *GuideCamera::Factory(const wxString& choice)
     return pReturn;
 }
 
+// ConnectCamera is the one place where we call camera->Connect(). Any work done here
+// applies to all camera types, regardless of how the various camera sub-ckasses
+// implement Connect().
 bool GuideCamera::ConnectCamera(GuideCamera *camera, const wxString& cameraId)
 {
     bool err = camera->Connect(cameraId);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -655,6 +655,12 @@ GuideCamera *GuideCamera::Factory(const wxString& choice)
     return pReturn;
 }
 
+bool GuideCamera::ConnectCamera(GuideCamera *camera, const wxString& cameraId)
+{
+    bool err = camera->Connect(cameraId);
+    return err;
+}
+
 bool GuideCamera::HandleSelectCameraButtonClick(wxCommandEvent&)
 {
     return false; // not handled

--- a/src/camera.h
+++ b/src/camera.h
@@ -163,7 +163,9 @@ public:
     static const wxString DEFAULT_CAMERA_ID;
     virtual bool EnumCameras(wxArrayString& names, wxArrayString& ids);
 
-    // Opens up and connects to camera. cameraId identifies which camera to connect to if
+    static bool ConnectCamera(GuideCamera *camera, const wxString& cameraId);
+
+    // Opens connection to the camera. cameraId identifies which camera to connect to if
     // there is more than one camera present
     virtual bool Connect(const wxString& cameraId) = 0;
     virtual bool Disconnect() = 0; // Disconnects, unloading any DLLs loaded by Connect

--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1101,7 +1101,7 @@ bool GearDialog::DoConnectCamera(bool autoReconnecting)
         Debug.Write(wxString::Format("Connecting to camera [%s] id = [%s]\n", newCam, cameraId));
 
         int profileBinning = m_pCamera->Binning;
-        if (m_pCamera->Connect(cameraId))
+        if (GuideCamera::ConnectCamera(m_pCamera, cameraId))
         {
             throw THROW_INFO("DoConnectCamera: connect failed");
         }

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -915,7 +915,7 @@ struct AutoConnectCamera
             else
                 camDeviceId = parent->GetCamDeviceId();
             wxBusyCursor busy;
-            m_camera->Connect(camDeviceId);
+            GuideCamera::ConnectCamera(m_camera, camDeviceId);
             pFrame->ClearAlert();
         }
 


### PR DESCRIPTION
Minor refactor - add a camera Connect wrapper method

Add a wrapper method to call Camera::Connect.  This will allow us to
put code common to all camera subclass Connect methods in ConectCamera
rather than repeating it in all camera subclasses' Connect methods.

