### PR TITLE
minor code cleanups

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -668,7 +668,7 @@ GuideCamera *GuideCamera::Factory(const wxString& choice)
 }
 
 // ConnectCamera is the one place where we call camera->Connect(). Any work done here
-// applies to all camera types, regardless of how the various camera sub-ckasses
+// applies to all camera types, regardless of how the various camera sub-classes
 // implement Connect().
 bool GuideCamera::ConnectCamera(GuideCamera *camera, const wxString& cameraId)
 {

--- a/src/gear_dialog.cpp
+++ b/src/gear_dialog.cpp
@@ -1419,7 +1419,7 @@ void GearDialog::OnButtonConnectScope(wxCommandEvent& event)
                 throw THROW_INFO("OnButtonConnectScope: connect failed");
             }
 
-            if (m_pScope && m_ascomScopeSelected && !m_pScope->CanPulseGuide())
+            if (m_ascomScopeSelected && !m_pScope->CanPulseGuide())
             {
                 m_pScope->Disconnect();
                 wxMessageBox(wxString::Format(_("Mount does not support the required PulseGuide interface"), _("Error")));


### PR DESCRIPTION
minor code cleanups

 - fix a spelling error in a comment
 - remove a redundant null check (already checked in the enclosing `if`)

