### PR TITLE
Fix incorrect sign extension for OGMA and ToupTek cameras in 8-bit mode

### DIFF
--- a/src/cam_ogma.cpp
+++ b/src/cam_ogma.cpp
@@ -695,7 +695,7 @@ bool CameraOgma::Capture(usImage& img, const CaptureParams& captureParams)
     {
         if (m_cam.m_bpp == 8)
         {
-            const char *src = static_cast<char *>(m_cam.m_buffer);
+            const unsigned char *src = static_cast<unsigned char *>(m_cam.m_buffer);
             for (unsigned int i = 0; i < img.NPixels; i++)
                 img.ImageData[i] = *src++;
         }

--- a/src/cam_touptek.cpp
+++ b/src/cam_touptek.cpp
@@ -703,7 +703,7 @@ bool CameraToupTek::Capture(usImage& img, const CaptureParams& captureParams)
     {
         if (m_cam.m_bpp == 8)
         {
-            const char *src = static_cast<char *>(m_cam.m_buffer);
+            const unsigned char *src = static_cast<unsigned char *>(m_cam.m_buffer);
             for (unsigned int i = 0; i < img.NPixels; i++)
                 img.ImageData[i] = *src++;
         }


### PR DESCRIPTION
Fix incorrect sign extension for OGMA and ToupTek cameras in 8-bit mode

