### PR TITLE
Use current image size in GuiderMultiStar::GetBoundingBox()

### DIFF
--- a/src/guider_multistar.cpp
+++ b/src/guider_multistar.cpp
@@ -579,7 +579,7 @@ wxRect GuiderMultiStar::GetBoundingBox() const
     if (subframe)
     {
         wxRect box(SubframeRect(pos, m_searchRegion + SUBFRAME_BOUNDARY_PX));
-        box.Intersect(wxRect(pCamera->FrameSize));
+        box.Intersect(wxRect(CurrentImage()->Size));
         return box;
     }
     else


### PR DESCRIPTION
Use current image size in GuiderMultiStar::GetBoundingBox()

When software binning is introduced #738, the camera FrameSize will be the
hardware frame size before binning, so this code needs an adjustment.

Although we could have used the binned camera frame size here, it's better
to use the actual image size.
