### PR TITLE
event server method to serialize wxRect

### DIFF
--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -232,6 +232,12 @@ struct NV
         ary << s.x << s.y;
         v = ary.str();
     }
+    NV(const wxString& n_, const wxRect& r) : n(n_)
+    {
+        JAry ary;
+        ary << r.x << r.y << r.width << r.height;
+        v = ary.str();
+    }
     NV(const wxString& n_, const NULL_TYPE& nul) : n(n_), v(literal_null) { }
 };
 


### PR DESCRIPTION
event server method to serialize wxRect

Event server has a method to parse a wxRect, but there is
no corresponding method to serialize a wxRect as a JSON object.

