### PR TITLE
Fix a compile error with newer compilers

### DIFF
--- a/src/serialport_win32.h
+++ b/src/serialport_win32.h
@@ -40,7 +40,7 @@ class SerialPortWin32 : public SerialPort
 {
     HANDLE m_handle;
 
-    bool SerialPortWin32::EscapeFunction(DWORD command);
+    bool EscapeFunction(DWORD command);
 
 public:
     wxArrayString GetSerialPortList() override;


### PR DESCRIPTION
Fix a compile error with newer compilers

Remove class qualifier from method declaration.

