### PR TITLE
De-Bayering conditional on combined binning level

### DIFF
--- a/src/cam_MeadeDSI.cpp
+++ b/src/cam_MeadeDSI.cpp
@@ -247,7 +247,7 @@ bool CameraDSI::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_RECON)
     {
-        if (MeadeCam->IsColor)
+        if (MeadeCam->IsColor && captureParams.CombinedBinning() == 1)
             QuickLRecon(img);
         if (MeadeCam->IsDsiII)
             SquarePixels(img, 8.6, 8.3);

--- a/src/cam_OSPL130.cpp
+++ b/src/cam_OSPL130.cpp
@@ -108,7 +108,7 @@ bool CameraOpticstarPL130::Capture(usImage& img, const CaptureParams& capturePar
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (Color && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_altair.cpp
+++ b/src/cam_altair.cpp
@@ -629,7 +629,7 @@ bool AltairCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_isColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_ascom.cpp
+++ b/src/cam_ascom.cpp
@@ -1104,7 +1104,7 @@ bool CameraASCOM::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (Color && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -409,7 +409,7 @@ bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
     // Do quick L recon to remove bayer array
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (Color && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_indi.cpp
+++ b/src/cam_indi.cpp
@@ -1131,10 +1131,10 @@ bool CameraINDI::Capture(usImage& img, const CaptureParams& captureParams)
                 delete frame;
                 if (options & CAPTURE_SUBTRACT_DARK)
                     SubtractDark(img);
-                if (HasBayer && Binning == 1 && (options & CAPTURE_RECON))
-                    QuickLRecon(img);
                 if (options & CAPTURE_RECON)
                 {
+                    if (HasBayer && captureParams.CombinedBinning() == 1)
+                        QuickLRecon(img);
                     if (PixSizeX != PixSizeY)
                         SquarePixels(img, PixSizeX, PixSizeY);
                 }

--- a/src/cam_moravian.cpp
+++ b/src/cam_moravian.cpp
@@ -921,7 +921,7 @@ bool MoravianCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_isColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -709,7 +709,7 @@ bool CameraOgma::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_cam.m_isColor && binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_cam.m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -962,7 +962,7 @@ bool PlayerOneCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_isColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_qhy.cpp
+++ b/src/cam_qhy.cpp
@@ -1205,7 +1205,7 @@ bool Camera_QHY::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (Color && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_sbig.cpp
+++ b/src/cam_sbig.cpp
@@ -625,7 +625,7 @@ bool CameraSBIG::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (IsColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && IsColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_sspiag.cpp
+++ b/src/cam_sspiag.cpp
@@ -401,7 +401,7 @@ bool CameraSSPIAG::Capture(usImage& img, const CaptureParams& captureParams)
         SubtractDark(img);
 
     // Do quick L recon to remove bayer array
-    if (options & CAPTURE_RECON)
+    if ((options & CAPTURE_RECON) && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -818,7 +818,7 @@ bool SVBCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_isColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -717,7 +717,7 @@ bool CameraToupTek::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_cam.m_isColor && binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_cam.m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -1014,7 +1014,7 @@ bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if (m_isColor && Binning == 1 && (options & CAPTURE_RECON))
+    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;


### PR DESCRIPTION
De-Bayering conditional on combined binning level

When deciding whether to de-Bayer a camera frame, use the
combined hardware+software binning level rather than just the
hardware binning.

The de-bayering is unneeded when software binning #738 is in effect.
