### PR TITLE
Rename GuideCamera's Binning member variable to HwBinning

### DIFF
--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -186,14 +186,14 @@ bool CameraAtik16::Connect(const wxString& camId)
     int maxbinx = 1, maxbiny = 1;
     ArtemisGetMaxBin(Cam_Handle, &maxbinx, &maxbiny);
     MaxHwBinning = wxMin(maxbinx, maxbiny);
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
-    FrameSize = wxSize(m_properties.nPixelsX / Binning, m_properties.nPixelsY / Binning);
+    FrameSize = wxSize(m_properties.nPixelsX / HwBinning, m_properties.nPixelsY / HwBinning);
 
-    ArtemisBin(Cam_Handle, Binning, Binning);
+    ArtemisBin(Cam_Handle, HwBinning, HwBinning);
     ArtemisSubframe(Cam_Handle, 0, 0, m_properties.nPixelsX, m_properties.nPixelsY);
-    m_curBin = Binning;
+    m_curBin = HwBinning;
 
     char devname[64];
     ArtemisDeviceName(devnum, devname);
@@ -301,11 +301,11 @@ bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
     if (subframe.width <= 0 || subframe.height <= 0)
         useSubframe = false;
 
-    if (m_curBin != Binning)
+    if (m_curBin != HwBinning)
     {
-        FrameSize = wxSize(m_properties.nPixelsX / Binning, m_properties.nPixelsY / Binning);
-        ArtemisBin(Cam_Handle, Binning, Binning);
-        m_curBin = Binning;
+        FrameSize = wxSize(m_properties.nPixelsX / HwBinning, m_properties.nPixelsY / HwBinning);
+        ArtemisBin(Cam_Handle, HwBinning, HwBinning);
+        m_curBin = HwBinning;
         useSubframe = false; // subframe may be out of bounds now
     }
 
@@ -323,25 +323,25 @@ bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
     {
         // Round height up to next multiple of 2 to workaround bug where the camera returns incorrect data when the subframe
         // height is odd.
-        int w = subframe.width * Binning;
-        int x = subframe.x * Binning;
+        int w = subframe.width * HwBinning;
+        int x = subframe.x * HwBinning;
         if (w & 1)
         {
-            w += Binning;
+            w += HwBinning;
             if (x + w > m_properties.nPixelsX)
-                x -= Binning;
+                x -= HwBinning;
         }
-        int h = subframe.height * Binning;
-        int y = subframe.y * Binning;
+        int h = subframe.height * HwBinning;
+        int y = subframe.y * HwBinning;
         if (h & 1)
         {
-            h += Binning;
+            h += HwBinning;
             if (y + h > m_properties.nPixelsY)
-                y -= Binning;
+                y -= HwBinning;
         }
         frame = wxRect(x, y, w, h);
-        subframePos.x = subframe.x - x / Binning;
-        subframePos.y = subframe.y - y / Binning;
+        subframePos.x = subframe.x - x / HwBinning;
+        subframePos.y = subframe.y - y / HwBinning;
         ArtemisSubframe(Cam_Handle, x, y, w, h);
     }
     else
@@ -391,7 +391,7 @@ bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
         img.Clear();
         const unsigned short *buf = (unsigned short *) ArtemisImageBuffer(Cam_Handle);
 
-        int w_binned = frame.width / Binning;
+        int w_binned = frame.width / HwBinning;
         for (int y = 0; y < subframe.height; y++)
         {
             const unsigned short *src = buf + (y + subframePos.y) * w_binned + subframePos.x;

--- a/src/cam_moravian.cpp
+++ b/src/cam_moravian.cpp
@@ -670,16 +670,16 @@ bool MoravianCamera::Connect(const wxString& camId)
 
     MaxHwBinning = std::min(maxbinx, maxbiny);
 
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
     m_maxSize = m_cam.ChipSize();
 
-    FrameSize.x = m_maxSize.x / Binning;
-    FrameSize.y = m_maxSize.y / Binning;
-    m_curBinning = Binning;
+    FrameSize.x = m_maxSize.x / HwBinning;
+    FrameSize.y = m_maxSize.y / HwBinning;
+    m_curBinning = HwBinning;
 
-    if (!m_cam.SetBinning(Binning))
+    if (!m_cam.SetBinning(HwBinning))
     {
         wxString err = m_cam.LastError();
         Disconnect();
@@ -801,17 +801,17 @@ bool MoravianCamera::Capture(usImage& img, const CaptureParams& captureParams)
         m_curGain = new_gain;
     }
 
-    if (Binning != m_curBinning)
+    if (HwBinning != m_curBinning)
     {
-        if (!m_cam.SetBinning(Binning))
+        if (!m_cam.SetBinning(HwBinning))
         {
-            Debug.Write(wxString::Format("MVN: SetBinning(%u): %s\n", Binning, m_cam.LastError()));
+            Debug.Write(wxString::Format("MVN: SetBinning(%u): %s\n", HwBinning, m_cam.LastError()));
             return true;
         }
-        Debug.Write(wxString::Format("MVN: SetBinning(%u): ok\n", Binning));
-        FrameSize.x = m_maxSize.x / Binning;
-        FrameSize.y = m_maxSize.y / Binning;
-        m_curBinning = Binning;
+        Debug.Write(wxString::Format("MVN: SetBinning(%u): ok\n", HwBinning));
+        FrameSize.x = m_maxSize.x / HwBinning;
+        FrameSize.y = m_maxSize.y / HwBinning;
+        m_curBinning = HwBinning;
     }
 
     if (img.Init(FrameSize))

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -373,15 +373,15 @@ bool CameraOgma::Connect(const wxString& camIdArg)
             Disconnect();
             return CamConnectFailed(_("Failed to initialize camera binning."));
         }
-        m_cam.SetBinning(Binning);
+        m_cam.SetBinning(HwBinning);
     }
     else
     {
         // hardware binning
-        if (!m_cam.SetBinning(Binning))
+        if (!m_cam.SetBinning(HwBinning))
         {
-            Binning = 1;
-            if (!m_cam.SetBinning(Binning))
+            HwBinning = 1;
+            if (!m_cam.SetBinning(HwBinning))
             {
                 Disconnect();
                 return CamConnectFailed(_("Failed to initialize camera binning."));
@@ -389,8 +389,8 @@ bool CameraOgma::Connect(const wxString& camIdArg)
         }
     }
 
-    FrameSize.x = m_cam.m_maxSize.x / Binning;
-    FrameSize.y = m_cam.m_maxSize.y / Binning;
+    FrameSize.x = m_cam.m_maxSize.x / HwBinning;
+    FrameSize.y = m_cam.m_maxSize.y / HwBinning;
 
     size_t buffer_size = m_cam.m_maxSize.x * m_cam.m_maxSize.y;
     if (m_cam.m_bpp != 8)
@@ -523,12 +523,12 @@ bool CameraOgma::Capture(usImage& img, const CaptureParams& captureParams)
 
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
-    if (Binning != m_cam.m_curBin)
+    if (HwBinning != m_cam.m_curBin)
     {
-        if (m_cam.SetBinning(Binning))
+        if (m_cam.SetBinning(HwBinning))
         {
-            FrameSize.x = m_cam.m_maxSize.x / Binning;
-            FrameSize.y = m_cam.m_maxSize.y / Binning;
+            FrameSize.x = m_cam.m_maxSize.x / HwBinning;
+            FrameSize.y = m_cam.m_maxSize.y / HwBinning;
             useSubframe = false; // subframe pos is now invalid
         }
     }

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -456,14 +456,14 @@ bool PlayerOneCamera::Connect(const wxString& camId)
     }
     MaxHwBinning = maxBin;
 
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
     m_maxSize.x = info.maxWidth;
     m_maxSize.y = info.maxHeight;
 
-    FrameSize = BinnedFrameSize(Binning);
-    m_prevBinning = Binning;
+    FrameSize = BinnedFrameSize(HwBinning);
+    m_prevBinning = HwBinning;
 
     ::free(m_buffer);
     m_buffer_size = info.maxWidth * info.maxHeight * (m_bpp == 8 ? 1 : 2);
@@ -557,7 +557,7 @@ bool PlayerOneCamera::Connect(const wxString& camId)
     m_frame = wxRect(FrameSize);
     Debug.Write(wxString::Format("Player One: frame (%d,%d)+(%d,%d)\n", m_frame.x, m_frame.y, m_frame.width, m_frame.height));
 
-    POASetImageBin(m_cameraId, Binning);
+    POASetImageBin(m_cameraId, HwBinning);
     POASetImageStartPos(m_cameraId, m_frame.GetLeft(), m_frame.GetTop());
     POASetImageSize(m_cameraId, m_frame.GetWidth(), m_frame.GetHeight());
     POASetImageFormat(m_cameraId, m_bpp == 8 ? POA_RAW8 : POA_RAW16);
@@ -713,10 +713,10 @@ bool PlayerOneCamera::Capture(usImage& img, const CaptureParams& captureParams)
     const wxRect& subframe = captureParams.subframe;
 
     bool binning_change = false;
-    if (Binning != m_prevBinning)
+    if (HwBinning != m_prevBinning)
     {
-        FrameSize = BinnedFrameSize(Binning);
-        m_prevBinning = Binning;
+        FrameSize = BinnedFrameSize(HwBinning);
+        m_prevBinning = HwBinning;
         binning_change = true;
     }
 
@@ -782,9 +782,9 @@ bool PlayerOneCamera::Capture(usImage& img, const CaptureParams& captureParams)
     {
         StopCapture();
 
-        POAErrors status = POASetImageBin(m_cameraId, Binning);
+        POAErrors status = POASetImageBin(m_cameraId, HwBinning);
         if (status != POA_OK)
-            Debug.Write(wxString::Format("Player One: setImageBin(%hu) => %d\n", Binning, status));
+            Debug.Write(wxString::Format("Player One: setImageBin(%hu) => %d\n", HwBinning, status));
 
         status = POASetImageSize(m_cameraId, frame.GetWidth(), frame.GetHeight());
         if (status != POA_OK)

--- a/src/cam_qhy.cpp
+++ b/src/cam_qhy.cpp
@@ -830,21 +830,21 @@ bool Camera_QHY::Connect(const wxString& camId)
     }
     Debug.Write(wxString::Format("QHY: max binning = %d\n", maxBin));
     MaxHwBinning = maxBin;
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
-    Debug.Write(wxString::Format("QHY: call SetQHYCCDBinMode bin = %d\n", Binning));
-    ret = SetQHYCCDBinMode(m_camhandle, Binning, Binning);
+    Debug.Write(wxString::Format("QHY: call SetQHYCCDBinMode bin = %d\n", HwBinning));
+    ret = SetQHYCCDBinMode(m_camhandle, HwBinning, HwBinning);
     if (ret != QHYCCD_SUCCESS)
     {
         CloseQHYCCD(m_camhandle);
         m_camhandle = 0;
         return CamConnectFailed(_("Failed to set camera binning"));
     }
-    m_curBin = Binning;
+    m_curBin = HwBinning;
 
     m_maxSize = wxSize(imagew, imageh);
-    FrameSize = wxSize(imagew / Binning, imageh / Binning);
+    FrameSize = wxSize(imagew / HwBinning, imageh / HwBinning);
 
     delete[] RawBuffer;
     size_t size = GetQHYCCDMemLength(m_camhandle);
@@ -939,10 +939,10 @@ bool Camera_QHY::Capture(usImage& img, const CaptureParams& captureParams)
 
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
-    if (Binning != m_curBin)
+    if (HwBinning != m_curBin)
     {
-        FrameSize = wxSize(m_maxSize.GetX() / Binning, m_maxSize.GetY() / Binning);
-        m_curBin = Binning;
+        FrameSize = wxSize(m_maxSize.GetX() / HwBinning, m_maxSize.GetY() / HwBinning);
+        m_curBin = HwBinning;
         useSubframe = false; // subframe may be out of bounds now
     }
 
@@ -979,7 +979,7 @@ bool Camera_QHY::Capture(usImage& img, const CaptureParams& captureParams)
 
     uint32_t ret = QHYCCD_ERROR;
     // lzr from QHY says this needs to be set for every exposure
-    ret = SetQHYCCDBinMode(m_camhandle, Binning, Binning);
+    ret = SetQHYCCDBinMode(m_camhandle, HwBinning, HwBinning);
     if (ret != QHYCCD_SUCCESS)
     {
         Debug.Write(wxString::Format("SetQHYCCDBinMode failed! ret = %d\n", (int) ret));

--- a/src/cam_sbig.cpp
+++ b/src/cam_sbig.cpp
@@ -395,10 +395,10 @@ bool CameraSBIG::Connect(const wxString& camId)
         }
     }
 
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
-    FrameSize = m_imageSize[Binning - 1];
+    FrameSize = m_imageSize[HwBinning - 1];
 
     IsColor = false;
 
@@ -465,7 +465,7 @@ bool CameraSBIG::Capture(usImage& img, const CaptureParams& captureParams)
 
     bool TakeSubframe = UseSubframes;
 
-    FrameSize = m_imageSize[Binning - 1];
+    FrameSize = m_imageSize[HwBinning - 1];
 
     if (subframe.width <= 0 || subframe.height <= 0 || subframe.GetRight() >= FrameSize.GetWidth() ||
         subframe.GetBottom() >= FrameSize.GetHeight())
@@ -499,7 +499,7 @@ bool CameraSBIG::Capture(usImage& img, const CaptureParams& captureParams)
 
     sep.exposureTime = (unsigned long) duration / 10;
     sep.openShutter = ShutterClosed ? SC_CLOSE_SHUTTER : SC_OPEN_SHUTTER;
-    sep.readoutMode = rlp.readoutMode = dlp.readoutMode = Binning == 1 ? RM_1X1 : RM_2X2;
+    sep.readoutMode = rlp.readoutMode = dlp.readoutMode = HwBinning == 1 ? RM_1X1 : RM_2X2;
 
     if (TakeSubframe)
     {

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -411,15 +411,15 @@ bool SVBCamera::Connect(const wxString& camId)
     }
     MaxHwBinning = maxBin;
 
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
     m_maxSize.x = props.MaxWidth;
     m_maxSize.y = props.MaxHeight;
 
-    FrameSize.x = m_maxSize.x / Binning;
-    FrameSize.y = m_maxSize.y / Binning;
-    m_prevBinning = Binning;
+    FrameSize.x = m_maxSize.x / HwBinning;
+    FrameSize.y = m_maxSize.y / HwBinning;
+    m_prevBinning = HwBinning;
 
     ::free(m_buffer);
     m_buffer_size = props.MaxWidth * props.MaxHeight * (m_bpp == 8 ? 1 : 2);
@@ -503,7 +503,7 @@ bool SVBCamera::Connect(const wxString& camId)
 
     SVBSetOutputImageType(m_cameraId, img_type);
 
-    SVBSetROIFormat(m_cameraId, m_frame.GetLeft(), m_frame.GetTop(), m_frame.GetWidth(), m_frame.GetHeight(), Binning);
+    SVBSetROIFormat(m_cameraId, m_frame.GetLeft(), m_frame.GetTop(), m_frame.GetWidth(), m_frame.GetHeight(), HwBinning);
 
     return false;
 }
@@ -590,11 +590,11 @@ bool SVBCamera::Capture(usImage& img, const CaptureParams& captureParams)
     const wxRect& subframe = captureParams.subframe;
 
     bool binning_change = false;
-    if (Binning != m_prevBinning)
+    if (HwBinning != m_prevBinning)
     {
-        FrameSize.x = m_maxSize.x / Binning;
-        FrameSize.y = m_maxSize.y / Binning;
-        m_prevBinning = Binning;
+        FrameSize.x = m_maxSize.x / HwBinning;
+        FrameSize.y = m_maxSize.y / HwBinning;
+        m_prevBinning = HwBinning;
         binning_change = true;
     }
 
@@ -661,11 +661,11 @@ bool SVBCamera::Capture(usImage& img, const CaptureParams& captureParams)
         StopCapture();
 
         SVB_ERROR_CODE status =
-            SVBSetROIFormat(m_cameraId, frame.GetLeft(), frame.GetTop(), frame.GetWidth(), frame.GetHeight(), Binning);
+            SVBSetROIFormat(m_cameraId, frame.GetLeft(), frame.GetTop(), frame.GetWidth(), frame.GetHeight(), HwBinning);
 
         if (status != SVB_SUCCESS)
             Debug.Write(wxString::Format("SVB: setImageFormat(%d,%d,%d,%d,%hu) => %d\n", frame.GetLeft(), frame.GetTop(),
-                                         frame.GetWidth(), frame.GetHeight(), Binning, status));
+                                         frame.GetWidth(), frame.GetHeight(), HwBinning, status));
     }
 
     int poll = wxMin(duration, 100);

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -374,15 +374,15 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
             Disconnect();
             return CamConnectFailed(_("Failed to initialize camera binning."));
         }
-        m_cam.SetBinning(Binning);
+        m_cam.SetBinning(HwBinning);
     }
     else
     {
         // hardware binning
-        if (!m_cam.SetBinning(Binning))
+        if (!m_cam.SetBinning(HwBinning))
         {
-            Binning = 1;
-            if (!m_cam.SetBinning(Binning))
+            HwBinning = 1;
+            if (!m_cam.SetBinning(HwBinning))
             {
                 Disconnect();
                 return CamConnectFailed(_("Failed to initialize camera binning."));
@@ -390,8 +390,8 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
         }
     }
 
-    FrameSize.x = m_cam.m_maxSize.x / Binning;
-    FrameSize.y = m_cam.m_maxSize.y / Binning;
+    FrameSize.x = m_cam.m_maxSize.x / HwBinning;
+    FrameSize.y = m_cam.m_maxSize.y / HwBinning;
 
     size_t buffer_size = m_cam.m_maxSize.x * m_cam.m_maxSize.y;
     if (m_cam.m_bpp != 8)
@@ -531,12 +531,12 @@ bool CameraToupTek::Capture(usImage& img, const CaptureParams& captureParams)
 
     bool useSubframe = UseSubframes && !subframe.IsEmpty();
 
-    if (Binning != m_cam.m_curBin)
+    if (HwBinning != m_cam.m_curBin)
     {
-        if (m_cam.SetBinning(Binning))
+        if (m_cam.SetBinning(HwBinning))
         {
-            FrameSize.x = m_cam.m_maxSize.x / Binning;
-            FrameSize.y = m_cam.m_maxSize.y / Binning;
+            FrameSize.x = m_cam.m_maxSize.x / HwBinning;
+            FrameSize.y = m_cam.m_maxSize.y / HwBinning;
             useSubframe = false; // subframe pos is now invalid
         }
     }

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -467,14 +467,14 @@ bool Camera_ZWO::Connect(const wxString& camId)
     }
     MaxHwBinning = maxBin;
 
-    if (Binning > MaxHwBinning)
-        Binning = MaxHwBinning;
+    if (HwBinning > MaxHwBinning)
+        HwBinning = MaxHwBinning;
 
     m_maxSize.x = info.MaxWidth;
     m_maxSize.y = info.MaxHeight;
 
-    FrameSize = BinnedFrameSize(Binning);
-    m_prevBinning = Binning;
+    FrameSize = BinnedFrameSize(HwBinning);
+    m_prevBinning = HwBinning;
 
     ::free(m_buffer);
     m_buffer_size = info.MaxWidth * info.MaxHeight * (m_bpp == 8 ? 1 : 2);
@@ -565,7 +565,7 @@ bool Camera_ZWO::Connect(const wxString& camId)
     Debug.Write(wxString::Format("ZWO: frame (%d,%d)+(%d,%d)\n", m_frame.x, m_frame.y, m_frame.width, m_frame.height));
 
     ASISetStartPos(m_cameraId, m_frame.GetLeft(), m_frame.GetTop());
-    ASISetROIFormat(m_cameraId, m_frame.GetWidth(), m_frame.GetHeight(), Binning, m_bpp == 8 ? ASI_IMG_RAW8 : ASI_IMG_RAW16);
+    ASISetROIFormat(m_cameraId, m_frame.GetWidth(), m_frame.GetHeight(), HwBinning, m_bpp == 8 ? ASI_IMG_RAW8 : ASI_IMG_RAW16);
 
     ASIStopExposure(m_cameraId);
     ASIStopVideoCapture(m_cameraId);
@@ -615,7 +615,7 @@ bool Camera_ZWO::GetDevicePixelSize(double *devPixelSize)
 
 wxSize Camera_ZWO::DarkFrameSize()
 {
-    return BinnedFrameSize(Binning);
+    return BinnedFrameSize(HwBinning);
 }
 
 int Camera_ZWO::GetDefaultCameraGain()
@@ -761,16 +761,16 @@ bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
     const wxRect& subframe = captureParams.subframe;
 
     bool binning_change = false;
-    if (Binning != m_prevBinning)
+    if (HwBinning != m_prevBinning)
     {
-        m_prevBinning = Binning;
+        m_prevBinning = HwBinning;
         binning_change = true;
     }
 
     wxRect const limit_frame = options & CAPTURE_IGNORE_FRAME_LIMIT ? wxRect() : LimitFrame;
 
     // always update the frame size in case the limit frame or binning changed
-    wxSize const binned_frame_size(BinnedFrameSize(Binning));
+    wxSize const binned_frame_size(BinnedFrameSize(HwBinning));
     if (limit_frame.IsEmpty())
         FrameSize = binned_frame_size;
     else
@@ -843,11 +843,11 @@ bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
     {
         StopCapture();
 
-        ASI_ERROR_CODE status = ASISetROIFormat(m_cameraId, frame.GetWidth(), frame.GetHeight(), Binning,
+        ASI_ERROR_CODE status = ASISetROIFormat(m_cameraId, frame.GetWidth(), frame.GetHeight(), HwBinning,
                                                 m_bpp == 8 ? ASI_IMG_RAW8 : ASI_IMG_RAW16);
         if (status != ASI_SUCCESS)
-            Debug.Write(wxString::Format("ZWO: setImageFormat(%d,%d,%hu) => %d\n", frame.GetWidth(), frame.GetHeight(), Binning,
-                                         status));
+            Debug.Write(wxString::Format("ZWO: setImageFormat(%d,%d,%hu) => %d\n", frame.GetWidth(), frame.GetHeight(),
+                                         HwBinning, status));
     }
 
     if (pos_change)

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -223,7 +223,7 @@ GuideCamera::GuideCamera()
     m_saturationByADU = pConfig->Profile.GetBoolean("/camera/SaturationByADU", true);
     m_pixelSize = GetProfilePixelSize();
     MaxHwBinning = 1;
-    Binning = pConfig->Profile.GetInt("/camera/binning", 1);
+    HwBinning = pConfig->Profile.GetInt("/camera/binning", 1);
     CurrentDarkFrame = nullptr;
     CurrentDefectMap = nullptr;
 }
@@ -727,7 +727,7 @@ bool GuideCamera::SetBinning(int binning)
 
     Debug.Write(wxString::Format("camera: set binning = %u\n", (unsigned int) binning));
 
-    Binning = binning;
+    HwBinning = binning;
     pConfig->Profile.SetInt("/camera/binning", binning);
 
     // if a Limit Frame ROI is in use, adjust it for the new binning

--- a/src/camera.h
+++ b/src/camera.h
@@ -144,7 +144,7 @@ public:
     bool HasSubframes;
     bool HasFrameLimiting;
     wxByte MaxHwBinning; // max hardware binning level
-    wxByte Binning;
+    wxByte HwBinning;
     bool ShutterClosed; // false=light, true=dark
     bool UseSubframes;
     bool HasCooler;
@@ -262,7 +262,7 @@ inline void GuideCamera::GetBinningOpts(wxArrayString *opts)
 // get the combined binning level -- hardware and software binning
 inline int GuideCamera::GetBinning() const
 {
-    return Binning;
+    return HwBinning;
 }
 
 inline double GuideCamera::GetCameraPixelSize() const

--- a/src/darks_dialog.cpp
+++ b/src/darks_dialog.cpp
@@ -515,7 +515,7 @@ bool DarksDialog::CreateMasterDarkFrame(usImage& darkFrame, int expTime, int fra
         Debug.Write(wxString::Format("Capture dark frame %d/%d exp=%d\n", j, frameCount, expTime));
         CaptureParams captureParams;
         captureParams.duration = expTime;
-        captureParams.hwBinning = pCamera->Binning;
+        captureParams.hwBinning = pCamera->HwBinning;
         captureParams.bpp = pCamera->BitsPerPixel();
         captureParams.gain = pCamera->GuideCameraGain;
         captureParams.captureOptions = CAPTURE_DARK;

--- a/src/gear_simulator.cpp
+++ b/src/gear_simulator.cpp
@@ -1229,7 +1229,7 @@ void SimCamState::FillImage(usImage& img, const wxRect& subframe, int exptime, i
     }
 # endif // STEPGUIDER_SIMULATOR
 
-    int binning = pCamera->Binning;
+    int binning = pCamera->HwBinning;
 
     // render each star
     if (!pCamera->ShutterClosed)
@@ -1456,8 +1456,8 @@ bool CameraSimulator::Capture(usImage& img, const CaptureParams& captureParams)
 
 # else
 
-    int width = sim.width / Binning;
-    int height = sim.height / Binning;
+    int width = sim.width / HwBinning;
+    int height = sim.height / HwBinning;
     FrameSize = wxSize(width, height);
 
     bool usingSubframe = UseSubframes;
@@ -1511,7 +1511,7 @@ bool CameraSimulator::ST4PulseGuideScope(int direction, int duration)
 {
     // Following must take into account how the render_star function works.  Render_star uses camera binning explicitly, so
     // relying only on image scale in computing d creates distances that are too small by a factor of <binning>
-    double d = SimCamParams::guide_rate * Binning * duration / (1000.0 * SimCamParams::image_scale);
+    double d = SimCamParams::guide_rate * HwBinning * duration / (1000.0 * SimCamParams::image_scale);
 
     // simulate RA motion scaling according to declination
     if (direction == WEST || direction == EAST)

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -1713,7 +1713,7 @@ void MyFrame::ScheduleExposure()
     CaptureParams captureParams;
     captureParams.duration = RequestedExposureDuration();
     captureParams.subframe = m_singleExposure.enabled ? m_singleExposure.subframe : pGuider->GetBoundingBox();
-    captureParams.hwBinning = pCamera->Binning;
+    captureParams.hwBinning = pCamera->HwBinning;
     captureParams.bpp = pCamera->BitsPerPixel();
     captureParams.limitFrame = pCamera->LimitFrame;
     captureParams.gain = pCamera->GuideCameraGain;


### PR DESCRIPTION
Rename GuideCamera's Binning member variable to HwBinning

In preparation for introducing software binning #738, rename Binning to
HwBinning to distinguish it from software binning.

No functional changes, just the rename.
