### PR TITLE
Windows x86_64: fix incorrect pointer unpacking from OnAlertFromThread

### DIFF
--- a/src/indi_gui.cpp
+++ b/src/indi_gui.cpp
@@ -766,8 +766,8 @@ void IndiGui::SetCheckboxEvent(wxCommandEvent& event)
 void IndiGui::OnRemovePropertyFromThread(wxThreadEvent& event)
 {
 #if defined(_WIN64)
-    unsigned long long lo = (unsigned long long) event.GetInt();
-    unsigned long long hi = (unsigned long long) event.GetExtraLong();
+    unsigned long long lo = (unsigned int) event.GetInt();
+    unsigned long long hi = (unsigned long) event.GetExtraLong();
     IndiProp *indiProp = (IndiProp *) ((hi << 32) | lo);
 #else
     IndiProp *indiProp = (IndiProp *) event.GetExtraLong();

--- a/src/myframe.cpp
+++ b/src/myframe.cpp
@@ -1345,8 +1345,8 @@ void MyFrame::Alert(const wxString& msg, int flags)
 void MyFrame::OnAlertFromThread(wxThreadEvent& event)
 {
 #if defined(_WIN64)
-    unsigned long long lo = (unsigned long long) event.GetInt();
-    unsigned long long hi = (unsigned long long) event.GetExtraLong();
+    unsigned long long lo = (unsigned int) event.GetInt();
+    unsigned long long hi = (unsigned long) event.GetExtraLong();
     alert_params *params = (alert_params *) ((hi << 32) | lo);
 #else
     alert_params *params = (alert_params *) event.GetExtraLong();


### PR DESCRIPTION
Windows x86_64: fix incorrect pointer unpacking from OnAlertFromThread

When a 64-bit pointer from OnAlertFromThread is unpacked in the main thread
there is an incorrect sign extension that can result in a bad pointer
value in the main thread.

