### PR TITLE
frame limit ROI: do not allow setting the ROI while calibrating or guiding

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -743,8 +743,14 @@ bool GuideCamera::SetBinning(int binning)
     return false;
 }
 
-bool GuideCamera::SetLimitFrame(const wxRect& roi, int binning)
+bool GuideCamera::SetLimitFrame(const wxRect& roi, int binning, wxString *errorMessage)
 {
+    if (pFrame->pGuider->IsCalibratingOrGuiding())
+    {
+        *errorMessage = "Cannot set the frame limit ROI while calibrating or guiding.";
+        return true;
+    }
+
     // Construct and store limit frames for all available binning values. This allows
     // accurate binning switching without rounding errors when switching from a higher
     // binning to a lower binning.  For example, if we have a limit frame coordinate

--- a/src/camera.h
+++ b/src/camera.h
@@ -186,7 +186,7 @@ public:
     static void GetBinningOpts(int maxBin, wxArrayString *opts);
     void GetBinningOpts(wxArrayString *opts);
     bool SetBinning(int binning);
-    bool SetLimitFrame(const wxRect& roi, int binning);
+    bool SetLimitFrame(const wxRect& roi, int binning, wxString *errorMessage);
     void LoadLimitFrame(int binning);
 
     virtual void ShowPropertyDialog() { return; }

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -2049,10 +2049,14 @@ static void set_limit_frame(JObj& response, const json_value *params)
         response << jrpc_error(1, "guide camera does not support frame limiting");
         return;
     }
-    bool err = pCamera->SetLimitFrame(roi, 1);
+
+    VERIFY_GUIDER(response);
+
+    wxString errorMessage;
+    bool err = pCamera->SetLimitFrame(roi, 1, &errorMessage);
 
     if (err)
-        response << jrpc_error(1, "could not set ROI. See Debug Log for more info.");
+        response << jrpc_error(1, errorMessage);
     else
         response << jrpc_result(0);
 }


### PR DESCRIPTION
frame limit ROI: do not allow setting the ROI while calibrating or guiding

