### PR TITLE
code cleanup: calibration details binning as int, not double

### DIFF
--- a/src/calreview_dialog.cpp
+++ b/src/calreview_dialog.cpp
@@ -339,7 +339,7 @@ void CalReviewDialog::CreateDataGrids(wxPanel *parentPanel, wxSizer *parentHSize
         if (validDetails)
         {
             wxString binning =
-                wxString::Format(_("Binning: %d"), (int) calDetails.origBinning); // Always binning used in actual calibration
+                wxString::Format(_("Binning: %d"), calDetails.origBinning); // Always binning used in actual calibration
             cfgGrid->SetCellValue(row, col++, wxString::Format("%0.2f %s\n%s", calDetails.imageScale, ARCSECPERPX, binning));
         }
         else

--- a/src/mount.cpp
+++ b/src/mount.cpp
@@ -1622,7 +1622,7 @@ void Mount::SaveCalibrationDetails(const CalibrationDetails& calDetails) const
         Debug.Write("Bogus guide speeds over-written in SaveCalibrationDetails\n");
     }
     pConfig->Profile.SetDouble(prefix + "ortho_error", calDetails.orthoError);
-    pConfig->Profile.SetDouble(prefix + "orig_binning", calDetails.origBinning);
+    pConfig->Profile.SetInt(prefix + "orig_binning", calDetails.origBinning);
     pConfig->Profile.SetString(prefix + "orig_timestamp", calDetails.origTimestamp);
     pConfig->Profile.SetInt(prefix + "orig_pierside", calDetails.origPierSide);
 
@@ -1789,7 +1789,7 @@ void Mount::LoadCalibrationDetails(CalibrationDetails *details) const
     details->orthoError = pConfig->Profile.GetDouble(prefix + "ortho_error", 0.0);
     details->raStepCount = pConfig->Profile.GetInt(prefix + "ra_step_count", 0);
     details->decStepCount = pConfig->Profile.GetInt(prefix + "dec_step_count", 0);
-    details->origBinning = pConfig->Profile.GetDouble(prefix + "orig_binning", 1.0);
+    details->origBinning = pConfig->Profile.GetInt(prefix + "orig_binning", 1);
     details->lastIssue = (CalibrationIssueType) pConfig->Profile.GetInt(prefix + "last_issue", 0);
     details->origTimestamp = pConfig->Profile.GetString(prefix + "orig_timestamp", "Unknown");
     details->origPierSide = pier_side(pConfig->Profile.GetInt(prefix + "orig_pierside", PIER_SIDE_UNKNOWN));

--- a/src/mount.h
+++ b/src/mount.h
@@ -109,7 +109,7 @@ struct CalibrationDetails
     double raGuideSpeed;
     double decGuideSpeed;
     double orthoError;
-    double origBinning;
+    int origBinning;
     std::vector<wxRealPoint> raSteps;
     std::vector<wxRealPoint> decSteps;
     int raStepCount;

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -1088,7 +1088,7 @@ void Scope::SetCalibration(const Calibration& cal)
     Mount::SetCalibration(cal);
 }
 
-void Scope::SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, double binning)
+void Scope::SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, int binning)
 {
     m_calibrationDetails = calDetails;
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -232,7 +232,7 @@ public:
     virtual ~Scope();
 
     void SetCalibration(const Calibration& cal) override;
-    void SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, double binning);
+    void SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, int binning);
     virtual void FlagCalibrationIssue(const CalibrationDetails& calDetails, CalibrationIssueType issue);
     bool IsCalibrated() const override;
     bool BeginCalibration(const PHD_Point& currentLocation) override;

--- a/src/stepguider.cpp
+++ b/src/stepguider.cpp
@@ -510,7 +510,7 @@ void StepGuider::SetCalibration(const Calibration& cal)
     Mount::SetCalibration(cal);
 }
 
-void StepGuider::SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, double binning)
+void StepGuider::SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, int binning)
 {
     m_calibrationDetails = calDetails;
 

--- a/src/stepguider.h
+++ b/src/stepguider.h
@@ -190,7 +190,7 @@ public:
     static StepGuider *Factory(const wxString& choice);
 
     void SetCalibration(const Calibration& cal) override;
-    void SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, double binning);
+    void SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, int binning);
     bool BeginCalibration(const PHD_Point& currentLocation) override;
     bool UpdateCalibrationState(const PHD_Point& currentLocation) override;
     void ClearCalibration() override;


### PR DESCRIPTION
code cleanup: calibration details binning as int, not double

The binning value can be stored as an int, not a double.

This is backwards compatible with stored calibration values
as the stored values can be read back as integer values
even though they were written out as doubles.

