### PR TITLE
Add Connect wrapper methods for other gear types besides GuideCamera

### DIFF
--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1414,7 +1414,7 @@ void GearDialog::OnButtonConnectScope(wxCommandEvent& event)
 
             Debug.Write(wxString::Format("Connecting to mount [%s]\n", m_pScopes->GetStringSelection()));
 
-            if (m_pScope->Connect())
+            if (Scope::ConnectScope(m_pScope))
             {
                 throw THROW_INFO("OnButtonConnectScope: connect failed");
             }
@@ -1465,7 +1465,7 @@ void GearDialog::OnButtonConnectAuxScope(wxCommandEvent& event)
 
             Debug.Write(wxString::Format("Connecting to aux mount [%s]\n", m_pAuxScopes->GetStringSelection()));
 
-            if (m_pAuxScope->Connect())
+            if (Scope::ConnectScope(m_pAuxScope))
             {
                 throw THROW_INFO("OnButtonConnectAuxScope: connect failed");
             }
@@ -1632,7 +1632,7 @@ void GearDialog::OnButtonConnectStepGuider(wxCommandEvent& event)
 
             Debug.Write(wxString::Format("Connecting to AO [%s]\n", m_pStepGuiders->GetStringSelection()));
 
-            if (m_pStepGuider->Connect())
+            if (StepGuider::ConnectStepGuider(m_pStepGuider))
             {
                 throw THROW_INFO("OnButtonConnectStepGuider: connect failed");
             }
@@ -1770,7 +1770,7 @@ void GearDialog::OnButtonConnectRotator(wxCommandEvent& event)
 
             Debug.Write(wxString::Format("Connecting to rotator [%s]\n", m_pRotators->GetStringSelection()));
 
-            if (m_pRotator->Connect())
+            if (Rotator::ConnectRotator(m_pRotator))
             {
                 throw THROW_INFO("OnButtonConnectRotator: connect failed");
             }

--- a/src/profile_wizard.cpp
+++ b/src/profile_wizard.cpp
@@ -1368,7 +1368,7 @@ void ProfileWizard::InitMountProps(Scope *theScope)
     if (theScope)
     {
         ShowStatus(_("Connecting to mount..."));
-        err = theScope->Connect();
+        err = Scope::ConnectScope(theScope);
         ShowStatus(wxEmptyString);
         if (err)
         {

--- a/src/rotator.cpp
+++ b/src/rotator.cpp
@@ -133,6 +133,14 @@ Rotator::Rotator() : m_connected(false)
 
 Rotator::~Rotator() { }
 
+// ConnectRotator is the one place where we call rotator->Connect(). Any work done here
+// applies to all rotator types, regardless of how the various rotator sub-classes
+// implement Connect().
+bool Rotator::ConnectRotator(Rotator *rotator)
+{
+    return rotator->Connect();
+}
+
 bool Rotator::Connect()
 {
     m_connected = true;

--- a/src/rotator.h
+++ b/src/rotator.h
@@ -77,6 +77,8 @@ public:
     Rotator();
     virtual ~Rotator();
 
+    static bool ConnectRotator(Rotator *rotator);
+
     virtual bool Connect();
     virtual bool Disconnect();
     virtual bool IsConnected() const;

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -121,6 +121,14 @@ Scope::~Scope()
     }
 }
 
+// ConnectScope is the one place where we call scope->Connect(). Any work done here
+// applies to all mount types, regardless of how the various mount sub-classes implement
+// Connect().
+bool Scope::ConnectScope(Scope *scope)
+{
+    return scope->Connect();
+}
+
 GUIDE_ALGORITHM Scope::DefaultXGuideAlgorithm() const
 {
     return DefaultRaGuideAlgorithm;

--- a/src/scope.h
+++ b/src/scope.h
@@ -231,6 +231,8 @@ public:
     Scope();
     virtual ~Scope();
 
+    static bool ConnectScope(Scope *scope);
+
     void SetCalibration(const Calibration& cal) override;
     void SetCalibrationDetails(const CalibrationDetails& calDetails, double xAngle, double yAngle, int binning);
     virtual void FlagCalibrationIssue(const CalibrationDetails& calDetails, CalibrationIssueType issue);

--- a/src/stepguider.cpp
+++ b/src/stepguider.cpp
@@ -87,6 +87,14 @@ StepGuider::StepGuider()
 
 StepGuider::~StepGuider() { }
 
+// ConnectStepGuider is the one place where we call stepguider->Connect(). Any work done
+// here applies to all stepguider types, regardless of how the various stepguider
+// sub-classes implement Connect().
+bool StepGuider::ConnectStepGuider(StepGuider *stepGuider)
+{
+    return stepGuider->Connect();
+}
+
 GUIDE_ALGORITHM StepGuider::DefaultXGuideAlgorithm() const
 {
     return DefaultGuideAlgorithm;

--- a/src/stepguider.h
+++ b/src/stepguider.h
@@ -186,6 +186,8 @@ public:
     StepGuider();
     virtual ~StepGuider();
 
+    static bool ConnectStepGuider(StepGuider *stepGuider);
+
     static wxArrayString AOList();
     static StepGuider *Factory(const wxString& choice);
 


### PR DESCRIPTION
Add Connect wrapper methods for other gear types besides GuideCamera

Provide a place to add code common to connecting each gear type,
common to all gear subclasses.

This will the place to enumerate scope tracking rates after connecting
the scope.

