### PR TITLE
minor refactor: camera DarkFrameSize return size by value not by reference

### DIFF
--- a/src/cam_sxv.cpp
+++ b/src/cam_sxv.cpp
@@ -79,7 +79,7 @@ public:
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void ShowPropertyDialog() override;
-    const wxSize& DarkFrameSize() override { return m_darkFrameSize; }
+    wxSize DarkFrameSize() override { return m_darkFrameSize; }
 
     bool HasNonGuiCapture() override { return true; }
     bool ST4HasNonGuiMove() override { return true; }

--- a/src/camera.h
+++ b/src/camera.h
@@ -208,7 +208,7 @@ public:
     void SubtractDark(usImage& img);
     void GetDarkLibraryProperties(int *pNumDarks, double *pMinExp, double *pMaxExp);
 
-    virtual const wxSize& DarkFrameSize() { return FrameSize; }
+    virtual wxSize DarkFrameSize() { return FrameSize; }
 
     static double GetProfilePixelSize();
 


### PR DESCRIPTION
More flexible interface -- allow subclasses to return a computed value, not necessarily a const reference.