### PR TITLE
add conversion gain,framerate and blacklevel control in camera connect

### DIFF
--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -874,7 +874,8 @@ struct ToupTekCameraDlg : public wxDialog
     }
 };
 
-ToupTekCameraDlg::ToupTekCameraDlg() : wxDialog(wxGetApp().GetTopWindow(), wxID_ANY, _("ToupTek Camera Properties"))
+ToupTekCameraDlg::ToupTekCameraDlg(const wxString& camId)
+    : wxDialog(wxGetApp().GetTopWindow(), wxID_ANY, _("ToupTek Camera Properties"))
 {
     m_maxSpeed = CameraToupTek::GetCameraMaxSpeed(camId);
     if (m_maxSpeed <= 0)


### PR DESCRIPTION
I am a software developer at ToupTek. When selecting the ToupTek Camera driver in the phd2 camera connection, the camera settings only allowed choosing between 8-bit and 16-bit. Now we have added options for Conversion Gain, FrameRate, and Black Level to better control the ToupTek camera.

![camera1](https://github.com/user-attachments/assets/99d85757-afa1-43f8-9855-35b3d93f6056)
