### PR TITLE
Add GuideCamera::GetFrameSize method

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -136,7 +136,15 @@ public:
 
     int GuideCameraGain;
     wxString Name; // User-friendly name
-    wxSize FrameSize; // Size of current image
+
+    // FrameSize is the size of the current guide frame, *before software binning*. To
+    // get the actual size of the current guide frame image, callers should use
+    // pFrame->pGuider->CurrentImage()->Size. If the current image is not available,
+    // pCamera->GetFrameSize() can be used, but this is not guaranteed match the current
+    // frame size, and may even be an empty rect for some cameras (ASCOM cameras for
+    // example) that do not report a frame size until after an image is captured.
+    wxSize FrameSize;
+
     bool Connected;
     PropDlgType PropertyDialogType;
     bool HasGainControl;
@@ -216,6 +224,7 @@ public:
     void SubtractDark(usImage& img);
     void GetDarkLibraryProperties(int *pNumDarks, double *pMinExp, double *pMaxExp);
 
+    virtual wxSize GetFrameSize() const;
     virtual wxSize DarkFrameSize() { return FrameSize; }
 
     static double GetProfilePixelSize();
@@ -264,6 +273,12 @@ inline void GuideCamera::GetBinningOpts(wxArrayString *opts)
 inline int GuideCamera::GetBinning() const
 {
     return HwBinning;
+}
+
+// returns the expected frame size after software binning
+inline wxSize GuideCamera::GetFrameSize() const
+{
+    return FrameSize;
 }
 
 inline double GuideCamera::GetCameraPixelSize() const

--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1191,7 +1191,8 @@ bool GearDialog::DoConnectCamera(bool autoReconnecting)
         m_cameraUpdated = true;
 
         Debug.AddLine("Connected Camera: " + m_pCamera->Name);
-        Debug.Write(wxString::Format("FrameSize=(%d,%d)\n", m_pCamera->FrameSize.x, m_pCamera->FrameSize.y));
+        auto frameSize = m_pCamera->GetFrameSize();
+        Debug.Write(wxString::Format("FrameSize=(%d,%d)\n", frameSize.x, frameSize.y));
         Debug.Write(wxString::Format("PixelSize=%.2f\n", m_pCamera->GetCameraPixelSize()));
         Debug.Write(wxString::Format("BitsPerPixel=%u\n", m_pCamera->BitsPerPixel()));
         Debug.Write(wxString::Format("HasGainControl=%d\n", m_pCamera->HasGainControl));


### PR DESCRIPTION
Add GuideCamera::GetFrameSize method

Add GuideCamera::GetFrameSize method returning the camera's frame size
after software binning #738. GuideCamera::FrameSize continues to
hold the guide camera frame size before software binning.

No functional changes in this pr, just setting the stage
for introducing software binning in a following PR.
