### PR TITLE
Include s/w binning options in CalStepDialog and ManualGuide

### DIFF
--- a/src/calstep_dialog.cpp
+++ b/src/calstep_dialog.cpp
@@ -123,7 +123,7 @@ CalstepDialog::CalstepDialog(wxWindow *parent, int focalLength, double pixelSize
 
     // binning
     wxArrayString opts;
-    bool includeSwBinning = false; // TODO: SW binning UI
+    bool includeSwBinning = true; // Include s/w options for "what-if" use cases
     GuideCamera::GetBinningOpts(&opts, pCamera ? pCamera->MaxHwBinning : 1, includeSwBinning);
     m_binningChoice = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, opts);
     m_binningChoice->Enable(!pFrame->pGuider || !pFrame->pGuider->IsCalibratingOrGuiding());

--- a/src/manualcal_dialog.cpp
+++ b/src/manualcal_dialog.cpp
@@ -45,7 +45,7 @@ ManualCalDialog::ManualCalDialog(const Calibration& cal)
 
     wxStaticText *pLabel = new wxStaticText(this, wxID_ANY, _("Camera binning:"));
     wxArrayString opts;
-    bool includeSwBinning = false; // TODO: SW binning UI
+    bool includeSwBinning = true; // Dialog is for expert use only so include s/w options
     pCamera->GetBinningOpts(&opts, includeSwBinning);
     m_binning = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, opts);
     SetIntChoice(m_binning, cal.binning);


### PR DESCRIPTION
This adds s/w binning for the 2 trivial cases: CalStepDialog and ManualGuide