### PR TITLE
GuideCamera::Capture CaptureParams argument

### DIFF
--- a/src/cam_INovaPLC.cpp
+++ b/src/cam_INovaPLC.cpp
@@ -123,8 +123,11 @@ bool CameraINovaPLC::Disconnect()
     return false;
 }
 
-bool CameraINovaPLC::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraINovaPLC::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     int xsize = FrameSize.GetWidth();
     int ysize = FrameSize.GetHeight();
     DS_CAMERA_STATUS rval;

--- a/src/cam_INovaPLC.h
+++ b/src/cam_INovaPLC.h
@@ -43,7 +43,7 @@ class CameraINovaPLC : public GuideCamera
 public:
     CameraINovaPLC();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
     bool Connect(const wxString& camId) override;

--- a/src/cam_KWIQGuider.cpp
+++ b/src/cam_KWIQGuider.cpp
@@ -50,7 +50,7 @@ class CameraKWIQGuider : public GuideCamera
 
 public:
     CameraKWIQGuider();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool ST4PulseGuideScope(int direction, int duration) override;
@@ -117,8 +117,11 @@ bool CameraKWIQGuider::ST4PulseGuideScope(int direction, int duration)
     return false;
 }
 
-bool CameraKWIQGuider::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraKWIQGuider::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     int xsize = FrameSize.GetWidth();
     int ysize = FrameSize.GetHeight();
 

--- a/src/cam_LEwebcam.cpp
+++ b/src/cam_LEwebcam.cpp
@@ -82,8 +82,11 @@ bool CameraLEWebcam::Disconnect()
     return bError;
 }
 
-bool CameraLEWebcam::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraLEWebcam::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     bool bError = false;
 
     try
@@ -120,19 +123,19 @@ bool CameraLEWebcam::Capture(int duration, usImage& img, int options, const wxRe
         // now record the frame.
         // Start by grabbing three frames
         usImage frame1;
-        if (CaptureOneFrame(frame1, options, subframe))
+        if (CaptureOneFrame(frame1, options))
         {
             throw ERROR_INFO("CaptureOneFrame(frame1) failed");
         }
 
         usImage frame2;
-        if (CaptureOneFrame(frame2, options, subframe))
+        if (CaptureOneFrame(frame2, options))
         {
             throw ERROR_INFO("CaptureOneFrame(frame2) failed");
         }
 
         usImage frame3;
-        if (CaptureOneFrame(frame3, options, subframe))
+        if (CaptureOneFrame(frame3, options))
         {
             throw ERROR_INFO("CaptureOneFrame(frame3) failed");
         }

--- a/src/cam_MeadeDSI.cpp
+++ b/src/cam_MeadeDSI.cpp
@@ -59,7 +59,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
     bool Connect(const wxString& camId) override;
@@ -185,8 +185,11 @@ bool CameraDSI::GetDevicePixelSize(double *devPixelSize)
     return false; // Pixel sizes are hard-coded
 }
 
-bool CameraDSI::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraDSI::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     MeadeCam->SetGain((unsigned int) (GuideCameraGain * 63 / 100));
     MeadeCam->SetExposureTime(duration);
 

--- a/src/cam_NebSBIG.cpp
+++ b/src/cam_NebSBIG.cpp
@@ -70,8 +70,11 @@ bool CameraNebSBIG::Disconnect()
     return false;
 }
 
-bool CameraNebSBIG::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraNebSBIG::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     if (img.Init(FrameSize))
     {
         DisconnectWithAlert(CAPT_FAIL_MEMORY);

--- a/src/cam_NebSBIG.h
+++ b/src/cam_NebSBIG.h
@@ -40,7 +40,7 @@ class CameraNebSBIG : public GuideCamera
 {
 public:
     CameraNebSBIG();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
     bool Connect(const wxString& camId) override;

--- a/src/cam_OSPL130.cpp
+++ b/src/cam_OSPL130.cpp
@@ -69,8 +69,11 @@ bool CameraOpticstarPL130::Disconnect()
     return false;
 }
 
-bool CameraOpticstarPL130::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraOpticstarPL130::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     bool still_going = true;
 
     int mode = 3 * (int) Color;

--- a/src/cam_OSPL130.h
+++ b/src/cam_OSPL130.h
@@ -41,7 +41,7 @@ class CameraOpticstarPL130 : public GuideCamera
 public:
     CameraOpticstarPL130();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     wxByte BitsPerPixel() override;

--- a/src/cam_StarShootDSCI.cpp
+++ b/src/cam_StarShootDSCI.cpp
@@ -151,8 +151,10 @@ bool CameraStarShootDSCI::Connect(const wxString& camId)
     return false;
 }
 
-bool CameraStarShootDSCI::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraStarShootDSCI::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+
     bool ampoff = true;
     if (duration < 1000)
         ampoff = false;

--- a/src/cam_StarShootDSCI.h
+++ b/src/cam_StarShootDSCI.h
@@ -55,7 +55,7 @@ class CameraStarShootDSCI : public GuideCamera
 
 public:
     CameraStarShootDSCI();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool HasNonGuiCapture() override { return true; }

--- a/src/cam_altair.cpp
+++ b/src/cam_altair.cpp
@@ -150,7 +150,7 @@ struct AltairCamera : public GuideCamera
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -522,8 +522,11 @@ void __stdcall CameraCallback(unsigned int event, void *pCallbackCtx)
 //     }
 // }
 
-bool AltairCamera::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool AltairCamera::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     if (img.Init(FrameSize))
     {
         DisconnectWithAlert(CAPT_FAIL_MEMORY);

--- a/src/cam_ascom.cpp
+++ b/src/cam_ascom.cpp
@@ -73,7 +73,7 @@ public:
     CameraASCOM(const wxString& choice);
     ~CameraASCOM();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
@@ -977,11 +977,14 @@ bool CameraASCOM::AbortExposure()
     }
 }
 
-bool CameraASCOM::Capture(int duration, usImage& img, int options, const wxRect& subframeArg)
+bool CameraASCOM::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     bool retval = false;
     bool takeSubframe = UseSubframes;
-    wxRect roi(subframeArg);
+    wxRect roi(captureParams.subframe);
 
     if (roi.width <= 0 || roi.height <= 0)
     {

--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -56,7 +56,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
@@ -290,8 +290,12 @@ static bool StopCapture(ArtemisHandle h)
     return ret == ARTEMIS_OK;
 }
 
-bool CameraAtik16::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool useSubframe = UseSubframes;
 
     if (subframe.width <= 0 || subframe.height <= 0)

--- a/src/cam_firewire.h
+++ b/src/cam_firewire.h
@@ -59,7 +59,7 @@ public:
     CameraFirewire();
     ~CameraFirewire();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
     bool Connect(const wxString& camId) override;

--- a/src/cam_firewire_IC.cpp
+++ b/src/cam_firewire_IC.cpp
@@ -400,8 +400,11 @@ void CameraFirewire::InitCapture()
     }
 }
 
-bool CameraFirewire::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraFirewire::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     static int programmed_dur = 200;
 
     int xsize = FrameSize.GetWidth();

--- a/src/cam_firewire_OSX.cpp
+++ b/src/cam_firewire_OSX.cpp
@@ -269,8 +269,11 @@ bool CameraFirewire::Disconnect()
     return false;
 }
 
-bool CameraFirewire::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraFirewire::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     static int programmed_dur = 1000;
     wxStopWatch swatch;
 

--- a/src/cam_indi.cpp
+++ b/src/cam_indi.cpp
@@ -181,7 +181,7 @@ public:
     bool GetDevicePixelSize(double *pixSize) override;
     void ShowPropertyDialog() override;
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
 
     bool ST4PulseGuideScope(int direction, int duration) override;
     bool ST4HasNonGuiMove() override;
@@ -983,13 +983,15 @@ void CameraINDI::SendBinning()
     m_curBinning = Binning;
 }
 
-bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& subframeArg)
+bool CameraINDI::Capture(usImage& img, const CaptureParams& captureParams)
 {
     if (!Connected)
         return true;
 
     bool takeSubframe = UseSubframes;
-    wxRect subframe(subframeArg);
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    wxRect subframe(captureParams.subframe);
 
     // we can set the exposure time directly in the camera
     if (expose_prop && !INDICameraForceVideo)
@@ -1101,7 +1103,7 @@ bool CameraINDI::Capture(int duration, usImage& img, int options, const wxRect& 
                         wxString::Format(_("Camera  %s, exposure error. Trying to use streaming instead."), INDICameraName));
                     INDICameraForceVideo = true;
                     first_frame = false;
-                    return Capture(duration, img, options, subframeArg);
+                    return Capture(img, captureParams);
                 }
                 else
                 {

--- a/src/cam_moravian.cpp
+++ b/src/cam_moravian.cpp
@@ -345,7 +345,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -786,8 +786,12 @@ bool MoravianCamera::GetSensorTemperature(double *temperature)
     return false;
 }
 
-bool MoravianCamera::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool MoravianCamera::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     unsigned int new_gain = cam_gain(0, m_maxGain, GuideCameraGain);
     if (new_gain != m_curGain)
     {

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -250,7 +250,7 @@ public:
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
-    bool Capture(int duration, usImage&, int, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool ST4HasGuideOutput() override;
@@ -515,8 +515,12 @@ inline static int round_up(int v, int m)
     return round_down(v + m - 1, m);
 }
 
-bool CameraOgma::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraOgma::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
     if (Binning != m_cam.m_curBin)

--- a/src/cam_opencv.cpp
+++ b/src/cam_opencv.cpp
@@ -114,8 +114,10 @@ bool CameraOpenCV::Disconnect()
     return false;
 }
 
-bool CameraOpenCV::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraOpenCV::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+
     bool bError = false;
 
     try

--- a/src/cam_opencv.h
+++ b/src/cam_opencv.h
@@ -50,7 +50,7 @@ public:
     CameraOpenCV(int devNumber);
     ~CameraOpenCV();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool HasNonGuiCapture() override { return true; }

--- a/src/cam_openssag.cpp
+++ b/src/cam_openssag.cpp
@@ -168,8 +168,11 @@ bool CameraOpenSSAG::Disconnect()
     return false;
 }
 
-bool CameraOpenSSAG::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraOpenSSAG::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     if (img.Init(FrameSize))
     {
         DisconnectWithAlert(CAPT_FAIL_MEMORY);

--- a/src/cam_openssag.h
+++ b/src/cam_openssag.h
@@ -47,7 +47,7 @@ class CameraOpenSSAG : public GuideCamera
 public:
     CameraOpenSSAG();
     ~CameraOpenSSAG();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool ST4PulseGuideScope(int direction, int duration) override;

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -78,7 +78,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -706,8 +706,12 @@ static void flush_buffered_image(int cameraId, void *buf, size_t size)
     }
 }
 
-bool PlayerOneCamera::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool PlayerOneCamera::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool binning_change = false;
     if (Binning != m_prevBinning)
     {

--- a/src/cam_qguide.cpp
+++ b/src/cam_qguide.cpp
@@ -141,9 +141,12 @@ static bool StopExposure()
     return true;
 }
 
-bool CameraQGuider::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraQGuider::Capture(usImage& img, const CaptureParams& captureParams)
 {
     // Only does full frames still
+
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
 
     unsigned short *dptr;
     bool firstimg = true;

--- a/src/cam_qguide.h
+++ b/src/cam_qguide.h
@@ -43,7 +43,7 @@ class CameraQGuider : public GuideCamera
 public:
     CameraQGuider();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void InitCapture() override;

--- a/src/cam_qhy.cpp
+++ b/src/cam_qhy.cpp
@@ -108,7 +108,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -931,8 +931,12 @@ inline static int round_up(int v, int m)
 // stopping capture causes problems on some cameras on Windows, disable it for now until we can test with a newer SDK
 // #define CAN_STOP_CAPTURE
 
-bool Camera_QHY::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool Camera_QHY::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
     if (Binning != m_curBin)

--- a/src/cam_qhy5.cpp
+++ b/src/cam_qhy5.cpp
@@ -189,8 +189,11 @@ bool CameraQHY5::Disconnect()
     return false;
 }
 
-bool CameraQHY5::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraQHY5::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     // Only does full frames still
     // static int last_dur = 0;
     static int last_gain = 60;

--- a/src/cam_qhy5.h
+++ b/src/cam_qhy5.h
@@ -43,7 +43,7 @@ class CameraQHY5 : public GuideCamera
 public:
     CameraQHY5();
     ~CameraQHY5();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void InitCapture() override;

--- a/src/cam_sbig.cpp
+++ b/src/cam_sbig.cpp
@@ -65,7 +65,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool HandleSelectCameraButtonClick(wxCommandEvent& evt) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void InitCapture() override;
@@ -457,8 +457,12 @@ static bool StopExposure(EndExposureParams *eep)
     return err == CE_NO_ERROR;
 }
 
-bool CameraSBIG::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraSBIG::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool TakeSubframe = UseSubframes;
 
     FrameSize = m_imageSize[Binning - 1];

--- a/src/cam_sbigrotator.cpp
+++ b/src/cam_sbigrotator.cpp
@@ -50,7 +50,7 @@ public:
     CameraSBIGRotator();
     ~CameraSBIGRotator();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool ST4PulseGuideScope(int direction, int duration) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
@@ -141,9 +141,9 @@ bool CameraSBIGRotator::Disconnect()
     return false;
 }
 
-bool CameraSBIGRotator::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraSBIGRotator::Capture(usImage& img, const CaptureParams& captureParams)
 {
-    bool bError = m_pSubcamera->Capture(duration, img, options, subframe);
+    bool bError = m_pSubcamera->Capture(img, captureParams);
 
     img.Rotate(m_raAngle, m_mirror);
 

--- a/src/cam_skyraider.cpp
+++ b/src/cam_skyraider.cpp
@@ -58,7 +58,7 @@ struct SkyraiderCamera : public GuideCamera
     SkyraiderCamera();
     ~SkyraiderCamera();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -187,8 +187,11 @@ bool SkyraiderCamera::Disconnect()
     return false;
 }
 
-bool SkyraiderCamera::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool SkyraiderCamera::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     if (img.Init(FrameSize))
     {
         DisconnectWithAlert(CAPT_FAIL_MEMORY);

--- a/src/cam_sspiag.cpp
+++ b/src/cam_sspiag.cpp
@@ -350,8 +350,11 @@ bool CameraSSPIAG::Disconnect()
     return false;
 }
 
-bool CameraSSPIAG::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraSSPIAG::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     // Only does full frames still
     static int last_dur = 0;
     static int last_gain = 60;

--- a/src/cam_sspiag.h
+++ b/src/cam_sspiag.h
@@ -42,7 +42,7 @@ class CameraSSPIAG : public GuideCamera
     unsigned char *RawBuffer;
 
 public:
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void InitCapture() override;

--- a/src/cam_starfish.cpp
+++ b/src/cam_starfish.cpp
@@ -54,7 +54,7 @@ class CameraStarfish : public GuideCamera
 public:
     CameraStarfish();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void InitCapture() override;
@@ -229,8 +229,12 @@ static bool StopExposure(int camNum)
     return ret == kIOReturnSuccess;
 }
 
-bool CameraStarfish::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraStarfish::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool debug = true;
     int xsize, ysize, xpos, ypos;
     bool usingSubFrames = UseSubframes && subframe.GetWidth() > 0 && subframe.GetHeight() > 0;

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -71,7 +71,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -583,8 +583,12 @@ static void flush_buffered_image(int cameraId, void *buf, size_t size)
     }
 }
 
-bool SVBCamera::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool SVBCamera::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool binning_change = false;
     if (Binning != m_prevBinning)
     {

--- a/src/cam_sxv.cpp
+++ b/src/cam_sxv.cpp
@@ -75,7 +75,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void ShowPropertyDialog() override;
@@ -762,10 +762,13 @@ static bool ReadPixels(sxccd_handle_t sxHandle, unsigned short *pixels, unsigned
     return true;
 }
 
-bool CameraSXV::Capture(int duration, usImage& img, int options, const wxRect& subframeArg)
+bool CameraSXV::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     bool takeSubframe = UseSubframes;
-    wxRect subframe(subframeArg);
+    wxRect subframe(captureParams.subframe);
 
     if (subframe.width <= 0 || subframe.height <= 0)
     {

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -251,7 +251,7 @@ public:
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
     bool HasNonGuiCapture() override;
     wxByte BitsPerPixel() override;
-    bool Capture(int duration, usImage&, int, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool ST4HasGuideOutput() override;
@@ -523,8 +523,12 @@ inline static int round_up(int v, int m)
     return round_down(v + m - 1, m);
 }
 
-bool CameraToupTek::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraToupTek::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
     if (Binning != m_cam.m_curBin)

--- a/src/cam_vfw.cpp
+++ b/src/cam_vfw.cpp
@@ -133,8 +133,11 @@ bool CameraVFW::Disconnect()
     return false;
 }
 
-bool CameraVFW::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraVFW::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     int xsize, ysize;
     int NFrames = 0;
     xsize = FrameSize.GetWidth();

--- a/src/cam_vfw.h
+++ b/src/cam_vfw.h
@@ -44,7 +44,7 @@ class CameraVFW : public GuideCamera
 
 public:
     CameraVFW();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void ShowPropertyDialog() override;

--- a/src/cam_wdm.cpp
+++ b/src/cam_wdm.cpp
@@ -461,8 +461,11 @@ void CameraWDM::EndCapture()
     }
 }
 
-bool CameraWDM::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraWDM::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
     bool bError = false;
 
     try
@@ -493,7 +496,7 @@ bool CameraWDM::Capture(int duration, usImage& img, int options, const wxRect& s
     return bError;
 }
 
-bool CameraWDM::CaptureOneFrame(usImage& img, int options, const wxRect& subframe)
+bool CameraWDM::CaptureOneFrame(usImage& img, int options)
 {
     bool bError = false;
 

--- a/src/cam_wdm_base.h
+++ b/src/cam_wdm_base.h
@@ -85,8 +85,8 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool HandleSelectCameraButtonClick(wxCommandEvent& evt);
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
-    bool CaptureOneFrame(usImage& img, int options, const wxRect& subframe);
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
+    bool CaptureOneFrame(usImage& img, int options);
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void ShowPropertyDialog() override;
@@ -130,7 +130,7 @@ public:
     CameraLEWebcam();
     ~CameraLEWebcam();
 
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     bool HasNonGuiCapture() override { return true; }

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -79,7 +79,7 @@ public:
 
     bool CanSelectCamera() const override { return true; }
     bool EnumCameras(wxArrayString& names, wxArrayString& ids) override;
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
 
@@ -754,8 +754,12 @@ inline static void copy_rect_16bit(usImage& img, const unsigned char *buffer, co
     }
 }
 
-bool Camera_ZWO::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
 {
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+    const wxRect& subframe = captureParams.subframe;
+
     bool binning_change = false;
     if (Binning != m_prevBinning)
     {

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1445,15 +1445,15 @@ void GuideCamera::DisconnectWithAlert(const wxString& msg, ReconnectType reconne
 
 void GuideCamera::InitCapture() { }
 
-bool GuideCamera::Capture(GuideCamera *camera, int duration, usImage& img, int captureOptions, const wxRect& subframe)
+bool GuideCamera::Capture(GuideCamera *camera, usImage& img, const CaptureParams& captureParams)
 {
     img.InitImgStartTime();
-    img.LimitFrame = camera->LimitFrame;
-    img.Binning = camera->GetBinning();
-    img.BitsPerPixel = camera->BitsPerPixel();
-    img.Gain = camera->GuideCameraGain;
-    img.ImgExpDur = duration;
-    bool err = camera->Capture(duration, img, captureOptions, subframe);
+    img.LimitFrame = captureParams.limitFrame;
+    img.Binning = captureParams.hwBinning;
+    img.BitsPerPixel = captureParams.bpp;
+    img.Gain = captureParams.gain;
+    img.ImgExpDur = captureParams.duration;
+    bool err = camera->Capture(img, captureParams);
     return err;
 }
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -104,6 +104,20 @@ enum CaptureOptionBits
     CAPTURE_BPM_REVIEW = CAPTURE_SUBTRACT_DARK | CAPTURE_IGNORE_FRAME_LIMIT,
 };
 
+struct CaptureParams
+{
+    wxRect subframe;
+    wxRect limitFrame;
+    int duration;
+    int gain;
+    int captureOptions;
+    wxByte hwBinning;
+    wxByte bpp;
+
+    // combined binning level - hardware + software
+    int CombinedBinning() const { return hwBinning; }
+};
+
 class GuideCamera : public wxMessageBoxProxy, public OnboardST4
 {
     friend class CameraConfigDialogPane;
@@ -150,11 +164,7 @@ public:
     virtual bool HasNonGuiCapture() = 0;
     virtual wxByte BitsPerPixel() = 0;
 
-    static bool Capture(GuideCamera *camera, int duration, usImage& img, int captureOptions, const wxRect& subframe);
-    static bool Capture(GuideCamera *camera, int duration, usImage& img, int captureOptions)
-    {
-        return Capture(camera, duration, img, captureOptions, wxRect(0, 0, 0, 0));
-    }
+    static bool Capture(GuideCamera *camera, usImage& img, const CaptureParams& capture);
 
     virtual bool CanSelectCamera() const { return false; }
     virtual bool HandleSelectCameraButtonClick(wxCommandEvent& evt);
@@ -217,7 +227,7 @@ public:
     bool SetCameraGain(int cameraGain);
     virtual int GetDefaultCameraGain();
 
-    virtual bool Capture(int duration, usImage& img, int captureOptions, const wxRect& subframe) = 0;
+    virtual bool Capture(usImage& img, const CaptureParams& captureParams) = 0;
 
 protected:
     int GetTimeoutMs() const;

--- a/src/darks_dialog.cpp
+++ b/src/darks_dialog.cpp
@@ -513,7 +513,13 @@ bool DarksDialog::CreateMasterDarkFrame(usImage& darkFrame, int expTime, int fra
         ShowStatus(wxString::Format(_("Taking dark frame %d/%d"), j, frameCount), true);
 
         Debug.Write(wxString::Format("Capture dark frame %d/%d exp=%d\n", j, frameCount, expTime));
-        err = GuideCamera::Capture(pCamera, expTime, darkFrame, CAPTURE_DARK);
+        CaptureParams captureParams;
+        captureParams.duration = expTime;
+        captureParams.hwBinning = pCamera->Binning;
+        captureParams.bpp = pCamera->BitsPerPixel();
+        captureParams.gain = pCamera->GuideCameraGain;
+        captureParams.captureOptions = CAPTURE_DARK;
+        err = GuideCamera::Capture(pCamera, darkFrame, captureParams);
         if (err)
         {
             ShowStatus(wxString::Format(_("%.1f s dark FAILED"), (double) expTime / 1000.0), true);

--- a/src/gear_simulator.cpp
+++ b/src/gear_simulator.cpp
@@ -1284,7 +1284,7 @@ class CameraSimulator : public GuideCamera
 public:
     CameraSimulator();
     ~CameraSimulator();
-    bool Capture(int duration, usImage& img, int options, const wxRect& subframe) override;
+    bool Capture(usImage& img, const CaptureParams& captureParams) override;
     bool Connect(const wxString& camId) override;
     bool Disconnect() override;
     void ShowPropertyDialog() override;
@@ -1374,7 +1374,7 @@ CameraSimulator::~CameraSimulator()
 }
 
 # if SIMMODE == 2
-bool CameraSimulator::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraSimulator::Capture(usImage& img, const CaptureParams& captureParams)
 {
     int xsize, ysize;
     wxImage disk_image;
@@ -1422,9 +1422,12 @@ static void fill_noise(usImage& img, const wxRect& subframe, int exptime, int ga
 }
 # endif // SIMMODE == 3
 
-bool CameraSimulator::Capture(int duration, usImage& img, int options, const wxRect& subframeArg)
+bool CameraSimulator::Capture(usImage& img, const CaptureParams& captureParams)
 {
-    wxRect subframe(subframeArg);
+    int duration = captureParams.duration;
+    int options = captureParams.captureOptions;
+
+    wxRect subframe(captureParams.subframe);
     CameraWatchdog watchdog(duration, GetTimeoutMs());
 
     // sleep before rendering the image so that any changes made in the middle of a long exposure (e.g. manual guide pulse)
@@ -1630,7 +1633,7 @@ void CameraSimulator::FlipPierSide()
 }
 
 # if SIMMODE == 4
-bool CameraSimulator::Capture(int duration, usImage& img, int options, const wxRect& subframe)
+bool CameraSimulator::Capture(usImage& img, const CaptureParams& captureParams)
 {
     int xsize, ysize;
     //  unsigned short *dataptr;

--- a/src/worker_thread.h
+++ b/src/worker_thread.h
@@ -59,9 +59,7 @@ class MyFrame;
 struct EXPOSE_REQUEST
 {
     usImage *pImage;
-    int exposureDuration;
-    int options;
-    wxRect subframe;
+    CaptureParams captureParams;
     bool error;
     wxSemaphore *pSemaphore;
 };
@@ -180,7 +178,7 @@ protected:
 
     /*************      Expose      **************************/
 public:
-    void EnqueueWorkerThreadExposeRequest(usImage *pImage, int exposureDuration, int exposureOptions, const wxRect& subframe);
+    void EnqueueWorkerThreadExposeRequest(usImage *pImage, const CaptureParams& captureParams);
     void SetSkipExposeComplete();
 
 protected:


### PR DESCRIPTION
GuideCamera::Capture CaptureParams argument

Update GuideCamera::Capture method replacing individual capture parameter arguments
with a struct wrapping all the capture parameters.

This will make it easier to transform the arguments for software binning #738.

No functional changes in this PR - just the arguments structure refactor.
