### PR TITLE
Dark subtraction for limited frame ROI

### DIFF
--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -90,6 +90,7 @@ public:
     bool ST4HasNonGuiMove() override { return true; }
     wxByte BitsPerPixel() override;
     bool GetDevicePixelSize(double *devPixelSize) override;
+    wxSize DarkFrameSize() override;
     int GetDefaultCameraGain() override;
     bool SetCoolerOn(bool on) override;
     bool SetCoolerSetpoint(double temperature) override;
@@ -612,6 +613,11 @@ bool Camera_ZWO::GetDevicePixelSize(double *devPixelSize)
     return false;
 }
 
+wxSize Camera_ZWO::DarkFrameSize()
+{
+    return BinnedFrameSize(Binning);
+}
+
 int Camera_ZWO::GetDefaultCameraGain()
 {
     return m_defaultGainPct;
@@ -757,7 +763,7 @@ bool Camera_ZWO::Capture(int duration, usImage& img, int options, const wxRect& 
         binning_change = true;
     }
 
-    wxRect const limit_frame = LimitFrame;
+    wxRect const limit_frame = options & CAPTURE_IGNORE_FRAME_LIMIT ? wxRect() : LimitFrame;
 
     // always update the frame size in case the limit frame or binning changed
     wxSize const binned_frame_size(BinnedFrameSize(Binning));

--- a/src/camera.h
+++ b/src/camera.h
@@ -98,10 +98,11 @@ enum CaptureOptionBits
 {
     CAPTURE_SUBTRACT_DARK = 1 << 0,
     CAPTURE_RECON = 1 << 1, // debayer and/or deinterlace as required
+    CAPTURE_IGNORE_FRAME_LIMIT = 1 << 2,
 
     CAPTURE_LIGHT = CAPTURE_SUBTRACT_DARK | CAPTURE_RECON,
-    CAPTURE_DARK = 0,
-    CAPTURE_BPM_REVIEW = CAPTURE_SUBTRACT_DARK,
+    CAPTURE_DARK = CAPTURE_IGNORE_FRAME_LIMIT,
+    CAPTURE_BPM_REVIEW = CAPTURE_SUBTRACT_DARK | CAPTURE_IGNORE_FRAME_LIMIT,
 };
 
 class GuideCamera : public wxMessageBoxProxy, public OnboardST4

--- a/src/myframe_events.cpp
+++ b/src/myframe_events.cpp
@@ -494,6 +494,10 @@ static void WarnRawImageMode(void)
 {
     if (pCamera->FrameSize != pCamera->DarkFrameSize())
     {
+        if (!pCamera->LimitFrame.IsEmpty())
+            // If a limited ROI is in effect, the camera's frame size may not match the
+            // full frame size
+            return;
         pFrame->SuppressibleAlert(RawModeWarningKey(),
                                   _("For refining the Bad-pixel Map PHD2 is now displaying raw camera data frames, which are a "
                                     "different size from ordinary guide frames for this camera."),


### PR DESCRIPTION
When a limited frame ROI is in effect, PHD2 can now properly do dark subtraction and bad-pixel correction.

Dark frame captures now always ignore the frame limit and capture full frames.

When it is time to subtract the dark frame from the light frame, the appropriate region of the dark frame is subtracted from the light taking the frame limit into account.

Likewise, for a bad-pixel map, the frame limit is taken into account when mapping the pixel position in the bad pixel map to the offset pixel position in the light frame.

Testing:
  - manually tested a dark library and bad-pixel map - varied the limit frame (no limit frame, limit frame in various sizes and offsets) - tested with and without subframes