### PR TITLE
Remove ReadDelay and HasDelayParam from GuideCamera

### DIFF
--- a/src/cam_LESerialWebcam.cpp
+++ b/src/cam_LESerialWebcam.cpp
@@ -237,10 +237,10 @@ bool CameraLESerialWebcam::LEControl(int actions)
     return bError;
 }
 
-struct LEWebcamDialog : public wxDialog
+struct LESerialWebcamDialog : public wxDialog
 {
-    LEWebcamDialog(wxWindow *parent, CVVidCapture *vc);
-    ~LEWebcamDialog() { }
+    LESerialWebcamDialog(wxWindow *parent, CameraLEWebcam *camera);
+    ~LESerialWebcamDialog() { }
     wxChoice *m_pPortNum;
     wxCheckBox *m_pLEMaskDTR;
     wxCheckBox *m_pLEMaskRTS;
@@ -252,6 +252,7 @@ struct LEWebcamDialog : public wxDialog
     wxCheckBox *m_pLEAmpRTS;
     wxCheckBox *m_pInvertedLogic;
     wxCheckBox *m_pUseAmp;
+    wxSpinCtrl *m_delay;
     CVVidCapture *m_pVidCap;
     void OnDefaults(wxCommandEvent& evt);
     void OnVidCapClick(wxCommandEvent& evt);
@@ -260,13 +261,13 @@ struct LEWebcamDialog : public wxDialog
 };
 
 // clang-format off
-wxBEGIN_EVENT_TABLE(LEWebcamDialog, wxDialog)
-    EVT_BUTTON(wxID_DEFAULT, LEWebcamDialog::OnDefaults)
-    EVT_BUTTON(wxID_CONVERT, LEWebcamDialog::OnVidCapClick)
+wxBEGIN_EVENT_TABLE(LESerialWebcamDialog, wxDialog)
+    EVT_BUTTON(wxID_DEFAULT, LESerialWebcamDialog::OnDefaults)
+    EVT_BUTTON(wxID_CONVERT, LESerialWebcamDialog::OnVidCapClick)
 wxEND_EVENT_TABLE();
 // clang-format on
 
-void LEWebcamDialog::OnDefaults(wxCommandEvent& evt)
+void LESerialWebcamDialog::OnDefaults(wxCommandEvent& evt)
 {
     int def = LE_DEFAULT;
 
@@ -282,7 +283,7 @@ void LEWebcamDialog::OnDefaults(wxCommandEvent& evt)
     m_pUseAmp->SetValue(false);
 }
 
-void LEWebcamDialog::OnVidCapClick(wxCommandEvent& evt)
+void LESerialWebcamDialog::OnVidCapClick(wxCommandEvent& evt)
 {
     if (m_pVidCap)
     {
@@ -290,9 +291,10 @@ void LEWebcamDialog::OnVidCapClick(wxCommandEvent& evt)
     }
 }
 
-LEWebcamDialog::LEWebcamDialog(wxWindow *parent, CVVidCapture *vc) : wxDialog(parent, wxID_ANY, _("Serial LE Webcam"))
+LESerialWebcamDialog::LESerialWebcamDialog(wxWindow *parent, CameraLEWebcam *camera)
+    : wxDialog(parent, wxID_ANY, _("Serial LE Webcam"))
 {
-    m_pVidCap = vc;
+    m_pVidCap = camera->m_pVidCap;
 
     wxBoxSizer *pHSizer = new wxBoxSizer(wxHORIZONTAL);
     wxStaticText *pPortLabel = new wxStaticText(this, wxID_ANY, _("LE Port"));
@@ -373,11 +375,23 @@ LEWebcamDialog::LEWebcamDialog(wxWindow *parent, CVVidCapture *vc) : wxDialog(pa
     m_pUseAmp = new wxCheckBox(this, wxID_ANY, _("Use Amp"));
     m_pUseAmp->SetValue(pConfig->Profile.GetBoolean("/camera/serialLEWebcam/UseAmp", false));
 
+    // Delay parameter
+    int textWidth = StringWidth(this, _T("0000"));
+    m_delay = pFrame->MakeSpinCtrl(this, wxID_ANY, _T(" "), wxDefaultPosition, wxSize(textWidth, -1), wxSP_ARROW_KEYS, 0, 250,
+                                   camera->ReadDelay);
+    m_delay->SetToolTip(_("LE Read Delay (ms). Adjust if you get dropped frames"));
+    m_delay->SetValue(camera->ReadDelay);
+    wxStaticText *label = new wxStaticText(this, wxID_ANY, _("Delay"));
+    wxBoxSizer *delaySizer = new wxBoxSizer(wxHORIZONTAL);
+    delaySizer->Add(label, wxSizerFlags().Align(wxALIGN_CENTER_VERTICAL).Border(wxRIGHT | wxLEFT, 10));
+    delaySizer->Add(m_delay, wxSizerFlags().Align(wxALIGN_CENTER_VERTICAL).Border(wxRIGHT | wxLEFT, 10).Expand());
+
     wxBoxSizer *pVSizer = new wxBoxSizer(wxVERTICAL);
     pVSizer->Add(pHSizer, wxSizerFlags().Border(wxTOP | wxBOTTOM, 10).Expand());
     pVSizer->Add(pSignalSizer, wxSizerFlags().Border(wxALL, 10).Expand());
     pVSizer->Add(m_pInvertedLogic, wxSizerFlags().Border(wxRIGHT | wxLEFT, 10));
     pVSizer->Add(m_pUseAmp, wxSizerFlags().Border(wxTOP | wxRIGHT | wxLEFT, 10));
+    pVSizer->Add(delaySizer, wxSizerFlags().Border(wxTOP | wxRIGHT | wxLEFT, 10));
 
     pHSizer = new wxBoxSizer(wxHORIZONTAL);
     wxButton *pBtnDefault = new wxButton(this, wxID_DEFAULT, _("Defaults"));
@@ -398,41 +412,43 @@ void CameraLESerialWebcam::ShowPropertyDialog()
     if (pFrame->pGearDialog->IsActive())
         parent = pFrame->pGearDialog;
 
-    LEWebcamDialog dlg(parent, m_pVidCap);
+    LESerialWebcamDialog dlg(parent, this);
 
-    if (dlg.ShowModal() == wxID_OK)
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    pConfig->Profile.SetString("/camera/serialLEWebcam/serialport", dlg.m_pPortNum->GetStringSelection());
+
+    m_signalConfig = 0;
+    if (dlg.m_pLEMaskDTR->GetValue())
+        m_signalConfig |= LE_MASK_DTR;
+    if (dlg.m_pLEMaskRTS->GetValue())
+        m_signalConfig |= LE_MASK_RTS;
+    // if (dlg.m_pLEInitDTR->GetValue()) m_signalConfig |= LE_INIT_DTR;
+    // if (dlg.m_pLEInitRTS->GetValue()) m_signalConfig |= LE_INIT_RTS;
+    if (dlg.m_pLEExpoDTR->GetValue())
+        m_signalConfig |= LE_EXPO_DTR;
+    if (dlg.m_pLEExpoRTS->GetValue())
+        m_signalConfig |= LE_EXPO_RTS;
+    if (dlg.m_pLEAmpDTR->GetValue())
+        m_signalConfig |= LE_AMP_DTR;
+    if (dlg.m_pLEAmpRTS->GetValue())
+        m_signalConfig |= LE_AMP_RTS;
+    m_InvertedLogic = dlg.m_pInvertedLogic->GetValue();
+    m_UseAmp = dlg.m_pUseAmp->GetValue();
+    m_Expo = (m_signalConfig & (LE_EXPO_DTR | LE_EXPO_RTS) ^ (LE_MASK_DTR | LE_MASK_RTS)) ? m_InvertedLogic : !m_InvertedLogic;
+    m_Amp = (m_signalConfig & (LE_AMP_DTR | LE_AMP_RTS) ^ (LE_MASK_DTR | LE_MASK_RTS)) ? m_InvertedLogic : !m_InvertedLogic;
+
+    pConfig->Profile.SetInt("/camera/serialLEWebcam/SignalConfig", m_signalConfig);
+    pConfig->Profile.SetBoolean("/camera/serialLEWebcam/InvertedLogic", m_InvertedLogic);
+    pConfig->Profile.SetBoolean("/camera/serialLEWebcam/UseAmp", m_UseAmp);
+
+    ReadDelay = dlg.m_delay->GetValue();
+    pConfig->Profile.SetInt("/camera/ReadDelay", ReadDelay);
+
+    if (!Connected)
     {
-        pConfig->Profile.SetString("/camera/serialLEWebcam/serialport", dlg.m_pPortNum->GetStringSelection());
-
-        m_signalConfig = 0;
-        if (dlg.m_pLEMaskDTR->GetValue())
-            m_signalConfig |= LE_MASK_DTR;
-        if (dlg.m_pLEMaskRTS->GetValue())
-            m_signalConfig |= LE_MASK_RTS;
-        // if (dlg.m_pLEInitDTR->GetValue()) m_signalConfig |= LE_INIT_DTR;
-        // if (dlg.m_pLEInitRTS->GetValue()) m_signalConfig |= LE_INIT_RTS;
-        if (dlg.m_pLEExpoDTR->GetValue())
-            m_signalConfig |= LE_EXPO_DTR;
-        if (dlg.m_pLEExpoRTS->GetValue())
-            m_signalConfig |= LE_EXPO_RTS;
-        if (dlg.m_pLEAmpDTR->GetValue())
-            m_signalConfig |= LE_AMP_DTR;
-        if (dlg.m_pLEAmpRTS->GetValue())
-            m_signalConfig |= LE_AMP_RTS;
-        m_InvertedLogic = dlg.m_pInvertedLogic->GetValue();
-        m_UseAmp = dlg.m_pUseAmp->GetValue();
-        m_Expo =
-            (m_signalConfig & (LE_EXPO_DTR | LE_EXPO_RTS) ^ (LE_MASK_DTR | LE_MASK_RTS)) ? m_InvertedLogic : !m_InvertedLogic;
-        m_Amp = (m_signalConfig & (LE_AMP_DTR | LE_AMP_RTS) ^ (LE_MASK_DTR | LE_MASK_RTS)) ? m_InvertedLogic : !m_InvertedLogic;
-
-        pConfig->Profile.SetInt("/camera/serialLEWebcam/SignalConfig", m_signalConfig);
-        pConfig->Profile.SetBoolean("/camera/serialLEWebcam/InvertedLogic", m_InvertedLogic);
-        pConfig->Profile.SetBoolean("/camera/serialLEWebcam/UseAmp", m_UseAmp);
-
-        if (!Connected)
-        {
-            CameraLEWebcam::ShowPropertyDialog();
-        }
+        CameraLEWebcam::ShowPropertyDialog();
     }
 }
 

--- a/src/cam_LEwebcam.cpp
+++ b/src/cam_LEwebcam.cpp
@@ -40,11 +40,13 @@
 
 # include "cam_wdm_base.h"
 
+static const int DefaultReadDelay = 150;
+
 CameraLEWebcam::CameraLEWebcam(void) : CameraWDM()
 {
     Name = _T("Generic LE Webcam");
     PropertyDialogType = PROPDLG_WHEN_CONNECTED;
-    HasDelayParam = true;
+    ReadDelay = pConfig->Profile.GetInt("/camera/ReadDelay", DefaultReadDelay);
 }
 
 CameraLEWebcam::~CameraLEWebcam(void) { }

--- a/src/cam_vfw.cpp
+++ b/src/cam_vfw.cpp
@@ -51,7 +51,6 @@ CameraVFW::CameraVFW()
     VFW_Window = NULL;
     Extra_Window = NULL;
     PropertyDialogType = PROPDLG_WHEN_CONNECTED;
-    HasDelayParam = false;
 }
 
 wxByte CameraVFW::BitsPerPixel()

--- a/src/cam_wdm.cpp
+++ b/src/cam_wdm.cpp
@@ -51,7 +51,6 @@ CameraWDM::CameraWDM()
     m_deviceNumber = -1; // Which WDM device connected
     m_deviceMode = -1;
     PropertyDialogType = PROPDLG_WHEN_CONNECTED;
-    HasDelayParam = false;
     m_captureMode = NOT_CAPTURING;
     m_pVidCap = nullptr;
     m_rawYUY2 = false;

--- a/src/cam_wdm_base.h
+++ b/src/cam_wdm_base.h
@@ -76,6 +76,8 @@ protected:
     int m_deviceNumber;
     int m_deviceMode;
     bool m_rawYUY2;
+
+public:
     CVVidCaptureDSWin32 *m_pVidCap;
 
 public:
@@ -120,6 +122,9 @@ protected:
         LECAMERA_EXPOSURE_FIELD_A = 256,
         LECAMERA_EXPOSURE_FIELD_B = 512,
     };
+
+public:
+    int ReadDelay;
 
 public:
     CameraLEWebcam();

--- a/src/camera.h
+++ b/src/camera.h
@@ -125,14 +125,12 @@ public:
     wxSize FrameSize; // Size of current image
     bool Connected;
     PropDlgType PropertyDialogType;
-    bool HasDelayParam;
     bool HasGainControl;
     bool HasShutter;
     bool HasSubframes;
     bool HasFrameLimiting;
     wxByte MaxBinning;
     wxByte Binning;
-    int ReadDelay;
     bool ShutterClosed; // false=light, true=dark
     bool UseSubframes;
     bool HasCooler;

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -69,7 +69,6 @@ enum BRAIN_CTRL_IDS
     AD_szTimeLapse,
     AD_szPixelSize,
     AD_szGain,
-    AD_szDelay,
     AD_szBinning,
     AD_szCooler,
     AD_CAMERA_TAB_BOUNDARY, // ------ end of camera tab controls


### PR DESCRIPTION
Remove ReadDelay and HasDelayParam from GuideCamera

Move the ReadDelay and HasDelayParam out of GuideCamera
down to CameraLEWebcam child class.

The ReadDelay setting is removed from the brain dialog and
now exists in each of the LE Webcam property dialogs - USB, Serial,
and Parallel.

<img width="181" height="95" alt="image" src="https://github.com/user-attachments/assets/69877934-1d86-4a87-a14d-18241ff42348" />
<img width="185" height="290" alt="image" src="https://github.com/user-attachments/assets/475c4ad7-6992-461f-b1cf-cdc3a954115f" />
<img width="196" height="178" alt="image" src="https://github.com/user-attachments/assets/a997684c-4d3b-40db-af61-43531312498d" />
