### PR TITLE
Fix a couple problems with setting the limit frame

### DIFF
--- a/src/cam_zwo.cpp
+++ b/src/cam_zwo.cpp
@@ -766,7 +766,7 @@ bool Camera_ZWO::Capture(usImage& img, const CaptureParams& captureParams)
         binning_change = true;
     }
 
-    wxRect const limit_frame = options & CAPTURE_IGNORE_FRAME_LIMIT ? wxRect() : LimitFrame;
+    wxRect const limit_frame = options & CAPTURE_IGNORE_FRAME_LIMIT ? wxRect() : captureParams.limitFrame;
 
     // always update the frame size in case the limit frame or binning changed
     wxSize const binned_frame_size(BinnedFrameSize(HwBinning));

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -772,7 +772,8 @@ bool GuideCamera::SetLimitFrame(const wxRect& roi, int binning, wxString *errorM
         pConfig->Profile.SetRect(key, limit_frame);
     }
 
-    // load the limit frame for the requested binning
+    // load the limit frame for the current camera binning level
+    binning = GetBinning();
     LoadLimitFrame(binning);
 
     return false; // no error


### PR DESCRIPTION
Fix a couple problems with setting the limit frame

When we added software binning, we introduced some problems handling the
frame limit ROI.

 - when setting the frame limit via the server API, set the limit corresponding
   to the combined (hw+sw) binning level, not the bin-1 limit.
 - when capturing a camera frame in Camera_ZWO::Capture, use the limit frame
   passed in the capture params which is the proper limit for hw-only binning , not
   the Camera instance's LimitFrame member which incorporates hw+sw binning.

