### PR TITLE
code cleanup: use local variables for pCamera->Binning

### DIFF
--- a/src/advanced_dialog.cpp
+++ b/src/advanced_dialog.cpp
@@ -610,19 +610,20 @@ double AdvancedDialog::PercentChange(double oldVal, double newVal)
 // cleared, MinMoves are set to defaults based on new image scale
 void AdvancedDialog::MakeImageScaleAdjustments()
 {
+    int binning = pCamera->Binning;
+    auto focalLength = pFrame->GetFocalLength();
+    auto pixelSize = pCamera->GetCameraPixelSize();
     double guideSpeedX;
     Debug.Write("Image scale has changed via AD UI - step-size and algo adjustments will be made\n");
-    Debug.Write(wxString::Format("New image scale properties:  fl= %d, px= %.3fu, bin= %d\n", pFrame->GetFocalLength(),
-                                 pCamera->GetCameraPixelSize(), pCamera->Binning));
+    Debug.Write(wxString::Format("New image scale properties:  fl= %d, px= %.3fu, bin= %d\n", focalLength, pixelSize, binning));
 
     // Determine a calibration step-size based on recommended distance and best estimator of mount guide speeds
     guideSpeedX = DetermineGuideSpeed();
     int calibrationStep;
-    int recDistance =
-        CalstepDialog::GetCalibrationDistance(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning);
+    int recDistance = CalstepDialog::GetCalibrationDistance(focalLength, pixelSize, binning);
     int oldStepSize = TheScope()->GetCalibrationDuration();
-    CalstepDialog::GetCalibrationStepSize(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning,
-                                          guideSpeedX, CalstepDialog::DEFAULT_STEPS, 0, recDistance, nullptr, &calibrationStep);
+    CalstepDialog::GetCalibrationStepSize(focalLength, pixelSize, binning, guideSpeedX, CalstepDialog::DEFAULT_STEPS, 0,
+                                          recDistance, nullptr, &calibrationStep);
     TheScope()->SetCalibrationDuration(calibrationStep);
     Debug.Write(wxString::Format("Cal step-size changed from %d ms to %d ms\n", oldStepSize, calibrationStep));
     // Clear the calibration to force a new one and reset the min-move values
@@ -633,8 +634,7 @@ void AdvancedDialog::MakeImageScaleAdjustments()
             pSecondaryMount->ClearCalibration();
         Debug.Write("Calibrations cleared because of image scale change\n");
 
-        double defMinMove =
-            GuideAlgorithm::SmartDefaultMinMove(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning);
+        double defMinMove = GuideAlgorithm::SmartDefaultMinMove(focalLength, pixelSize, binning);
         Debug.Write(wxString::Format("Guide algo min moves reset to %.3fu\n", defMinMove));
         pMount->GetXGuideAlgorithm()->SetMinMove(defMinMove);
         pMount->GetYGuideAlgorithm()->SetMinMove(defMinMove);

--- a/src/backlash_comp.cpp
+++ b/src/backlash_comp.cpp
@@ -1169,7 +1169,8 @@ void BacklashTool::DecMeasurementStep(const PHD_Point& currentCamLoc)
                 Debug.Write(
                     wxString::Format("BLT: Trial backlash pulse resulted in net DecDelta = %0.2f px, Dec Location %0.2f\n",
                                      decDelta, currMountLocation.Y));
-                tol = TRIAL_TOLERANCE_AS / pFrame->GetCameraPixelScale(); // tolerance in units of px
+                auto pixelScale = pFrame->GetCameraPixelScale();
+                tol = TRIAL_TOLERANCE_AS / pixelScale; // tolerance in units of px
                 if (fabs(decDelta) > tol) // decDelta = (current - markerPoint)
                 {
                     double pulse_delta = fabs(currMountLocation.Y - m_endSouth.Y); // How far we moved with the test pulse
@@ -1188,7 +1189,7 @@ void BacklashTool::DecMeasurementStep(const PHD_Point& currentCamLoc)
                 }
                 else
                     Debug.Write(wxString::Format("BLT: Nominal backlash pulse resulted in final delta of %0.1f a-s\n",
-                                                 fabs(decDelta) * pFrame->GetCameraPixelScale()));
+                                                 fabs(decDelta) * pixelScale));
             }
 
             m_bltState = BLT_STATE_RESTORE;

--- a/src/calibration_assistant.cpp
+++ b/src/calibration_assistant.cpp
@@ -338,13 +338,14 @@ void CalibrationAssistant::PerformSanityChecks(void)
     }
     else
     {
-        int recDistance =
-            CalstepDialog::GetCalibrationDistance(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning);
+        int binning = pCamera->Binning;
+        auto focalLength = pFrame->GetFocalLength();
+        auto pixelSize = pCamera->GetCameraPixelSize();
+        int recDistance = CalstepDialog::GetCalibrationDistance(focalLength, pixelSize, binning);
         int currStepSize = TheScope()->GetCalibrationDuration();
         int recStepSize;
-        CalstepDialog::GetCalibrationStepSize(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning,
-                                              sidRate, CalstepDialog::DEFAULT_STEPS, m_currentDec, recDistance, 0,
-                                              &recStepSize);
+        CalstepDialog::GetCalibrationStepSize(focalLength, pixelSize, binning, sidRate, CalstepDialog::DEFAULT_STEPS,
+                                              m_currentDec, recDistance, 0, &recStepSize);
         if (fabs(1.0 - (double) currStepSize / (double) recStepSize) > 0.3) // Within 30% is good enough
         {
             msg = _("Your current calibration parameters can be adjusted for more accurate results."
@@ -1199,11 +1200,12 @@ void CalAssistSanityDialog::OnRecal(wxCommandEvent& evt)
                     minSpd = raSpd;
                 double sidrate = RateX(minSpd);
                 int calibrationStep;
-                int recDistance = CalstepDialog::GetCalibrationDistance(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(),
-                                                                        pCamera->Binning);
-                CalstepDialog::GetCalibrationStepSize(pFrame->GetFocalLength(), pCamera->GetCameraPixelSize(), pCamera->Binning,
-                                                      sidrate, CalstepDialog::DEFAULT_STEPS, m_parent->GetCalibrationDec(),
-                                                      recDistance, nullptr, &calibrationStep);
+                int binning = pCamera->Binning;
+                auto focalLength = pFrame->GetFocalLength();
+                auto pixelSize = pCamera->GetCameraPixelSize();
+                int recDistance = CalstepDialog::GetCalibrationDistance(focalLength, pixelSize, binning);
+                CalstepDialog::GetCalibrationStepSize(focalLength, pixelSize, binning, sidrate, CalstepDialog::DEFAULT_STEPS,
+                                                      m_parent->GetCalibrationDec(), recDistance, nullptr, &calibrationStep);
                 TheScope()->SetCalibrationDuration(calibrationStep);
                 EndDialog(wxOK);
             }

--- a/src/calstep_dialog.cpp
+++ b/src/calstep_dialog.cpp
@@ -220,7 +220,7 @@ int CalstepDialog::GetCalibrationDistance(int focalLength, double pixelSize, int
 //
 //  FocalLength = focal length in millimeters
 //  PixelSize = pixel size in microns (un-binned)
-//  Binning = hardware pixel binning factor
+//  Binning = pixel binning factor (combined hardware and software binning)
 //  GuideSpeed = guide rate as fraction of sidereal rate
 //  DesiredSteps = desired number of calibration steps
 //  Declination = declination in degrees

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -663,7 +663,8 @@ bool GuideCamera::ConnectCamera(GuideCamera *camera, const wxString& cameraId)
     if (camera->HasFrameLimiting)
     {
         // restore the saved limit frame (if any)
-        camera->LoadLimitFrame(camera->Binning);
+        int binning = camera->Binning;
+        camera->LoadLimitFrame(binning);
     }
     return err;
 }
@@ -733,7 +734,7 @@ bool GuideCamera::SetBinning(int binning)
     if (HasFrameLimiting)
     {
         // restore the saved limit frame for this binning (if any)
-        LoadLimitFrame(Binning);
+        LoadLimitFrame(binning);
     }
 
     return false;

--- a/src/gear_simulator.cpp
+++ b/src/gear_simulator.cpp
@@ -1229,6 +1229,8 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
     }
 # endif // STEPGUIDER_SIMULATOR
 
+    int binning = pCamera->Binning;
+
     // render each star
     if (!pCamera->ShutterClosed)
     {
@@ -1239,7 +1241,7 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
             double noise = (double) (rand() % (gain * 100));
             double inten = star + dark + noise;
 
-            render_star(img, pCamera->Binning, subframe, cc[i], inten);
+            render_star(img, binning, subframe, cc[i], inten);
         }
 
 # ifndef SIM_FILE_DISPLACEMENTS
@@ -1256,7 +1258,7 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
             double noise = (double) (rand() % (gain * 100));
             inten = star + dark + noise;
 
-            render_comet(img, pCamera->Binning, subframe, wxRealPoint(cx, cy), inten);
+            render_comet(img, binning, subframe, wxRealPoint(cx, cy), inten);
         }
 # endif
     }
@@ -1268,8 +1270,8 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
     for (unsigned int i = 0; i < hotpx.size(); i++)
     {
         wxPoint p(hotpx[i]);
-        p.x /= pCamera->Binning;
-        p.y /= pCamera->Binning;
+        p.x /= binning;
+        p.y /= binning;
         if (subframe.Contains(p))
             set_pixel(img, p.x, p.y, (unsigned short) -1);
     }

--- a/src/guide_algorithm.cpp
+++ b/src/guide_algorithm.cpp
@@ -72,10 +72,12 @@ double GuideAlgorithm::SmartDefaultMinMove()
 {
     try
     {
-        double focalLength = pFrame->GetFocalLength();
+        auto focalLength = pFrame->GetFocalLength();
         if (focalLength != 0)
         {
-            return GuideAlgorithm::SmartDefaultMinMove(focalLength, pCamera->GetCameraPixelSize(), pCamera->Binning);
+            int binning = pCamera->Binning;
+            auto pixelSize = pCamera->GetCameraPixelSize();
+            return GuideAlgorithm::SmartDefaultMinMove(focalLength, pixelSize, binning);
         }
         else
             return 0.2;

--- a/src/guider_multistar.cpp
+++ b/src/guider_multistar.cpp
@@ -1315,8 +1315,9 @@ void GuiderMultiStar::SaveStarFITS()
         hdr.write("DATE", wxDateTime::UNow(), wxDateTime::UTC, "file creation time, UTC");
         hdr.write("DATE-OBS", pImage->ImgStartTime, wxDateTime::UTC, "image capture start time, UTC");
         hdr.write("EXPOSURE", (float) pImage->ImgExpDur / 1000.0f, "Exposure time [s]");
-        hdr.write("XBINNING", (unsigned int) pCamera->Binning, "Camera X binning");
-        hdr.write("YBINNING", (unsigned int) pCamera->Binning, "Camera Y binning");
+        unsigned int binning = pCamera->Binning;
+        hdr.write("XBINNING", binning, "Camera X binning");
+        hdr.write("YBINNING", binning, "Camera Y binning");
         hdr.write("XORGSUB", start_x, "Subframe x position in binned pixels");
         hdr.write("YORGSUB", start_y, "Subframe y position in binned pixels");
 

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -2830,10 +2830,14 @@ wxString MyFrame::GetDefaultFileDir()
 
 double MyFrame::GetCameraPixelScale() const
 {
-    if (!pCamera || pCamera->GetCameraPixelSize() == 0.0 || m_focalLength == 0)
+    if (!pCamera)
+        return 1.0;
+    auto pixelSize = pCamera->GetCameraPixelSize();
+    if (pixelSize == 0.0 || m_focalLength == 0)
         return 1.0;
 
-    return GetPixelScale(pCamera->GetCameraPixelSize(), m_focalLength, pCamera->Binning);
+    int binning = pCamera->Binning;
+    return GetPixelScale(pixelSize, m_focalLength, binning);
 }
 
 wxString MyFrame::PixelScaleSummary() const
@@ -2851,7 +2855,8 @@ wxString MyFrame::PixelScaleSummary() const
     else
         focalLengthStr = wxString::Format("%d mm", m_focalLength);
 
-    return wxString::Format("Pixel scale = %s, Binning = %hu, Focal length = %s", scaleStr, pCamera->Binning, focalLengthStr);
+    int binning = pCamera->Binning;
+    return wxString::Format("Pixel scale = %s, Binning = %d, Focal length = %s", scaleStr, binning, focalLengthStr);
 }
 
 bool MyFrame::GetBeepForLostStar()

--- a/src/stepguider.cpp
+++ b/src/stepguider.cpp
@@ -757,7 +757,7 @@ bool StepGuider::UpdateCalibrationState(const PHD_Point& currentLocation)
             m_calibration.rotatorAngle = Rotator::RotatorPosition();
             m_calibration.binning = pCamera->Binning;
             SetCalibration(m_calibration);
-            SetCalibrationDetails(m_calibrationDetails, m_calibration.xAngle, m_calibration.yAngle, pCamera->Binning);
+            SetCalibrationDetails(m_calibrationDetails, m_calibration.xAngle, m_calibration.yAngle, m_calibration.binning);
             status0 = _("Calibration complete");
             GuideLog.CalibrationComplete(this);
             Debug.Write("Calibration Complete\n");


### PR DESCRIPTION
code cleanup: use local variables for pCamera->Binning

In preparation for adding software binning #738, getting the current binning
value is going to be a method call, not longer a direct member variable
access.

This PR will simplify the following PRs by storing the binning value
in a local variable rather than repeatedly accessing pCamera->Binning.

Other variables in the vicinity of the change--like focal length and
pixel scale--are also stored in local variables to make the code slightly
more concise and readable.
