### PR TITLE
Fix incorrect adjustment of limit frame when binning changes

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -186,7 +186,7 @@ public:
     static void GetBinningOpts(int maxBin, wxArrayString *opts);
     void GetBinningOpts(wxArrayString *opts);
     bool SetBinning(int binning);
-    bool SetLimitFrame(const wxRect& roi);
+    bool SetLimitFrame(const wxRect& roi, int binning);
 
     virtual void ShowPropertyDialog() { return; }
     bool SetCameraPixelSize(double pixel_size);

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2049,7 +2049,7 @@ static void set_limit_frame(JObj& response, const json_value *params)
         response << jrpc_error(1, "guide camera does not support frame limiting");
         return;
     }
-    bool err = pCamera->SetLimitFrame(roi);
+    bool err = pCamera->SetLimitFrame(roi, 1);
 
     if (err)
         response << jrpc_error(1, "could not set ROI. See Debug Log for more info.");


### PR DESCRIPTION
The code to adjust the frame limit ROI when binning changes was just wrong. This PR fixes the calculation.