### PR TITLE
Push info about multi-star guiding to event server

### DIFF
--- a/src/guider.cpp
+++ b/src/guider.cpp
@@ -32,6 +32,7 @@
  *
  */
 #include "phd.h"
+#include "event_server.h"
 #include "nudge_lock.h"
 #include "comet_tool.h"
 #include "polardrift_tool.h"
@@ -1307,8 +1308,8 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
 
         GuiderOffset ofs;
         FrameDroppedInfo info;
-
-        if (UpdateCurrentPosition(pImage, &ofs, &info)) // true means error
+        DeferedEvent<MultiStarReport> frameStarPositions;
+        if (UpdateCurrentPosition(pImage, &ofs, &info, &frameStarPositions.value)) // true means error
         {
             info.frameNumber = pImage->FrameNum;
             info.time = pFrame->TimeSinceGuidingStarted();
@@ -1526,6 +1527,7 @@ void Guider::UpdateGuideState(usImage *pImage, bool bStopping)
         case STATE_STOP:
             break;
         }
+        frameStarPositions.send();
     }
     catch (const wxString& Msg)
     {

--- a/src/guider.h
+++ b/src/guider.h
@@ -105,6 +105,7 @@ struct LockPosShiftParams
 };
 
 class DefectMap;
+class MultiStarReport;
 
 /*
  * The Guider class is responsible for running the state machine
@@ -205,6 +206,7 @@ protected:
     bool PaintHelper(wxAutoBufferedPaintDCBase& dc, wxMemoryDC& memDC);
     void SetState(GUIDER_STATE newState);
     void UpdateCurrentDistance(double distance, double distanceRA);
+    virtual void reportSecondaryStarsAsUnused(MultiStarReport *multiStarReport) = 0;
 
     void ToggleBookmark(const wxRealPoint& pt);
 
@@ -297,7 +299,8 @@ public:
     virtual void InvalidateCurrentPosition(bool fullReset = false) = 0;
 
 private:
-    virtual bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo) = 0;
+    virtual bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo,
+                                       MultiStarReport *multiStarReport) = 0;
     virtual bool SetCurrentPosition(const usImage *pImage, const PHD_Point& position) = 0;
 
 public:

--- a/src/guider_multistar.h
+++ b/src/guider_multistar.h
@@ -47,6 +47,7 @@
 class MassChecker;
 class GuiderMultiStar;
 class GuiderConfigDialogCtrlSet;
+class MultiStarReport;
 
 class GuiderMultiStarConfigDialogCtrlSet : public GuiderConfigDialogCtrlSet
 {
@@ -112,7 +113,7 @@ public:
     bool SetMassChangeThreshold(double starMassChangeThreshold);
     bool SetTolerateJumps(bool enable, double threshold);
     bool SetSearchRegion(int searchRegion);
-    bool RefineOffset(const usImage *pImage, GuiderOffset *pOffset);
+    bool RefineOffset(const usImage *pImage, GuiderOffset *pOffset, MultiStarReport *multiStarReport);
 
     friend class GuiderMultiStarConfigDialogPane;
     friend class GuiderMultiStarConfigDialogCtrlSet;
@@ -146,8 +147,10 @@ private:
     bool IsValidLockPosition(const PHD_Point& pt) final;
     bool IsValidSecondaryStarPosition(const PHD_Point& pt) final;
     void InvalidateCurrentPosition(bool fullReset = false) final;
-    bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo) final;
+    bool UpdateCurrentPosition(const usImage *pImage, GuiderOffset *ofs, FrameDroppedInfo *errorInfo,
+                               MultiStarReport *multiStarReport) final;
     bool SetCurrentPosition(const usImage *pImage, const PHD_Point& position) final;
+    void reportSecondaryStarsAsUnused(MultiStarReport *multiStarReport) final;
 
     void OnLClick(wxMouseEvent& evt);
 

--- a/src/image_math.cpp
+++ b/src/image_math.cpp
@@ -40,6 +40,7 @@
 #include <wx/tokenzr.h>
 
 #include <algorithm>
+#include <set>
 
 int dbl_sort_func(double *first, double *second)
 {

--- a/src/log_uploader.cpp
+++ b/src/log_uploader.cpp
@@ -34,6 +34,7 @@
 
 #include "log_uploader.h"
 #include "phd.h"
+#include "json_parser.h"
 
 #include <algorithm>
 #include <curl/curl.h>

--- a/src/mount.cpp
+++ b/src/mount.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "phd.h"
+#include "event_server.h"
 #include "backlash_comp.h"
 #include "guiding_assistant.h"
 #include "gaussian_process_guider.h"

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -36,6 +36,7 @@
 
 #include "phd.h"
 
+#include "event_server.h"
 #include "aui_controls.h"
 #include "comet_tool.h"
 #include "config_indi.h"

--- a/src/myframe_events.cpp
+++ b/src/myframe_events.cpp
@@ -34,6 +34,7 @@
 
 #include "phd.h"
 
+#include "event_server.h"
 #include "about_dialog.h"
 #include "aui_controls.h"
 #include "camcal_import_dialog.h"

--- a/src/phd.h
+++ b/src/phd.h
@@ -183,7 +183,6 @@ WX_DEFINE_ARRAY_DOUBLE(double, ArrayOfDbl);
 #include "myframe.h"
 #include "debuglog.h"
 #include "worker_thread.h"
-#include "event_server.h"
 #include "confirm_dialog.h"
 #include "phdcontrol.h"
 #include "runinbg.h"

--- a/src/phdcontrol.cpp
+++ b/src/phdcontrol.cpp
@@ -33,7 +33,7 @@
  */
 
 #include "phd.h"
-
+#include "event_server.h"
 enum State
 {
     STATE_IDLE = 0,

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -32,6 +32,7 @@
  *
  */
 #include "phd.h"
+#include "event_server.h"
 
 #include "backlash_comp.h"
 #include "calreview_dialog.h"

--- a/src/socket_server.cpp
+++ b/src/socket_server.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "phd.h"
+#include "event_server.h"
 
 #include "socket_server.h"
 #include "gear_simulator.h"

--- a/src/star.cpp
+++ b/src/star.cpp
@@ -36,6 +36,7 @@
  */
 
 #include "phd.h"
+#include "event_server.h"
 #include <algorithm>
 
 Star::Star()

--- a/src/stepguider.cpp
+++ b/src/stepguider.cpp
@@ -34,6 +34,7 @@
  */
 #include "phd.h"
 
+#include "event_server.h"
 #include "gear_simulator.h"
 #include "image_math.h"
 #include "socket_server.h"


### PR DESCRIPTION
This MR adds a new event on the event-server, to publish detailed info about multi-star (list all stars, their status, ...), so a third party app can show what multi-star guiding is doing.

I am not sure about the impact of adding this new event for existing app: it might be worth making it a per client opt-in.

Events look like:
```json
{
  "Event": "MultiStarReport",
  "Timestamp": 1771099742.883,
  "Host": "xubuntu",
  "Inst": 1,
  "Stars": [
    {
      "X": 912.002,
      "Y": 1763,
      "RefX": 912.002,
      "RefY": 1763,
      "Mass": 52862.2,
      "SNR": 75.5823,
      "HFD": 8.24756,
      "used": true,
      "err": null
    },
    {
      "X": 829.996,
      "Y": 222.982,
      "RefX": 829.99,
      "RefY": 223.001,
      "Mass": 18362.8,
      "SNR": 63.3208,
      "HFD": 8.2487,
      "used": true,
      "err": null
    },
    {
      "X": 68.0043,
      "Y": 1836,
      "RefX": 67.9971,
      "RefY": 1836,
      "Mass": 16162.3,
      "SNR": 66.9968,
      "HFD": 8.24832,
      "used": true,
      "err": "M8"
    },
    {
      "X": 2192.01,
      "Y": 560.981,
      "RefX": 2191.98,
      "RefY": 560.983,
      "Mass": 11518.2,
      "SNR": 53.6009,
      "HFD": 8.23794,
      "used": true,
      "err": "M4"
    },
```