### PR TITLE
cosmetic: cleanup config mixed case key names

### DIFF
--- a/src/camcal_import_dialog.cpp
+++ b/src/camcal_import_dialog.cpp
@@ -167,7 +167,7 @@ void CamCalImportDialog::OnDarkProfileChoice(wxCommandEvent& evt)
     {
         pConfig->SetCurrentProfile(selProfile);
         m_sourceDarksProfileId = pConfig->GetCurrentProfileId();
-        wxString thatCamera = pConfig->Profile.GetString("/camera/LastMenuchoice", _("None"));
+        wxString thatCamera = pConfig->Profile.GetString("/camera/LastMenuChoice", _("None"));
         m_darkCameraChoice->SetLabelText(thatCamera);
         pConfig->SetCurrentProfile(m_activeProfileName);
     }
@@ -185,7 +185,7 @@ void CamCalImportDialog::OnBPMProfileChoice(wxCommandEvent& evt)
     {
         pConfig->SetCurrentProfile(selProfile);
         m_sourceBpmProfileId = pConfig->GetCurrentProfileId();
-        wxString thatCamera = pConfig->Profile.GetString("/camera/LastMenuchoice", _("None"));
+        wxString thatCamera = pConfig->Profile.GetString("/camera/LastMenuChoice", _("None"));
         m_bpmCameraChoice->SetLabelText(thatCamera);
         pConfig->SetCurrentProfile(m_activeProfileName);
     }

--- a/src/guiding_assistant.cpp
+++ b/src/guiding_assistant.cpp
@@ -985,7 +985,7 @@ static void GetBLTHistory(const std::vector<wxString>& Timestamps, int *oldestBL
     int bltCount = 0;
     for (int inx = 0; inx < Timestamps.size(); inx++)
     {
-        wxString northBLT = "/GA/" + Timestamps[inx] + "/BLT_north";
+        wxString northBLT = "/GA/" + Timestamps[inx] + "/BLT_North";
         if (pConfig->Profile.GetString(northBLT, wxEmptyString) != wxEmptyString)
         {
             bltCount++;
@@ -1069,7 +1069,7 @@ void GuidingAsstWin::SaveGAResults(const wxString *AllRecommendations)
             stepStr += wxString::Format("%0.1f,", *it);
         }
         stepStr = stepStr.Left(stepStr.length() - 2);
-        pConfig->Profile.SetString(prefix + "/BLT_north", stepStr);
+        pConfig->Profile.SetString(prefix + "/BLT_North", stepStr);
 
         stepStr = "";
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -76,7 +76,7 @@ const wxString& Logger::GetLogDir()
 
         if (pConfig)
         {
-            rslt = pConfig->Global.GetString("/frame/LogDir", wxEmptyString);
+            rslt = pConfig->Global.GetString("/frame/logdir", wxEmptyString);
             if (rslt.empty())
                 rslt = DefaultDir(); // user has never even looked at it
             else if (!wxDirExists(rslt)) // user might have deleted our old directories

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -1027,7 +1027,7 @@ void ProfileWizard::WrapUp()
     }
 
     // populate the profile. The caller will load the profile.
-    pConfig->Profile.SetString("/camera/LastMenuchoice", m_SelectedCamera);
+    pConfig->Profile.SetString("/camera/LastMenuChoice", m_SelectedCamera);
     pConfig->Profile.SetString("/scope/LastMenuChoice", m_SelectedMount);
     pConfig->Profile.SetString("/scope/LastAuxMenuChoice", m_SelectedAuxMount);
     pConfig->Profile.SetString("/stepguider/LastMenuChoice", m_SelectedAO);


### PR DESCRIPTION
cosmetic: cleanup config mixed case key names

wxWidgets documentation is not clear about the case-sensitivity of
wxConfig key names, but key names are case-insensitive.

Windows uses wxRegConfig which is always case-insensitive.
Mac and Linux use wxFileConfig which has a compile time option,
wxCONFIG_CASE_SENSITIVE, which defaults to 0 so those platforms
are also case insensitive.

For consistency and to prevent readers of the code from going off into
the weeds, this PR updates a few keys to use consistent mixed case.

This is purely a cosmetic change and has no effect at run time for PHD2.

