### PR TITLE
Windows: add missing webp DLLs to build

### DIFF
--- a/phd2-x64.iss.in
+++ b/phd2-x64.iss.in
@@ -64,6 +64,8 @@ Source: Release\libcurl.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\liblzma.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libwebp.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libwebpdecoder.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\libwebpdemux.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\libwebpmux.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libsharpyuv.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libpng16.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\tiff.dll; DestDir: {app}; Flags: replacesameversion

--- a/phd2-x86.iss.in
+++ b/phd2-x86.iss.in
@@ -67,6 +67,8 @@ Source: Release\libcurl.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\liblzma.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libwebp.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libwebpdecoder.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\libwebpdemux.dll; DestDir: {app}; Flags: replacesameversion
+Source: Release\libwebpmux.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libsharpyuv.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\libpng16.dll; DestDir: {app}; Flags: replacesameversion
 Source: Release\tiff.dll; DestDir: {app}; Flags: replacesameversion

--- a/thirdparty/thirdparty.cmake
+++ b/thirdparty/thirdparty.cmake
@@ -588,6 +588,8 @@ if(WIN32)
       ${VCPKG_DEBUG_BIN}/liblzma.dll
       ${VCPKG_DEBUG_BIN}/libwebp.dll
       ${VCPKG_DEBUG_BIN}/libwebpdecoder.dll
+      ${VCPKG_DEBUG_BIN}/libwebpdemux.dll
+      ${VCPKG_DEBUG_BIN}/libwebpmux.dll
       ${VCPKG_DEBUG_BIN}/libsharpyuv.dll
   )
   list(APPEND PHD_COPY_EXTERNAL_REL
@@ -602,6 +604,8 @@ if(WIN32)
       ${VCPKG_RELEASE_BIN}/liblzma.dll
       ${VCPKG_RELEASE_BIN}/libwebp.dll
       ${VCPKG_RELEASE_BIN}/libwebpdecoder.dll
+      ${VCPKG_RELEASE_BIN}/libwebpdemux.dll
+      ${VCPKG_RELEASE_BIN}/libwebpmux.dll
       ${VCPKG_RELEASE_BIN}/libsharpyuv.dll
   )
 endif()


### PR DESCRIPTION
Windows: add missing webp DLLs to build

Recent opencv update split webp DLL into multiple DLLs

