### PR TITLE
Fix assumption that binning choices are consecutive int values.

### DIFF
--- a/src/calstep_dialog.cpp
+++ b/src/calstep_dialog.cpp
@@ -127,8 +127,7 @@ CalstepDialog::CalstepDialog(wxWindow *parent, int focalLength, double pixelSize
     m_binningChoice = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, opts);
     m_binningChoice->Enable(!pFrame->pGuider || !pFrame->pGuider->IsCalibratingOrGuiding());
     m_binningChoice->Bind(wxEVT_CHOICE, &CalstepDialog::OnText, this);
-    int idx = binning - 1;
-    m_binningChoice->Select(idx);
+    SetIntChoice(m_binningChoice, binning);
     AddTableEntry(m_pInputTableSizer, _("Camera binning"), m_binningChoice, _("Guide camera pixel binning"));
     m_binningChoice->Enable(m_binningChoice->GetCount() > 1);
 
@@ -254,7 +253,8 @@ void CalstepDialog::OnSpinCtrlDouble(wxSpinDoubleEvent& evt)
 
 void CalstepDialog::OnReset(wxCommandEvent& evt)
 {
-    int bestDistance = GetCalibrationDistance(m_iFocalLength, m_pPixelSize->GetValue(), m_binningChoice->GetSelection() + 1);
+    int binning = GetIntChoice(m_binningChoice, 1);
+    int bestDistance = GetCalibrationDistance(m_iFocalLength, m_pPixelSize->GetValue(), binning);
     m_pDistance->SetValue(bestDistance);
     m_pNumSteps->SetValue(DEFAULT_STEPS);
     DoRecalc();
@@ -268,7 +268,7 @@ void CalstepDialog::DoRecalc(void)
     {
         m_fPixelSize = m_pPixelSize->GetValue();
         m_pPixelSize->SetValue(m_fPixelSize); // For European locales, '.' -> ',' on output
-        m_binning = m_binningChoice->GetSelection() + 1;
+        m_binning = GetIntChoice(m_binningChoice, 1);
         m_fGuideSpeed = m_pGuideSpeed->GetValue();
         m_pGuideSpeed->SetValue(m_fGuideSpeed);
         m_iNumSteps = m_pNumSteps->GetValue();

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1063,9 +1063,9 @@ void CameraConfigDialogCtrlSet::LoadValues()
         m_resetGain->Enable(false);
     }
 
-    int idx = m_pCamera->GetBinning() - 1;
-    m_binning->Select(idx);
-    m_prevBinning = idx + 1;
+    int binning = m_pCamera->GetBinning();
+    SetIntChoice(m_binning, binning);
+    m_prevBinning = binning;
     // don't allow binning change when calibrating or guiding
     m_binning->Enable(!pFrame->pGuider || !pFrame->pGuider->IsCalibratingOrGuiding());
 
@@ -1169,10 +1169,10 @@ void CameraConfigDialogCtrlSet::UnloadValues()
     if (m_binning)
     {
         int oldBin = m_pCamera->GetBinning();
-        int newBin = m_binning->GetSelection() + 1;
-        if (oldBin != newBin)
+        int newBin = GetIntChoice(m_binning, 1);
+        if (newBin != oldBin)
             pFrame->pAdvancedDialog->FlagImageScaleChange();
-        m_pCamera->SetBinning(m_binning->GetSelection() + 1);
+        m_pCamera->SetBinning(newBin);
     }
 
     m_pCamera->SetTimeoutMs(m_timeoutVal->GetValue() * 1000);
@@ -1230,13 +1230,15 @@ void CameraConfigDialogCtrlSet::SetPixelSize(double val)
 
 int CameraConfigDialogCtrlSet::GetBinning()
 {
-    return m_binning ? m_binning->GetSelection() + 1 : 1;
+    if (!m_binning)
+        return 1;
+    return GetIntChoice(m_binning, 1);
 }
 
 void CameraConfigDialogCtrlSet::SetBinning(int binning)
 {
     if (m_binning)
-        m_binning->Select(binning - 1);
+        SetIntChoice(m_binning, binning);
 }
 
 void GuideCamera::GetBinningOpts(int maxBin, wxArrayString *opts)

--- a/src/manualcal_dialog.cpp
+++ b/src/manualcal_dialog.cpp
@@ -47,7 +47,7 @@ ManualCalDialog::ManualCalDialog(const Calibration& cal)
     wxArrayString opts;
     pCamera->GetBinningOpts(&opts);
     m_binning = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, opts);
-    m_binning->Select(cal.binning - 1);
+    SetIntChoice(m_binning, cal.binning);
     pGridSizer->Add(pLabel);
     pGridSizer->Add(m_binning);
 

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -3594,3 +3594,17 @@ void MyFrame::NotifyGuidingParam(const wxString& name, const wxString& val, bool
     GuideLog.SetGuidingParam(name, val, true);
     EvtServer.NotifyGuidingParam(name, val);
 }
+
+int GetIntChoice(wxChoice *choice, int dflt)
+{
+    unsigned long value;
+    if (!choice->GetStringSelection().ToULong(&value))
+        value = dflt;
+    return value;
+}
+
+void SetIntChoice(wxChoice *choice, int value)
+{
+    if (!choice->SetStringSelection(wxString::Format("%d", value)))
+        choice->SetSelection(0);
+}

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -788,4 +788,10 @@ inline int MyFrame::GetFocalLength() const
     return m_focalLength;
 }
 
+// utility function to get an integer value from a wxChoice control
+extern int GetIntChoice(wxChoice *choice, int dflt);
+
+// utility function to set an integer value in a wxChoice control
+extern void SetIntChoice(wxChoice *choice, int value);
+
 #endif /* MYFRAME_H_INCLUDED */

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -968,7 +968,7 @@ void ProfileWizard::WrapUp()
     m_launchDarks = m_pLaunchDarks->GetValue();
     m_autoRestore = m_pAutoRestore->GetValue();
 
-    int binning = m_pBinningLevel->GetSelection() + 1;
+    int binning = GetIntChoice(m_pBinningLevel, 1);
     if (m_useCamera)
         SetBinningLevel(this, m_SelectedCamera, binning);
 
@@ -1387,7 +1387,7 @@ inline static double round2(double x)
 
 void ProfileWizard::UpdatePixelScale()
 {
-    int binning = m_pBinningLevel->GetSelection() + 1;
+    int binning = GetIntChoice(m_pBinningLevel, 1);
 
     double scale = 0.0;
     if (m_FocalLength > 0)


### PR DESCRIPTION
Fix assumption that binning choices are consecutive int values.

When software binning is added #738, there may be gaps in the list of allowed binning
levels.
