### PR TITLE
code cleanup: remove unneeded subframe check for single_exposure

### DIFF
--- a/src/myframe_events.cpp
+++ b/src/myframe_events.cpp
@@ -437,9 +437,6 @@ bool SingleExposure::Activate(int duration, wxByte binning, int gain, const wxRe
         return false;
 
     this->subframe = subframe;
-    if (!this->subframe.IsEmpty())
-        subframe.Intersect(wxRect(pCamera->FrameSize));
-
     this->save = save;
     this->path = path;
 


### PR DESCRIPTION
code cleanup: remove unneeded subframe check for single_exposure

Remove an unneeded subframe check in the server get_single_exposure
code path.  The subframe is already validated in Capture().

