### PR TITLE
Add accessor method for GuideCamera::Binning

### DIFF
--- a/src/advanced_dialog.cpp
+++ b/src/advanced_dialog.cpp
@@ -610,7 +610,7 @@ double AdvancedDialog::PercentChange(double oldVal, double newVal)
 // cleared, MinMoves are set to defaults based on new image scale
 void AdvancedDialog::MakeImageScaleAdjustments()
 {
-    int binning = pCamera->Binning;
+    auto binning = pCamera->GetBinning();
     auto focalLength = pFrame->GetFocalLength();
     auto pixelSize = pCamera->GetCameraPixelSize();
     double guideSpeedX;

--- a/src/calibration_assistant.cpp
+++ b/src/calibration_assistant.cpp
@@ -338,7 +338,7 @@ void CalibrationAssistant::PerformSanityChecks(void)
     }
     else
     {
-        int binning = pCamera->Binning;
+        auto binning = pCamera->GetBinning();
         auto focalLength = pFrame->GetFocalLength();
         auto pixelSize = pCamera->GetCameraPixelSize();
         int recDistance = CalstepDialog::GetCalibrationDistance(focalLength, pixelSize, binning);
@@ -1200,7 +1200,7 @@ void CalAssistSanityDialog::OnRecal(wxCommandEvent& evt)
                     minSpd = raSpd;
                 double sidrate = RateX(minSpd);
                 int calibrationStep;
-                int binning = pCamera->Binning;
+                auto binning = pCamera->GetBinning();
                 auto focalLength = pFrame->GetFocalLength();
                 auto pixelSize = pCamera->GetCameraPixelSize();
                 int recDistance = CalstepDialog::GetCalibrationDistance(focalLength, pixelSize, binning);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -663,7 +663,7 @@ bool GuideCamera::ConnectCamera(GuideCamera *camera, const wxString& cameraId)
     if (camera->HasFrameLimiting)
     {
         // restore the saved limit frame (if any)
-        int binning = camera->Binning;
+        auto binning = camera->GetBinning();
         camera->LoadLimitFrame(binning);
     }
     return err;
@@ -1064,7 +1064,7 @@ void CameraConfigDialogCtrlSet::LoadValues()
 
     if (m_binning)
     {
-        int idx = m_pCamera->Binning - 1;
+        int idx = m_pCamera->GetBinning() - 1;
         m_binning->Select(idx);
         m_prevBinning = idx + 1;
         // don't allow binning change when calibrating or guiding
@@ -1172,7 +1172,7 @@ void CameraConfigDialogCtrlSet::UnloadValues()
 
     if (m_binning)
     {
-        int oldBin = m_pCamera->Binning;
+        int oldBin = m_pCamera->GetBinning();
         int newBin = m_binning->GetSelection() + 1;
         if (oldBin != newBin)
             pFrame->pAdvancedDialog->FlagImageScaleChange();
@@ -1449,7 +1449,7 @@ bool GuideCamera::Capture(GuideCamera *camera, int duration, usImage& img, int c
 {
     img.InitImgStartTime();
     img.LimitFrame = camera->LimitFrame;
-    img.Binning = camera->Binning;
+    img.Binning = camera->GetBinning();
     img.BitsPerPixel = camera->BitsPerPixel();
     img.Gain = camera->GuideCameraGain;
     img.ImgExpDur = duration;

--- a/src/camera.h
+++ b/src/camera.h
@@ -180,6 +180,7 @@ public:
 
     static void GetBinningOpts(int maxBin, wxArrayString *opts);
     void GetBinningOpts(wxArrayString *opts);
+    int GetBinning() const;
     bool SetBinning(int binning);
     bool SetLimitFrame(const wxRect& roi, int binning, wxString *errorMessage);
     void LoadLimitFrame(int binning);
@@ -246,6 +247,12 @@ inline int GuideCamera::GetTimeoutMs() const
 inline void GuideCamera::GetBinningOpts(wxArrayString *opts)
 {
     GetBinningOpts(MaxHwBinning, opts);
+}
+
+// get the combined binning level -- hardware and software binning
+inline int GuideCamera::GetBinning() const
+{
+    return Binning;
 }
 
 inline double GuideCamera::GetCameraPixelSize() const

--- a/src/eegg.cpp
+++ b/src/eegg.cpp
@@ -97,7 +97,7 @@ void MyFrame::OnEEGG(wxCommandEvent& evt)
             cal.pierSide = pPointingSource->SideOfPier();
             cal.raGuideParity = cal.decGuideParity = GUIDE_PARITY_UNCHANGED;
             cal.rotatorAngle = Rotator::RotatorPosition();
-            cal.binning = pCamera->Binning;
+            cal.binning = pCamera->GetBinning();
             cal.isValid = true;
 
             if (!pMount->IsCalibrated())

--- a/src/event_server.cpp
+++ b/src/event_server.cpp
@@ -1406,7 +1406,7 @@ static void capture_single_frame(JObj& response, const json_value *params)
         exposure = j->int_value;
     }
 
-    wxByte binning = pCamera->Binning;
+    wxByte binning = pCamera->GetBinning();
     if ((j = p.param("binning")) != nullptr)
     {
         if (j->type != JSON_INT || j->int_value < 1 || j->int_value > pCamera->MaxHwBinning)
@@ -1770,7 +1770,7 @@ static void get_camera_binning(JObj& response, const json_value *params)
 {
     if (pCamera && pCamera->Connected)
     {
-        int binning = pCamera->Binning;
+        int binning = pCamera->GetBinning();
         response << jrpc_result(binning);
     }
     else

--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1100,7 +1100,7 @@ bool GearDialog::DoConnectCamera(bool autoReconnecting)
 
         Debug.Write(wxString::Format("Connecting to camera [%s] id = [%s]\n", newCam, cameraId));
 
-        int profileBinning = m_pCamera->Binning;
+        int profileBinning = m_pCamera->GetBinning();
         if (GuideCamera::ConnectCamera(m_pCamera, cameraId))
         {
             throw THROW_INFO("DoConnectCamera: connect failed");

--- a/src/guide_algorithm.cpp
+++ b/src/guide_algorithm.cpp
@@ -75,7 +75,7 @@ double GuideAlgorithm::SmartDefaultMinMove()
         auto focalLength = pFrame->GetFocalLength();
         if (focalLength != 0)
         {
-            int binning = pCamera->Binning;
+            auto binning = pCamera->GetBinning();
             auto pixelSize = pCamera->GetCameraPixelSize();
             return GuideAlgorithm::SmartDefaultMinMove(focalLength, pixelSize, binning);
         }

--- a/src/guider_multistar.cpp
+++ b/src/guider_multistar.cpp
@@ -1315,7 +1315,7 @@ void GuiderMultiStar::SaveStarFITS()
         hdr.write("DATE", wxDateTime::UNow(), wxDateTime::UTC, "file creation time, UTC");
         hdr.write("DATE-OBS", pImage->ImgStartTime, wxDateTime::UTC, "image capture start time, UTC");
         hdr.write("EXPOSURE", (float) pImage->ImgExpDur / 1000.0f, "Exposure time [s]");
-        unsigned int binning = pCamera->Binning;
+        auto binning = pCamera->GetBinning();
         hdr.write("XBINNING", binning, "Camera X binning");
         hdr.write("YBINNING", binning, "Camera Y binning");
         hdr.write("XORGSUB", start_x, "Subframe x position in binned pixels");

--- a/src/guiding_assistant.cpp
+++ b/src/guiding_assistant.cpp
@@ -1156,7 +1156,7 @@ void GuidingAsstWin::GetMinMoveRecs(double& RecRA, double& RecDec)
 
     int lastInx = m_decAxisStats.GetCount() - 1;
     auto pxscale = pFrame->GetCameraPixelScale();
-    int binning = pCamera->Binning;
+    auto binning = pCamera->GetBinning();
     auto focalLength = pFrame->GetFocalLength();
     auto pixelSize = pCamera->GetCameraPixelSize();
     StarDisplacement val = m_decAxisStats.GetEntry(0);
@@ -1385,7 +1385,7 @@ void GuidingAsstWin::MakeRecommendations()
     m_exposure_msg = AddRecommendationMsg(msg);
     Debug.Write(wxString::Format("Recommendation: %s\n", msg));
     // Binning opportunity if image scale is < 0.5
-    if (pxscale <= 0.5 && pCamera->Binning == 1 && pCamera->MaxHwBinning > 1)
+    if (pxscale <= 0.5 && pCamera->GetBinning() == 1 && pCamera->MaxHwBinning > 1)
     {
         wxString msg = _("Try binning your guide camera");
         allRecommendations += "Bin:" + msg + "\n";

--- a/src/mount.cpp
+++ b/src/mount.cpp
@@ -1255,7 +1255,7 @@ void Mount::AdjustCalibrationForScopePointing()
     double newDeclination = pPointingSource->GetDeclinationRadians();
     PierSide newPierSide = pPointingSource->SideOfPier();
     double newRotatorAngle = Rotator::RotatorPosition();
-    unsigned short binning = pCamera->Binning;
+    unsigned short binning = pCamera->GetBinning();
 
     Debug.AddLine(wxString::Format(
         "AdjustCalibrationForScopePointing (%s): current dec=%s pierSide=%d, cal dec=%s pierSide=%d rotAngle=%s bin=%hu",

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -2836,7 +2836,7 @@ double MyFrame::GetCameraPixelScale() const
     if (pixelSize == 0.0 || m_focalLength == 0)
         return 1.0;
 
-    int binning = pCamera->Binning;
+    auto binning = pCamera->GetBinning();
     return GetPixelScale(pixelSize, m_focalLength, binning);
 }
 
@@ -2855,7 +2855,7 @@ wxString MyFrame::PixelScaleSummary() const
     else
         focalLengthStr = wxString::Format("%d mm", m_focalLength);
 
-    int binning = pCamera->Binning;
+    int binning = pCamera->GetBinning();
     return wxString::Format("Pixel scale = %s, Binning = %d, Focal length = %s", scaleStr, binning, focalLengthStr);
 }
 

--- a/src/myframe_events.cpp
+++ b/src/myframe_events.cpp
@@ -426,7 +426,7 @@ bool SingleExposure::Activate(int duration, wxByte binning, int gain, const wxRe
 
     this->duration = duration;
 
-    prev_binning = pCamera->Binning;
+    prev_binning = pCamera->GetBinning();
     error = pCamera->SetBinning(binning);
     if (error)
         return false;
@@ -473,7 +473,7 @@ void SingleExposure::Complete(bool succeeded, const wxString& errorMsgArg)
 
     EvtServer.NotifySingleFrameComplete(succeeded, errorMsg, *this);
 
-    if (pCamera->Binning != prev_binning)
+    if (pCamera->GetBinning() != prev_binning)
         pCamera->SetBinning(prev_binning);
     if (pCamera->GuideCameraGain != prev_gain)
         pCamera->SetCameraGain(prev_gain);

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -997,7 +997,7 @@ void Scope::CheckCalibrationDuration(int currDuration)
     CalibrationDetails calDetails;
     LoadCalibrationDetails(&calDetails);
 
-    int binning = pCamera->Binning;
+    auto binning = pCamera->GetBinning();
     bool binningChange = binning != calDetails.origBinning;
 
     // if binning changed, may need to update the calibration distance
@@ -1756,7 +1756,7 @@ bool Scope::UpdateCalibrationState(const PHD_Point& currentLocation)
             cal.declination = pPointingSource->GetDeclinationRadians();
             cal.pierSide = pPointingSource->SideOfPier();
             cal.rotatorAngle = Rotator::RotatorPosition();
-            cal.binning = pCamera->Binning;
+            cal.binning = pCamera->GetBinning();
             SetCalibration(cal);
             m_calibrationDetails.raStepCount = m_raSteps;
             m_calibrationDetails.decStepCount = m_decSteps;

--- a/src/statswindow.cpp
+++ b/src/statswindow.cpp
@@ -327,7 +327,7 @@ void StatsWindow::UpdateScopePointing()
         m_grid2->SetCellValue(row++, col, Mount::DeclinationStrTr(declination, "% .1f" DEGREES_SYMBOL));
         m_grid2->SetCellValue(row++, col, Mount::PierSideStrTr(pierSide));
         m_grid2->SetCellValue(row++, col, RotatorPosStr());
-        m_grid2->SetCellValue(row++, col, pCamera ? wxString::Format("%hu", pCamera->Binning) : _("N/A"));
+        m_grid2->SetCellValue(row++, col, pCamera ? wxString::Format("%d", pCamera->GetBinning()) : _("N/A"));
         m_grid2->EndBatch();
     }
 }

--- a/src/stepguider.cpp
+++ b/src/stepguider.cpp
@@ -755,7 +755,7 @@ bool StepGuider::UpdateCalibrationState(const PHD_Point& currentLocation)
             m_calibration.pierSide = PIER_SIDE_UNKNOWN;
             m_calibration.raGuideParity = m_calibration.decGuideParity = GUIDE_PARITY_UNKNOWN;
             m_calibration.rotatorAngle = Rotator::RotatorPosition();
-            m_calibration.binning = pCamera->Binning;
+            m_calibration.binning = pCamera->GetBinning();
             SetCalibration(m_calibration);
             SetCalibrationDetails(m_calibrationDetails, m_calibration.xAngle, m_calibration.yAngle, m_calibration.binning);
             status0 = _("Calibration complete");
@@ -1315,7 +1315,7 @@ void StepGuider::AdjustCalibrationForScopePointing()
 {
     // compensate for binning change
 
-    unsigned short binning = pCamera->Binning;
+    unsigned short binning = pCamera->GetBinning();
 
     if (binning == m_calibration.binning)
     {


### PR DESCRIPTION
Add accessor method for GuideCamera::Binning

Update callers to get binning from new accessor method GetBinning()
rather than from the Binning member variable.

This is a step towards implementing software binning #738, as the final
binning value will be a combination of the hardware and software
binning values.

No functional changes in this commit.
