### PR TITLE
Rename MaxBinning to MaxHwBinning

### DIFF
--- a/src/calstep_dialog.cpp
+++ b/src/calstep_dialog.cpp
@@ -123,7 +123,7 @@ CalstepDialog::CalstepDialog(wxWindow *parent, int focalLength, double pixelSize
 
     // binning
     wxArrayString opts;
-    GuideCamera::GetBinningOpts(pCamera ? pCamera->MaxBinning : 1, &opts);
+    GuideCamera::GetBinningOpts(pCamera ? pCamera->MaxHwBinning : 1, &opts);
     m_binningChoice = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, opts);
     m_binningChoice->Enable(!pFrame->pGuider || !pFrame->pGuider->IsCalibratingOrGuiding());
     m_binningChoice->Bind(wxEVT_CHOICE, &CalstepDialog::OnText, this);

--- a/src/cam_ascom.cpp
+++ b/src/cam_ascom.cpp
@@ -679,10 +679,10 @@ bool CameraASCOM::Connect(const wxString& camId)
         maxBinX = vRes.iVal;
     if (driver.GetProp(&vRes, L"MaxBinY"))
         maxBinY = vRes.iVal;
-    MaxBinning = wxMin(maxBinX, maxBinY);
-    Debug.Write(wxString::Format("ASCOM camera: MaxBinning is %hu\n", MaxBinning));
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    MaxHwBinning = wxMin(maxBinX, maxBinY);
+    Debug.Write(wxString::Format("ASCOM camera: MaxBinning is %hu\n", MaxHwBinning));
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
     m_curBin = Binning;
 
     HasCooler = false;
@@ -775,7 +775,7 @@ bool CameraASCOM::Connect(const wxString& camId)
     if (ASCOM_SetBin(driver.IDisp(), Binning, &excep))
     {
         // only make this error fatal if the camera supports binning > 1
-        if (MaxBinning > 1)
+        if (MaxHwBinning > 1)
         {
             return CamConnectFailed(_("The ASCOM camera failed to set binning. See the debug log for more information."));
         }

--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -185,9 +185,9 @@ bool CameraAtik16::Connect(const wxString& camId)
 
     int maxbinx = 1, maxbiny = 1;
     ArtemisGetMaxBin(Cam_Handle, &maxbinx, &maxbiny);
-    MaxBinning = wxMin(maxbinx, maxbiny);
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    MaxHwBinning = wxMin(maxbinx, maxbiny);
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     FrameSize = wxSize(m_properties.nPixelsX / Binning, m_properties.nPixelsY / Binning);
 

--- a/src/cam_indi.cpp
+++ b/src/cam_indi.cpp
@@ -382,10 +382,10 @@ void CameraINDI::updateProperty(INDI::Property property)
         }
         else if (nvp == binning_prop)
         {
-            MaxBinning = wxMin(binning_x->max, binning_y->max);
+            MaxHwBinning = wxMin(binning_x->max, binning_y->max);
             m_curBinning = wxMin(binning_x->value, binning_y->value);
-            if (Binning > MaxBinning)
-                Binning = MaxBinning;
+            if (Binning > MaxHwBinning)
+                Binning = MaxHwBinning;
             // defer defining FrameSize since it is not simply derivable from max size and binning
             // no: FrameSize = wxSize(m_maxSize.x / Binning, m_maxSize.y / Binning);
         }

--- a/src/cam_moravian.cpp
+++ b/src/cam_moravian.cpp
@@ -668,10 +668,10 @@ bool MoravianCamera::Connect(const wxString& camId)
     int maxbinx = m_cam.IntParam(gipMaxBinningX);
     int maxbiny = m_cam.IntParam(gipMaxBinningY);
 
-    MaxBinning = std::min(maxbinx, maxbiny);
+    MaxHwBinning = std::min(maxbinx, maxbiny);
 
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     m_maxSize = m_cam.ChipSize();
 

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -279,7 +279,7 @@ CameraOgma::CameraOgma()
     m_cam.m_defaultGainPct = GuideCamera::GetDefaultCameraGain();
     int value = pConfig->Profile.GetInt("/camera/ogma/bpp", 8);
     m_cam.m_bpp = value == 8 ? 8 : 16;
-    MaxBinning = 4;
+    MaxHwBinning = 4;
 }
 
 CameraOgma::~CameraOgma() { }

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -454,10 +454,10 @@ bool PlayerOneCamera::Connect(const wxString& camId)
         if (info.bins[i] > maxBin)
             maxBin = info.bins[i];
     }
-    MaxBinning = maxBin;
+    MaxHwBinning = maxBin;
 
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     m_maxSize.x = info.maxWidth;
     m_maxSize.y = info.maxHeight;

--- a/src/cam_qhy.cpp
+++ b/src/cam_qhy.cpp
@@ -829,9 +829,9 @@ bool Camera_QHY::Connect(const wxString& camId)
             break;
     }
     Debug.Write(wxString::Format("QHY: max binning = %d\n", maxBin));
-    MaxBinning = maxBin;
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    MaxHwBinning = maxBin;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     Debug.Write(wxString::Format("QHY: call SetQHYCCDBinMode bin = %d\n", Binning));
     ret = SetQHYCCDBinMode(m_camhandle, Binning, Binning);

--- a/src/cam_sbig.cpp
+++ b/src/cam_sbig.cpp
@@ -376,7 +376,7 @@ bool CameraSBIG::Connect(const wxString& camId)
         }
     }
 
-    MaxBinning = 1;
+    MaxHwBinning = 1;
     m_devicePixelSize = 0.0;
     for (int i = 0; i < gcir0.readoutModes; i++)
     {
@@ -391,12 +391,12 @@ bool CameraSBIG::Connect(const wxString& camId)
                 m_devicePixelSize = (double) bcd2long(bcd) / 100.0;
             }
             else // RM_2x2
-                MaxBinning = 2;
+                MaxHwBinning = 2;
         }
     }
 
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     FrameSize = m_imageSize[Binning - 1];
 
@@ -421,7 +421,7 @@ bool CameraSBIG::Connect(const wxString& camId)
 
     Debug.Write(
         wxString::Format("SBIG: %s type=%u, UseTrackingCCD=%d, MaxBin = %hu, 1x1 size %d x %d, 2x2 size %d x %d IsColor %d\n",
-                         gcir0.name, gcir0.cameraType, m_useTrackingCCD, MaxBinning, m_imageSize[0].x, m_imageSize[0].y,
+                         gcir0.name, gcir0.cameraType, m_useTrackingCCD, MaxHwBinning, m_imageSize[0].x, m_imageSize[0].y,
                          m_imageSize[1].x, m_imageSize[1].y, IsColor));
 
     Connected = true;

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -409,10 +409,10 @@ bool SVBCamera::Connect(const wxString& camId)
         if (props.SupportedBins[i] > maxBin)
             maxBin = props.SupportedBins[i];
     }
-    MaxBinning = maxBin;
+    MaxHwBinning = maxBin;
 
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     m_maxSize.x = props.MaxWidth;
     m_maxSize.y = props.MaxHeight;

--- a/src/cam_sxv.cpp
+++ b/src/cam_sxv.cpp
@@ -461,10 +461,10 @@ bool CameraSXV::Connect(const wxString& camId)
 
     if (!IsCMOSGuider(CameraModel))
     {
-        MaxBinning = 2;
+        MaxHwBinning = 2;
     }
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     InitFrameSizes();
     m_prevBin = Binning;

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -280,7 +280,7 @@ CameraToupTek::CameraToupTek()
     m_cam.m_defaultGainPct = GuideCamera::GetDefaultCameraGain();
     int value = pConfig->Profile.GetInt("/camera/ToupTek/bpp", 8);
     m_cam.m_bpp = value == 8 ? 8 : 16;
-    MaxBinning = 4;
+    MaxHwBinning = 4;
 }
 
 CameraToupTek::~CameraToupTek() { }

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -465,10 +465,10 @@ bool Camera_ZWO::Connect(const wxString& camId)
         if (info.SupportedBins[i] > maxBin)
             maxBin = info.SupportedBins[i];
     }
-    MaxBinning = maxBin;
+    MaxHwBinning = maxBin;
 
-    if (Binning > MaxBinning)
-        Binning = MaxBinning;
+    if (Binning > MaxHwBinning)
+        Binning = MaxHwBinning;
 
     m_maxSize.x = info.MaxWidth;
     m_maxSize.y = info.MaxHeight;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -222,7 +222,7 @@ GuideCamera::GuideCamera()
     m_saturationADU = (unsigned short) wxMin(pConfig->Profile.GetInt("/camera/SaturationADU", 0), 65535);
     m_saturationByADU = pConfig->Profile.GetBoolean("/camera/SaturationByADU", true);
     m_pixelSize = GetProfilePixelSize();
-    MaxBinning = 1;
+    MaxHwBinning = 1;
     Binning = pConfig->Profile.GetInt("/camera/binning", 1);
     CurrentDarkFrame = nullptr;
     CurrentDefectMap = nullptr;
@@ -721,8 +721,8 @@ bool GuideCamera::SetBinning(int binning)
 {
     if (binning < 1)
         binning = 1;
-    if (binning > MaxBinning)
-        binning = MaxBinning;
+    if (binning > MaxHwBinning)
+        binning = MaxHwBinning;
 
     Debug.Write(wxString::Format("camera: set binning = %u\n", (unsigned int) binning));
 
@@ -752,7 +752,7 @@ bool GuideCamera::SetLimitFrame(const wxRect& roi, int binning, wxString *errorM
     // binning to a lower binning.  For example, if we have a limit frame coordinate
     // value of 101 at bin 1, after switching to bin 2 the coordinate will be 50; and
     // switching back to bin 1 we can recover the inital value of 101.
-    for (int new_bin = 1; new_bin <= MaxBinning; new_bin++)
+    for (int new_bin = 1; new_bin <= MaxHwBinning; new_bin++)
     {
         wxRect const limit_frame(roi.x * binning / new_bin, roi.y * binning / new_bin, roi.width * binning / new_bin,
                                  roi.height * binning / new_bin);

--- a/src/camera.h
+++ b/src/camera.h
@@ -129,7 +129,7 @@ public:
     bool HasShutter;
     bool HasSubframes;
     bool HasFrameLimiting;
-    wxByte MaxBinning;
+    wxByte MaxHwBinning; // max hardware binning level
     wxByte Binning;
     bool ShutterClosed; // false=light, true=dark
     bool UseSubframes;
@@ -245,7 +245,7 @@ inline int GuideCamera::GetTimeoutMs() const
 
 inline void GuideCamera::GetBinningOpts(wxArrayString *opts)
 {
-    GetBinningOpts(MaxBinning, opts);
+    GetBinningOpts(MaxHwBinning, opts);
 }
 
 inline double GuideCamera::GetCameraPixelSize() const

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -1409,10 +1409,10 @@ static void capture_single_frame(JObj& response, const json_value *params)
     wxByte binning = pCamera->Binning;
     if ((j = p.param("binning")) != nullptr)
     {
-        if (j->type != JSON_INT || j->int_value < 1 || j->int_value > pCamera->MaxBinning)
+        if (j->type != JSON_INT || j->int_value < 1 || j->int_value > pCamera->MaxHwBinning)
         {
             response << jrpc_error(JSONRPC_INVALID_PARAMS,
-                                   wxString::Format("invalid binning value: min=1, max=%d", pCamera->MaxBinning));
+                                   wxString::Format("invalid binning value: min=1, max=%d", pCamera->MaxHwBinning));
             return;
         }
         binning = j->int_value;

--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1173,7 +1173,7 @@ bool GearDialog::DoConnectCamera(bool autoReconnecting)
 
         // See if the profile was created with a binning level that isn't supported by the camera (user mistake) - if so, reset
         // binning to 1 Must be done here because orig binning level is not saved
-        if (profileBinning > m_pCamera->MaxBinning)
+        if (profileBinning > m_pCamera->MaxHwBinning)
         {
             int rslt;
             if (TheScope())

--- a/src/gear_simulator.cpp
+++ b/src/gear_simulator.cpp
@@ -1308,7 +1308,7 @@ CameraSimulator::CameraSimulator()
     HasGainControl = true;
     HasSubframes = true;
     PropertyDialogType = PROPDLG_WHEN_CONNECTED;
-    MaxBinning = 3;
+    MaxHwBinning = 3;
     HasCooler = true;
 }
 

--- a/src/guiding_assistant.cpp
+++ b/src/guiding_assistant.cpp
@@ -1332,8 +1332,8 @@ void GuidingAsstWin::MakeRecommendations()
     GetMinMoveRecs(m_ra_minmove_rec, m_dec_minmove_rec);
 
     // Refine the drift-limiting exposure value based on the ra_min_move recommendation
-    m_othergrid->SetCellValue(
-        m_ra_drift_exp_loc, maxRateRA <= 0.0 ? _(" ") : wxString::Format("%6.1f %s ", m_ra_minmove_rec / maxRateRA, (_("s"))));
+    m_othergrid->SetCellValue(m_ra_drift_exp_loc,
+                              maxRateRA <= 0.0 ? _(" ") : wxString::Format("%6.1f %s ", m_ra_minmove_rec / maxRateRA, _("s")));
 
     LogResults(); // Dump the raw statistics
 
@@ -1382,7 +1382,7 @@ void GuidingAsstWin::MakeRecommendations()
     m_exposure_msg = AddRecommendationMsg(msg);
     Debug.Write(wxString::Format("Recommendation: %s\n", msg));
     // Binning opportunity if image scale is < 0.5
-    if (pxscale <= 0.5 && pCamera->Binning == 1 && pCamera->MaxBinning > 1)
+    if (pxscale <= 0.5 && pCamera->Binning == 1 && pCamera->MaxHwBinning > 1)
     {
         wxString msg = _("Try binning your guide camera");
         allRecommendations += "Bin:" + msg + "\n";

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -958,7 +958,7 @@ struct AutoConnectCamera
 static void SetBinningLevel(ProfileWizard *parent, const wxString& selection, int val)
 {
     AutoConnectCamera cam(parent, selection, false);
-    if (cam && cam->MaxBinning > 1)
+    if (cam && cam->MaxHwBinning > 1)
         cam->SetBinning(val);
 }
 


### PR DESCRIPTION
Rename MaxBinning to MaxHwBinning

In preparation for introducing software binning #738, rename MaxBinning to
MaxHwBinning to be more specific about the meaning.

No functional changes in this PR, just the member variable name change.
