### PR TITLE
GuideCamera HasBayer property

### DIFF
--- a/src/cam_MeadeDSI.cpp
+++ b/src/cam_MeadeDSI.cpp
@@ -151,6 +151,9 @@ bool CameraDSI::Connect(const wxString& camId)
 
         MeadeCam->SetOffset(255);
         MeadeCam->SetFastReadoutSpeed(true);
+
+        HasBayer = MeadeCam->IsColor;
+
         Connected = true;
     }
 
@@ -247,7 +250,7 @@ bool CameraDSI::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_RECON)
     {
-        if (MeadeCam->IsColor && captureParams.CombinedBinning() == 1)
+        if (HasBayer && captureParams.CombinedBinning() == 1)
             QuickLRecon(img);
         if (MeadeCam->IsDsiII)
             SquarePixels(img, 8.6, 8.3);

--- a/src/cam_OSPL130.cpp
+++ b/src/cam_OSPL130.cpp
@@ -38,7 +38,6 @@ CameraOpticstarPL130::CameraOpticstarPL130()
     FrameSize = wxSize(1280, 1024);
     m_hasGuideOutput = false;
     HasGainControl = false;
-    Color = false;
 }
 
 wxByte CameraOpticstarPL130::BitsPerPixel()
@@ -53,7 +52,7 @@ bool CameraOpticstarPL130::Connect(const wxString& camId)
     if (!DLLExists("OSPL130RT.dll"))
         return CamConnectFailed(_("Cannot find OSPL130RT.dll"));
 
-    int retval = OSPL130_Initialize((int) Color, false, 0, 2);
+    int retval = OSPL130_Initialize((int) HasBayer, false, 0, 2);
     if (retval)
         return CamConnectFailed(_("Cannot init camera"));
 
@@ -76,7 +75,7 @@ bool CameraOpticstarPL130::Capture(usImage& img, const CaptureParams& capturePar
 
     bool still_going = true;
 
-    int mode = 3 * (int) Color;
+    int mode = 3 * (int) HasBayer;
     if (img.Init(FrameSize))
     {
         DisconnectWithAlert(CAPT_FAIL_MEMORY);
@@ -108,7 +107,7 @@ bool CameraOpticstarPL130::Capture(usImage& img, const CaptureParams& capturePar
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_OSPL130.h
+++ b/src/cam_OSPL130.h
@@ -36,8 +36,6 @@
 
 class CameraOpticstarPL130 : public GuideCamera
 {
-    bool Color;
-
 public:
     CameraOpticstarPL130();
 

--- a/src/cam_StarShootDSCI.cpp
+++ b/src/cam_StarShootDSCI.cpp
@@ -147,6 +147,9 @@ bool CameraStarShootDSCI::Connect(const wxString& camId)
     USB2 = OCP_isUSB2();
     RawX = OCP_Width();
     RawY = OCP_Height();
+
+    HasBayer = true;
+
     Connected = true;
     return false;
 }

--- a/src/cam_altair.cpp
+++ b/src/cam_altair.cpp
@@ -132,7 +132,6 @@ struct AltairCamera : public GuideCamera
     SDKLib m_sdk;
     wxRect m_frame;
     unsigned char *m_buffer;
-    bool m_isColor;
     bool m_capturing;
     unsigned int m_discardCnt;
     int m_minGain;
@@ -361,9 +360,9 @@ bool AltairCamera::Connect(const wxString& camIdArg)
     Name = pai->displayname;
     bool hasROI = (pai->model->flag & ALTAIRCAM_FLAG_ROI_HARDWARE) != 0;
     bool hasSkip = (pai->model->flag & ALTAIRCAM_FLAG_BINSKIP_SUPPORTED) != 0;
-    m_isColor = (pai->model->flag & ALTAIRCAM_FLAG_MONO) == 0;
+    HasBayer = (pai->model->flag & ALTAIRCAM_FLAG_MONO) == 0;
 
-    Debug.Write(wxString::Format("ALTAIR: isColor = %d, hasROI = %d, hasSkip = %d\n", m_isColor, hasROI, hasSkip));
+    Debug.Write(wxString::Format("ALTAIR: isColor = %d, hasROI = %d, hasSkip = %d\n", HasBayer, hasROI, hasSkip));
 
     int width, height;
     if (FAILED(m_sdk.get_Resolution(m_handle, 0, &width, &height)))
@@ -629,7 +628,7 @@ bool AltairCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_ascom.cpp
+++ b/src/cam_ascom.cpp
@@ -68,8 +68,6 @@ class CameraASCOM : public GuideCamera
     double m_driverPixelSize;
 
 public:
-    bool Color;
-
     CameraASCOM(const wxString& choice);
     ~CameraASCOM();
 
@@ -431,7 +429,6 @@ CameraASCOM::CameraASCOM(const wxString& choice)
     HasGainControl = false;
     HasSubframes = true;
     PropertyDialogType = PROPDLG_WHEN_DISCONNECTED;
-    Color = false;
     DriverVersion = 1;
     m_bitsPerPixel = 0;
 }
@@ -653,7 +650,7 @@ bool CameraASCOM::Connect(const wxString& camId)
     if (DriverVersion > 1 && // We can check the color sensor status of the cam
         driver.GetProp(&vRes, L"SensorType") && vRes.iVal > 1)
     {
-        Color = true;
+        HasBayer = true;
     }
 
     // Get pixel size in micons
@@ -1104,7 +1101,7 @@ bool CameraASCOM::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_atik16.cpp
+++ b/src/cam_atik16.cpp
@@ -64,7 +64,6 @@ public:
     bool ST4PulseGuideScope(int direction, int duration) override;
     wxByte BitsPerPixel() override;
 
-    bool Color;
     bool HSModel;
 
 private:
@@ -79,7 +78,7 @@ CameraAtik16::CameraAtik16(bool hsmodel, bool color) : m_dllLoaded(false)
     FrameSize = wxSize(1280, 1024);
     m_hasGuideOutput = true;
     HasGainControl = true;
-    Color = color;
+    HasBayer = color;
     Cam_Handle = NULL;
     HSModel = hsmodel;
     HasSubframes = true;
@@ -409,7 +408,7 @@ bool CameraAtik16::Capture(usImage& img, const CaptureParams& captureParams)
     // Do quick L recon to remove bayer array
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_indi.cpp
+++ b/src/cam_indi.cpp
@@ -133,7 +133,6 @@ private:
     double PixSizeY;
     wxSize m_maxSize;
     wxByte m_curBinning;
-    bool HasBayer;
     long INDIport;
     wxString INDIhost;
     wxString INDICameraName;

--- a/src/cam_moravian.cpp
+++ b/src/cam_moravian.cpp
@@ -335,7 +335,6 @@ class MoravianCamera : public GuideCamera
     bool m_canGuide;
     int m_maxGain;
     int m_defaultGainPct;
-    bool m_isColor;
     double m_devicePixelSize;
     int m_maxMoveMs;
 
@@ -658,8 +657,8 @@ bool MoravianCamera::Connect(const wxString& camId)
     bool rgb = m_cam.BoolParam(gbpRGB);
     bool cmy = m_cam.BoolParam(gbpCMY);
     bool cmyg = m_cam.BoolParam(gbpCMYG);
-    m_isColor = rgb || cmy || cmyg;
-    Debug.Write(wxString::Format("MVN: IsColorCam = %d  (rgb:%d cmy:%d cmyg:%d)\n", m_isColor, rgb, cmy, cmyg));
+    HasBayer = rgb || cmy || cmyg;
+    Debug.Write(wxString::Format("MVN: IsColorCam = %d  (rgb:%d cmy:%d cmyg:%d)\n", HasBayer, rgb, cmy, cmyg));
 
     int pxwidth = m_cam.IntParam(gipPixelW); // nm
     int pxheight = m_cam.IntParam(gipPixelD); // nm
@@ -921,7 +920,7 @@ bool MoravianCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -352,7 +352,7 @@ bool CameraOgma::Connect(const wxString& camIdArg)
 
     Name = info->displayname;
     HasSubframes = (info->model->flag & OGMACAM_FLAG_ROI_HARDWARE) != 0;
-    m_cam.m_isColor = (info->model->flag & OGMACAM_FLAG_MONO) == 0;
+    HasBayer = m_cam.m_isColor = (info->model->flag & OGMACAM_FLAG_MONO) == 0;
     HasCooler = (info->model->flag & OGMACAM_FLAG_TEC) != 0;
     m_cam.m_hasGuideOutput = (info->model->flag & OGMACAM_FLAG_ST4) != 0;
 
@@ -709,7 +709,7 @@ bool CameraOgma::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_cam.m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_playerone.cpp
+++ b/src/cam_playerone.cpp
@@ -69,7 +69,6 @@ class PlayerOneCamera : public GuideCamera
     int m_minGain;
     int m_maxGain;
     int m_defaultGainPct;
-    bool m_isColor;
     double m_devicePixelSize;
 
 public:
@@ -441,9 +440,9 @@ bool PlayerOneCamera::Connect(const wxString& camId)
     m_cameraId = selected;
     Connected = true;
     Name = info.cameraModelName;
-    m_isColor = info.isColorCamera != POA_FALSE;
+    HasBayer = info.isColorCamera != POA_FALSE;
 
-    Debug.Write(wxString::Format("Player One: isColorCamera = %d\n", m_isColor));
+    Debug.Write(wxString::Format("Player One: isColorCamera = %d\n", HasBayer));
 
     int maxBin = 1;
     for (int i = 0; i <= WXSIZEOF(info.bins); i++)
@@ -962,7 +961,7 @@ bool PlayerOneCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_qhy.cpp
+++ b/src/cam_qhy.cpp
@@ -88,7 +88,6 @@ class Camera_QHY : public GuideCamera
     wxSize m_maxSize;
     unsigned short m_curBin;
     wxRect m_roi;
-    bool Color;
     wxByte m_bpp;
     bool m_settingsChanged;
     bool m_hasAmpnr;
@@ -218,7 +217,7 @@ Camera_QHY::Camera_QHY()
     HasCooler = false;
 
     RawBuffer = 0;
-    Color = false;
+    HasBayer = false;
     HasSubframes = true;
     m_camhandle = 0;
 
@@ -787,14 +786,14 @@ bool Camera_QHY::Connect(const wxString& camId)
     int bayer = IsQHYCCDControlAvailable(m_camhandle, CAM_COLOR);
     Debug.Write(wxString::Format("QHY: cam reports bayer type %d\n", bayer));
 
-    Color = false;
+    HasBayer = false;
     switch ((BAYER_ID) bayer)
     {
     case BAYER_GB:
     case BAYER_GR:
     case BAYER_BG:
     case BAYER_RG:
-        Color = true;
+        HasBayer = true;
     }
 
     // check bin modes
@@ -1205,7 +1204,7 @@ bool Camera_QHY::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && Color && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_sspiag.cpp
+++ b/src/cam_sspiag.cpp
@@ -297,6 +297,8 @@ bool CameraSSPIAG::Connect(const wxString& camId)
     Q5V_SetQHY5VGlobalGain(60);
     Q5V_GetFullSizeImage(RawBuffer);
 
+    HasBayer = true;
+
     Connected = true;
     return false;
 }

--- a/src/cam_svb.cpp
+++ b/src/cam_svb.cpp
@@ -62,7 +62,6 @@ class SVBCamera : public GuideCamera
     int m_minGain;
     int m_maxGain;
     int m_defaultGainPct;
-    bool m_isColor;
     double m_devicePixelSize;
 
 public:
@@ -395,8 +394,8 @@ bool SVBCamera::Connect(const wxString& camId)
 
     Connected = true;
     Name = info.FriendlyName;
-    m_isColor = props.IsColorCam != SVB_FALSE;
-    Debug.Write(wxString::Format("SVB: IsColorCam = %d\n", m_isColor));
+    HasBayer = props.IsColorCam != SVB_FALSE;
+    Debug.Write(wxString::Format("SVB: IsColorCam = %d\n", HasBayer));
 
     HasShutter = false;
 
@@ -818,7 +817,7 @@ bool SVBCamera::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -353,7 +353,7 @@ bool CameraToupTek::Connect(const wxString& camIdArg)
 
     Name = info->displayname;
     HasSubframes = (info->model->flag & TOUPCAM_FLAG_ROI_HARDWARE) != 0;
-    m_cam.m_isColor = (info->model->flag & TOUPCAM_FLAG_MONO) == 0;
+    HasBayer = m_cam.m_isColor = (info->model->flag & TOUPCAM_FLAG_MONO) == 0;
     HasCooler = (info->model->flag & TOUPCAM_FLAG_TEC) != 0;
     m_cam.m_hasGuideOutput = (info->model->flag & TOUPCAM_FLAG_ST4) != 0;
 
@@ -717,7 +717,7 @@ bool CameraToupTek::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_cam.m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -70,7 +70,6 @@ class Camera_ZWO : public GuideCamera
     int m_minGain;
     int m_maxGain;
     int m_defaultGainPct;
-    bool m_isColor;
     double m_devicePixelSize;
 
 public:
@@ -447,8 +446,8 @@ bool Camera_ZWO::Connect(const wxString& camId)
     m_cameraId = selected;
     Connected = true;
     Name = info.Name;
-    m_isColor = info.IsColorCam != ASI_FALSE;
-    Debug.Write(wxString::Format("ZWO: IsColorCam = %d\n", m_isColor));
+    HasBayer = info.IsColorCam != ASI_FALSE;
+    Debug.Write(wxString::Format("ZWO: IsColorCam = %d\n", HasBayer));
 
     if (m_mode == CM_SNAP && info.MechanicalShutter != ASI_FALSE)
     {
@@ -1014,7 +1013,7 @@ bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
 
     if (options & CAPTURE_SUBTRACT_DARK)
         SubtractDark(img);
-    if ((options & CAPTURE_RECON) && m_isColor && captureParams.CombinedBinning() == 1)
+    if ((options & CAPTURE_RECON) && HasBayer && captureParams.CombinedBinning() == 1)
         QuickLRecon(img);
 
     return false;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -215,6 +215,7 @@ GuideCamera::GuideCamera()
     HasSubframes = false;
     HasFrameLimiting = false;
     HasCooler = false;
+    HasBayer = false;
     FrameSize = UNDEFINED_FRAME_SIZE;
     UseSubframes = pConfig->Profile.GetBoolean("/camera/UseSubframes", DefaultUseSubframes);
     GuideCameraGain = pConfig->Profile.GetInt("/camera/gain", DefaultGuideCameraGain);

--- a/src/camera.h
+++ b/src/camera.h
@@ -148,6 +148,7 @@ public:
     bool ShutterClosed; // false=light, true=dark
     bool UseSubframes;
     bool HasCooler;
+    bool HasBayer; // true for color camera
     wxRect LimitFrame; // limit full frames to this region of interest (ROI). An empty rect for no limit.
 
     wxCriticalSection DarkFrameLock; // dark frames can be accessed in the main thread or the camera worker thread

--- a/src/gear_simulator.cpp
+++ b/src/gear_simulator.cpp
@@ -1312,6 +1312,11 @@ CameraSimulator::CameraSimulator()
     PropertyDialogType = PROPDLG_WHEN_CONNECTED;
     MaxHwBinning = 3;
     HasCooler = true;
+# if SIMMODE == 2
+    HasBayer = true;
+# else
+    HasBayer = false;
+# endif
 }
 
 wxByte CameraSimulator::BitsPerPixel()


### PR DESCRIPTION
GuideCamera HasBayer property

Move the "has Bayer" property from GuideCamera child classes up to the parent class.
This will allow moving the image post-processing up to the parent class as
well in a following PR.

No functional changes, just adding the property to the parent class
and replacing the child class member variables with the member from
the parent class.

