### PR TITLE
Guider's CurrentImage is never null

### DIFF
--- a/src/guider.cpp
+++ b/src/guider.cpp
@@ -852,10 +852,6 @@ bool Guider::MoveLockPosition(const PHD_Point& mountDeltaArg)
         }
 
         const usImage *image = CurrentImage();
-        if (!image)
-        {
-            throw ERROR_INFO("cannot move lock pos without an image");
-        }
 
         // This loop is to handle dithers when the star is near the edge of the frame. The strategy
         // is to try reflecting the requested dither in 4 directions along the RA/Dec axes; if any

--- a/src/guider_multistar.cpp
+++ b/src/guider_multistar.cpp
@@ -452,7 +452,7 @@ bool GuiderMultiStar::AutoSelect(const wxRect& roi)
 
     try
     {
-        if (!image || !image->ImageData)
+        if (!image->ImageData)
         {
             throw ERROR_INFO("No Current Image");
         }
@@ -519,7 +519,7 @@ bool GuiderMultiStar::AutoSelect(const wxRect& roi)
         error = true;
     }
 
-    if (image && image->ImageData)
+    if (image->ImageData)
     {
         if (error)
             Debug.Write("GuiderMultiStar::AutoSelect failed.\n");
@@ -1078,8 +1078,6 @@ bool GuiderMultiStar::SetLockPosition(const PHD_Point& position)
 bool GuiderMultiStar::IsValidLockPosition(const PHD_Point& pt)
 {
     const usImage *pImage = CurrentImage();
-    if (!pImage)
-        return false;
     // this is a bit ugly as it is tightly coupled to Star::Find
     return pt.X >= 1 + m_searchRegion && pt.X + 1 + m_searchRegion < pImage->Size.GetX() && pt.Y >= 1 + m_searchRegion &&
         pt.Y + 1 + m_searchRegion < pImage->Size.GetY();
@@ -1088,8 +1086,6 @@ bool GuiderMultiStar::IsValidLockPosition(const PHD_Point& pt)
 bool GuiderMultiStar::IsValidSecondaryStarPosition(const PHD_Point& pt)
 {
     const usImage *pImage = CurrentImage();
-    if (!pImage)
-        return false;
     // As above, tightly coupled to Star::Find but with somewhat relaxed constraints. Find handles cases where search region is
     // only partly within image
     return pt.X >= 5 && pt.X + 5 < pImage->Size.GetX() && pt.Y >= 5 && pt.Y + 5 < pImage->Size.GetY();


### PR DESCRIPTION
Guider's CurrentImage is never null

Remove some unnecessary null checks for Guider::CurrentImage().

Although the checks are harmless, they make the code a bit harder
to understand as readers may be wondering about how or why the
current image could be null (it cannot!).

