### PR TITLE
Remove dead code - ChooseParallelPort

### DIFF
--- a/src/parallelport.h
+++ b/src/parallelport.h
@@ -46,8 +46,6 @@ public:
     ParallelPort(void);
     virtual ~ParallelPort(void);
 
-    virtual wxString ChooseParallelPort(const wxString& dflt) = 0;
-
     virtual bool Connect(const wxString& portName) = 0;
     virtual bool Disconnect(void) = 0;
 

--- a/src/parallelport_win32.cpp
+++ b/src/parallelport_win32.cpp
@@ -50,65 +50,6 @@ ParallelPortWin32::ParallelPortWin32(void)
 
 ParallelPortWin32::~ParallelPortWin32(void) { }
 
-struct ParallelPortChooser : public wxDialog
-{
-    ParallelPortChooser();
-};
-
-wxString ParallelPortWin32::ChooseParallelPort(const wxString& dflt)
-{
-    wxArrayString ports;
-    ports.Add("LPT1 - 0x3BC");
-    ports.Add("LPT2 - 0x378");
-    ports.Add("LPT3 - 0x278");
-
-    wxString customPort = pConfig->Global.GetString("/CustomParallelPort", wxEmptyString);
-    if (!customPort.IsEmpty())
-        ports.Add(customPort);
-
-    wxDialog dlg(NULL, wxID_ANY, _("Select Parallel Port"));
-    wxSizer *sz1 = new wxBoxSizer(wxVERTICAL);
-
-    wxListBox *portlb = new wxListBox(&dlg, wxID_ANY, wxDefaultPosition, wxDefaultSize, ports);
-    portlb->SetStringSelection(dflt);
-    sz1->Add(portlb);
-
-    wxWindow *label = new wxStaticText(&dlg, wxID_ANY, _("Custom Port Address:"));
-    wxTextCtrl *customtxt = new wxTextCtrl(&dlg, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(70, -1));
-
-    wxSizer *sz2 = new wxBoxSizer(wxHORIZONTAL);
-    sz2->Add(label, wxSizerFlags(0).Border(wxALL, 10));
-    sz2->Add(customtxt, wxSizerFlags(0).Border(wxALL, 10));
-
-    sz1->Add(sz2);
-
-    sz1->Add(dlg.CreateButtonSizer(wxOK | wxCANCEL), wxSizerFlags(0).Right().Border(wxALL, 10));
-
-    dlg.SetSizerAndFit(sz1);
-
-    wxString choice;
-
-    if (dlg.ShowModal() == wxID_OK)
-    {
-        wxString custom = customtxt->GetValue();
-        if (!custom.IsEmpty())
-        {
-            long val;
-            if (custom.ToLong(&val, 16) && val != 0)
-            {
-                choice = wxString::Format("Custom - 0x%x", val);
-                pConfig->Global.SetString("/CustomParallelPort", choice);
-            }
-        }
-        else
-        {
-            choice = portlb->GetStringSelection();
-        }
-    }
-
-    return choice;
-}
-
 bool ParallelPortWin32::Connect(const wxString& portName)
 {
     bool bError = false;

--- a/src/parallelport_win32.h
+++ b/src/parallelport_win32.h
@@ -44,8 +44,6 @@ public:
     ParallelPortWin32(void);
     virtual ~ParallelPortWin32(void);
 
-    virtual wxString ChooseParallelPort(const wxString& dflt);
-
     virtual bool Connect(const wxString& portName);
     virtual bool Disconnect(void);
 


### PR DESCRIPTION
Remove dead code - ChooseParallelPort

ChooseParallelPort no longer has any callers. The functionality
was moved to the parallel LE webcam property dialog.

