### PR TITLE
API server: add missing guider safety check for guide_pulse

### DIFF
--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2137,6 +2137,8 @@ static void guide_pulse(JObj& response, const json_value *params)
         return;
     }
 
+    VERIFY_GUIDER(response);
+
     if (pFrame->pGuider->IsCalibratingOrGuiding() || m->IsBusy())
     {
         response << jrpc_error(1, "cannot issue guide pulse while calibrating or guiding");


### PR DESCRIPTION
API server: add missing guider safety check for guide_pulse

Guard against a possible null pointer exception.
May be impossible, but best to have the check for paranoia and consistency
with the other api methods that all do the check before accessing
pFrame->pGuider.

